### PR TITLE
Refactor target list management and CLI entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ Thumbs.db
 
 # Windows Zone Identifier files (WSL artifact)
 *:Zone.Identifier
+
+# Local POC / scratch fixtures and packaging artifacts
+poc/
+*.tgz
+mint.tokens.json

--- a/bin/mint.mjs
+++ b/bin/mint.mjs
@@ -5,13 +5,12 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
-import { fileURLToPath } from 'node:url'
 import {
   buildAuditPrompt,
   buildResolvePrompt,
   buildExportPrompt,
   EXPORT_OUTPUT,
-  TARGET_ALIASES,
+  ADVERTISED_TARGETS,
   resolveTarget,
   callAnthropic,
   stripFences,
@@ -54,8 +53,8 @@ ${styles.bold('AUDIT OPTIONS')}
   --quiet                      Suppress chaos summary
 
 ${styles.bold('EXPORT OPTIONS')}
-  --target <name>              Required. tailwind, react, vue, svelte, astro,
-                                 css, scss, ts, css-modules, styled, emotion
+  --target <name>              Required. ${ADVERTISED_TARGETS.slice(0, 5).join(', ')},
+                                 ${ADVERTISED_TARGETS.slice(5).join(', ')}
   --tokens <file>              Tokens input path (default: ${DEFAULT_TOKENS_FILE})
   --out <file>                 Override the generated filename
   --stdout                     Print to stdout instead of writing a file
@@ -170,9 +169,6 @@ async function cmdAudit(argv) {
   const target = rest[0]
   if (!target) die('Usage: mint audit <directory>')
 
-  const apiKey = process.env.ANTHROPIC_API_KEY
-  if (!apiKey) die('ANTHROPIC_API_KEY is required (export it before running, or pass it inline)')
-
   const outFile = String(flags.out || DEFAULT_TOKENS_FILE)
   const reportFile = flags.report ? String(flags.report) : null
   const quiet = Boolean(flags.quiet)
@@ -180,6 +176,9 @@ async function cmdAudit(argv) {
   log(styles.cyan('→') + ` Reading sources from ${styles.bold(target)}…`)
   const { files, css } = await collectSources(target)
   log(styles.dim(`  ${files.length} file(s), ${(css.length / 1000).toFixed(1)}k chars`))
+
+  const apiKey = process.env.ANTHROPIC_API_KEY
+  if (!apiKey) die('ANTHROPIC_API_KEY is required (export it before running, or pass it inline)')
 
   log(styles.cyan('→') + ' Auditing with Claude…')
   const auditText = await callAnthropic({ apiKey, prompt: buildAuditPrompt(css), maxTokens: 3000 })
@@ -228,8 +227,7 @@ async function cmdExport(argv) {
 
   const target = resolveTarget(String(targetInput))
   if (!target) {
-    const known = [...new Set([...Object.keys(EXPORT_OUTPUT), ...Object.keys(TARGET_ALIASES)])].sort().join(', ')
-    die(`Unknown --target "${targetInput}". Try one of: ${known}`)
+    die(`Unknown --target "${targetInput}". Try one of: ${ADVERTISED_TARGETS.join(', ')}`)
   }
 
   const apiKey = process.env.ANTHROPIC_API_KEY
@@ -287,6 +285,4 @@ async function main() {
   }
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
-  main()
-}
+main()

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -282,6 +282,13 @@ export const TARGET_ALIASES = {
   astro:              'astro-component',
 }
 
+// Curated short list shown in --help and validation errors. Keeps the public
+// surface friendly; full alias map above remains accepted by resolveTarget.
+export const ADVERTISED_TARGETS = [
+  'tailwind', 'react', 'vue', 'svelte', 'astro',
+  'css', 'scss', 'ts', 'css-modules', 'styled', 'emotion',
+]
+
 export function resolveTarget(input) {
   if (!input) return null
   const lc = String(input).toLowerCase()


### PR DESCRIPTION
## Summary

- Introduce `ADVERTISED_TARGETS` constant to centralize the curated list of supported export targets, replacing hardcoded strings in help text and error messages
- Simplify CLI entry point by removing unnecessary `fileURLToPath` check and always calling `main()`
- Move API key validation in `cmdAudit` to occur after source collection (minor logic reordering)
- Update `.gitignore` to exclude POC fixtures, packaging artifacts, and generated token files

## Type of change

- [x] Refactor / cleanup

## How to test

1. Run `mint export --help` and verify the target list displays correctly across two lines
2. Run `mint export --target invalid` and verify the error message shows the correct advertised targets
3. Run the script directly with `node bin/mint.mjs` and verify it executes normally

## Checklist

- [x] `npx tsc --noEmit` passes with no errors
- [x] No new user-facing strings introduced
- [x] No hardcoded values that should be centralized

https://claude.ai/code/session_017TBLrv837AqtmBE5XJBWrX