### PR TITLE
feat: CSS preprocessing before audit prompt (#14)

### DIFF
--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -6,11 +6,20 @@
 const MODEL = 'claude-sonnet-4-20250514'
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages'
 
+export function preprocessCss(raw) {
+  return String(raw)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')  // block comments
+    .replace(/\/\/[^\n]*/g, ' ')         // line comments (SCSS/LESS)
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 export function buildAuditPrompt(css) {
+  const processed = preprocessCss(css)
   return `You are a design-system auditor. Analyze the CSS/SCSS/HTML below and return a JSON AuditReport.
 
 CSS SOURCE:
-${String(css).slice(0, 60000)}
+${processed.slice(0, 60000)}
 
 Instructions:
 1. COLORS — Find every hex, rgb(), rgba(), hsl() value. Group near-duplicates (within ~15% on H, S, or L) into clusters. Per cluster:


### PR DESCRIPTION
Strip block/line comments and collapse whitespace before sending CSS to Claude, reducing token usage and removing noise from the prompt.

## Summary


- Adds `preprocessCss(raw)` to `lib/prompts.mjs` that strips block comments
  (`/* */`), line comments (`//`, for SCSS/LESS), and collapses whitespace to
  a single space
- `buildAuditPrompt()` now calls it before building the prompt, so Claude
  receives cleaner signal within the 60k-char budget

## Test plan

- Run `mint-ds audit` against a CSS file with comments — verify comments
      don't appear in the prompt sent to Claude
- Verify the 60k char slice still works correctly on large inputs
- Confirm `preprocessCss` is exported and importable from `lib/prompts.mjs`
