### PR TITLE
Add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,101 @@
+name: Bug report
+description: Something in mint-ds doesn't work the way you expected
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! A few things up front:
+        - **Search first** — there may already be an open issue for this.
+        - **Don't paste your `ANTHROPIC_API_KEY`** anywhere in this report. If you accidentally do, rotate it at [console.anthropic.com](https://console.anthropic.com).
+        - The more reproducible the report, the faster we can fix it. A minimal CSS snippet that triggers the bug is gold.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where did you hit this?
+      description: Pick the surface where the bug shows up.
+      options:
+        - CLI (`mint-ds audit` / `mint-ds export`)
+        - Web playground
+        - Both CLI and web
+        - Documentation / README
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: mint-ds version
+      description: Run `mint-ds --version` — or `node bin/mint-ds.mjs --version` if you're working from a clone. Use `n/a` for web-only or docs bugs.
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: node
+    attributes:
+      label: Node.js version
+      description: Output of `node --version`. Skip if this is a web-only or docs bug.
+      placeholder: "v20.11.1"
+
+  - type: input
+    id: env
+    attributes:
+      label: OS & shell
+      description: e.g. `macOS 14.4 / zsh`, `Ubuntu 22.04 / bash`, `Windows 11 / PowerShell 7`, `WSL2 Ubuntu / bash`. For web bugs, give the browser instead (e.g. `Firefox 124 on macOS 14`).
+      placeholder: "macOS 14.4 / zsh"
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: A numbered list of what you did. Include the exact command you ran (with API key redacted) or what you clicked in the playground.
+      placeholder: |
+        1. Cloned the repo and ran `npm install`.
+        2. Ran `node bin/mint-ds.mjs audit ./examples/frankenstein`.
+        3. Saw the audit complete but the resulting `mint-ds.tokens.json` is missing the `spacing` key.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What happened instead. Include error messages, unexpected output, or a screenshot for UI bugs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: input
+    attributes:
+      label: Minimal CSS / HTML input that reproduces the bug
+      description: If the bug is triggered by a specific input, paste the smallest possible snippet that still reproduces. For web-only bugs you can leave this blank.
+      render: css
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or stack traces
+      description: Paste raw output from the failing command, browser console errors, or network response bodies. Don't include your API key.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Sanity checks
+      options:
+        - label: I'm running Node 20 or newer (CLI requirement).
+          required: false
+        - label: I confirmed `ANTHROPIC_API_KEY` is set (or I'm passing `--api-key`) and the key is valid.
+          required: false
+        - label: I searched existing issues and didn't find this bug already reported.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/nujovich/mint/discussions
+    about: For "how do I…" questions, design discussions, or feedback that isn't a concrete bug or feature request, please open a Discussion instead.
+  - name: Anthropic API key issues
+    url: https://console.anthropic.com
+    about: If your `ANTHROPIC_API_KEY` is rejected or rate-limited, that's an Anthropic account issue, not a mint-ds bug. Manage your key at console.anthropic.com.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,70 @@
+name: Feature request
+description: Propose a new export target, CLI flag, playground improvement, or other enhancement
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for thinking about how to make mint-ds better. To help triage:
+        - Lead with the **problem**, not the solution. The clearer the problem, the easier it is to evaluate alternatives.
+        - **Search first** — there may already be an open issue for this idea.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Which surface does this affect?
+      options:
+        - CLI (commands, flags, output formats)
+        - Web playground (UI, wizard flow)
+        - Audit / token-generation pipeline (prompts, clustering, scales)
+        - Export targets (new framework, new file format)
+        - Documentation
+        - Build / release / packaging
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the situation today and what's painful about it. Skip the proposed solution for now — that's the next field.
+      placeholder: |
+        I'm migrating a Bootstrap 4 codebase. After running `mint-ds audit`, the spacing scale comes out clean but I can't tell which legacy classes (`mb-3`, `pt-2`, etc.) map to which new spacing tokens.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Concretely, what would you like to happen? CLI flag? New export format? UI element? Be as specific as you can.
+      placeholder: |
+        Add a `--target bootstrap-mapping` export that emits a JSON file pairing each legacy class name with the new token, e.g. `{ "mb-3": "var(--spacing-3)" }`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: Other ways to solve the same problem, and why you ruled them out. Optional but useful.
+      placeholder: |
+        - Manually grepping the source for class usages — too noisy on a large codebase.
+        - Using a separate tool like `purgecss` — doesn't know about the new token names.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, screenshots, links to similar features in other tools, sample input/output, etc. Optional.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Sanity checks
+      options:
+        - label: I searched existing issues and didn't find this proposal.
+          required: true
+        - label: This isn't something I could solve with existing CLI flags or playground options.
+          required: false


### PR DESCRIPTION
## Summary

- Add structured bug report template (`bug_report.yml`) with fields for reproduction steps, version info, and environment details
- Add feature request template (`feature_request.yml`) with problem/solution/alternatives structure
- Add issue template config (`config.yml`) to disable blank issues and provide contact links for questions and API key issues

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Dependency update

## How to test

1. Navigate to the "Issues" tab on GitHub and click "New issue"
2. Verify that blank issues are disabled and users see the contact links for questions and API key issues
3. Verify that "Bug report" and "Feature request" templates are available and display correctly with all fields

## Checklist

- [x] No code changes requiring TypeScript compilation
- [x] No testing needed — configuration files only
- [x] No UI changes
- [x] No new user-facing strings
- [x] No hardcoded values

https://claude.ai/code/session_0117mGRpJYBsQTWw7c18CS63