### PR TITLE
feat: add Angular and Angular (Legacy) export targets

### DIFF
--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -238,6 +238,77 @@ Requirements:
 - Input: label?, placeholder?, value?, error?, hint?, disabled, type, name, id
 - Add a <!-- Usage example --> comment per component showing how to import and use it
 - Make the components compatible with both SSR and static Astro projects`,
+
+  'angular-component': (shared) => `Generate production-ready Angular standalone components using these design tokens.${shared}
+
+Generate these 4 standalone components in a single file:
+
+Button:
+- Selector: mint-button
+- Props: variant (primary|secondary|ghost|danger), size (sm|md|lg), disabled, loading, fullWidth
+- Loading state with spinner SVG shown via @if
+- Emit a clicked event
+
+Card:
+- Selector: mint-card
+- Props: title?, description?, variant (default|elevated|outlined), padding (sm|md|lg)
+- Project content via <ng-content />
+
+Badge:
+- Selector: mint-badge
+- Props: variant (primary|secondary|accent|neutral|success|danger), size (sm|md)
+- Project content via <ng-content />
+
+Input:
+- Selector: mint-input
+- Props: label?, placeholder?, value, error?, hint?, disabled, type
+
+Requirements:
+- Standalone components with standalone: true
+- Signal inputs: input<T>() for required props, input<T>(defaultValue) for optional ones
+- Signal outputs: output<T>() for events (e.g. clicked = output<void>())
+- Use @if / @for control flow blocks (not *ngIf / *ngFor)
+- Inline styles via styles: [...] array using var(--token-name) CSS custom properties — no hardcoded hex/px values
+- ChangeDetectionStrategy.OnPush on every component
+- host: { ... } for data attributes (e.g. '[attr.data-variant]': 'variant()')
+- Add a "// Usage" comment at the top showing how to import and add to standalone imports
+- Named exports for each component`,
+
+  'angular-legacy-component': (shared) => `Generate production-ready Angular components using the classic @NgModule pattern with these design tokens.${shared}
+
+Generate these 4 classic components plus a MintDesignSystemModule in a single file:
+
+Button:
+- Selector: mint-button
+- Props: variant (primary|secondary|ghost|danger), size (sm|md|lg), disabled, loading, fullWidth
+- Loading state with spinner SVG shown via *ngIf
+- Emit an onClick event
+
+Card:
+- Selector: mint-card
+- Props: title?, description?, variant (default|elevated|outlined), padding (sm|md|lg)
+- Project content via <ng-content />
+
+Badge:
+- Selector: mint-badge
+- Props: variant (primary|secondary|accent|neutral|success|danger), size (sm|md)
+- Project content via <ng-content />
+
+Input:
+- Selector: mint-input
+- Props: label?, placeholder?, value, error?, hint?, disabled, type
+
+Requirements:
+- Components use the classic @Component() decorator (no standalone: true)
+- @Input() and @Output() decorators for props and events (not signal inputs)
+- Use *ngIf / *ngFor structural directives (not @if / @for control flow)
+- Inline styles via styles: [...] array using var(--token-name) CSS custom properties — no hardcoded hex/px values
+- At the bottom of the file, a MintDesignSystemModule @NgModule that:
+  - Imports CommonModule and FormsModule
+  - Declares all 4 components
+  - Exports all 4 components
+- Add a "// Usage" comment at the top showing how to import MintDesignSystemModule and add to @NgModule.imports
+- Named exports for each component and the module`,
 }
 
 export function buildExportPrompt(tokens, target) {
@@ -261,6 +332,8 @@ export const EXPORT_OUTPUT = {
   'vue-component':     { filename: 'components',       ext: 'vue' },
   'svelte-component':  { filename: 'components',       ext: 'svelte' },
   'astro-component':   { filename: 'components',       ext: 'astro' },
+  'angular-component': { filename: 'components',       ext: 'ts' },
+  'angular-legacy-component':    { filename: 'components.module', ext: 'ts' },
 }
 
 // Short aliases the CLI accepts for --target.
@@ -280,13 +353,15 @@ export const TARGET_ALIASES = {
   vue:                'vue-component',
   svelte:             'svelte-component',
   astro:              'astro-component',
+  angular:            'angular-component',
+  'angular-legacy':   'angular-legacy-component',
 }
 
 // Curated short list shown in --help and validation errors. Keeps the public
 // surface friendly; full alias map above remains accepted by resolveTarget.
 export const ADVERTISED_TARGETS = [
   'tailwind', 'react', 'vue', 'svelte', 'astro',
-  'css', 'scss', 'ts', 'css-modules', 'styled', 'emotion',
+  'css', 'scss', 'ts', 'css-modules', 'styled', 'emotion', 'angular', 'angular-legacy',
 ]
 
 export function resolveTarget(input) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -33,6 +33,8 @@ export type ExportTarget =
   | 'vue-component'
   | 'svelte-component'
   | 'astro-component'
+  | 'angular-component'
+  | 'angular-legacy-component'
 
 export interface ExportConfig {
   target: ExportTarget
@@ -182,5 +184,21 @@ export const EXPORT_TARGETS: ExportConfig[] = [
     ext: 'astro',
     category: 'Components',
     description: '.astro components with typed props and scoped CSS',
+  },
+  {
+    target: 'angular-component',
+    label: 'Angular',
+    filename: 'components',
+    ext: 'ts',
+    category: 'Components',
+    description: 'Standalone components + signal inputs',
+  },
+  {
+    target: 'angular-legacy-component',
+    label: 'Angular (Legacy)',
+    filename: 'components.module',
+    ext: 'ts',
+    category: 'Components',
+    description: 'Classic @NgModule with @Input/@Output decorators',
   },
 ]


### PR DESCRIPTION
## Summary
- Adds `--target angular` for Angular 17+ standalone components with signal inputs/outputs, `@if`/`@for` control flow, and `OnPush`
- Adds `--target angular-legacy` for Angular 2+ projects using `@Input`/`@Output` decorators with a `MintDesignSystemModule` NgModule wrapper
## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Dependency update
## How to test
1. Place an Anthropic API key in `ANTHROPIC_API_KEY`
2. Run `npx tsc --noEmit` — passes with no errors
3. Run `node bin/mint-ds.mjs audit examples/frankenstein --out /tmp/frank-tokens.json`
4. Run `node bin/mint-ds.mjs export --tokens /tmp/frank-tokens.json --target angular --stdout` — outputs 4 standalone Angular components with signal inputs, `@if` control flow, and CSS custom properties
5. Run `node bin/mint-ds.mjs export --tokens /tmp/frank-tokens.json --target angular-legacy --stdout` — outputs 4 classic components with `@Input`/`@Output` decorators, `*ngIf` directives, and a `MintDesignSystemModule`
6. Check both Angular buttons appear in the playground's export step
## Notes on testing
The full audit → tokens → export flow was verified end-to-end using DeepSeek V4 Flash (`deepseek-v4-flash`) as the backend since I don't have Anthropic access at the moment. The API swap was temporary and required no changes to the prompts or logic — only the endpoint and key resolution were adapted. Both targets produced valid, idiomatic Angular code. Mobile responsiveness was checked at 375px — no breaking since no UI code was modified.

Output files
[angular-legacy.ts](https://pastebin.com/raw/uxxBtxB7)
[angular-standalone.ts](https://pastebin.com/raw/cR51QHz5)


## Checklist
- [x] `npx tsc --noEmit` passes with no errors
- [x] Tested end-to-end: audit → tokens → export against `examples/frankenstein` (DeepSeek V4 Flash), producing valid Angular code for both `angular` and `angular-legacy` targets
- [x] UI is responsive on mobile (tested at 375px width)
- [x] No new Spanish strings introduced — all user-facing text is English
- [x] No hardcoded colors or values that should be CSS variables