### PR TITLE
feat(audit): refine prompt following Claude prompting best practices

### DIFF
--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { buildAuditPrompt, callAnthropic, stripFences } from '@/lib/prompts.mjs'
+import { AUDIT_SYSTEM_PROMPT, buildAuditPrompt, callAnthropic, stripFences } from '@/lib/prompts.mjs'
 
 export async function POST(req: NextRequest) {
   const { css } = await req.json()
@@ -11,6 +11,7 @@ export async function POST(req: NextRequest) {
   try {
     const text = await callAnthropic({
       apiKey: process.env.ANTHROPIC_API_KEY,
+      system: AUDIT_SYSTEM_PROMPT,
       prompt: buildAuditPrompt(css),
       maxTokens: 3000,
     })

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -6,6 +6,7 @@ import {
   buildAuditPrompt,
   buildResolvePrompt,
   buildExportPrompt,
+  AUDIT_SYSTEM_PROMPT,
 } from '../prompts.mjs'
 
 describe('stripFences', () => {
@@ -66,6 +67,21 @@ describe('preprocessCss', () => {
   })
 })
 
+describe('AUDIT_SYSTEM_PROMPT', () => {
+  it('is a non-empty string', () => {
+    expect(typeof AUDIT_SYSTEM_PROMPT).toBe('string')
+    expect(AUDIT_SYSTEM_PROMPT.length).toBeGreaterThan(0)
+  })
+
+  it('establishes an auditor role', () => {
+    expect(AUDIT_SYSTEM_PROMPT).toContain('auditor')
+  })
+
+  it('mentions JSON output requirement', () => {
+    expect(AUDIT_SYSTEM_PROMPT).toContain('JSON')
+  })
+})
+
 describe('buildAuditPrompt', () => {
   const css = 'body { color: #ff0000; font-size: 16px; }'
 
@@ -78,8 +94,87 @@ describe('buildAuditPrompt', () => {
     expect(buildAuditPrompt(css)).toContain(css)
   })
 
+  it('wraps CSS source in <css_source> tags', () => {
+    const prompt = buildAuditPrompt(css)
+    expect(prompt).toContain('<css_source>')
+    expect(prompt).toContain('</css_source>')
+    expect(prompt.indexOf('<css_source>')).toBeLessThan(prompt.indexOf(css))
+  })
+
   it('includes the AuditReport instruction', () => {
     expect(buildAuditPrompt(css)).toContain('AuditReport')
+  })
+
+  it('includes <instructions> wrapper tags', () => {
+    const prompt = buildAuditPrompt(css)
+    expect(prompt).toContain('<instructions>')
+    expect(prompt).toContain('</instructions>')
+  })
+
+  it('includes <output_format> and <example> tags', () => {
+    const prompt = buildAuditPrompt(css)
+    expect(prompt).toContain('<output_format>')
+    expect(prompt).toContain('</output_format>')
+    expect(prompt).toContain('<example>')
+    expect(prompt).toContain('</example>')
+  })
+
+  it('includes all six analysis steps', () => {
+    const prompt = buildAuditPrompt(css)
+    expect(prompt).toContain('STEP 1')
+    expect(prompt).toContain('STEP 2')
+    expect(prompt).toContain('STEP 3')
+    expect(prompt).toContain('STEP 4')
+    expect(prompt).toContain('STEP 5')
+    expect(prompt).toContain('STEP 6')
+  })
+
+  it('covers all required JSON output fields in the example', () => {
+    const prompt = buildAuditPrompt(css)
+    expect(prompt).toContain('"brand"')
+    expect(prompt).toContain('"chaosScore"')
+    expect(prompt).toContain('"summary"')
+    expect(prompt).toContain('"colorClusters"')
+    expect(prompt).toContain('"fonts"')
+    expect(prompt).toContain('"spacing"')
+  })
+
+  it('includes all allowed semantic color names', () => {
+    const prompt = buildAuditPrompt(css)
+    for (const name of ['primary', 'secondary', 'accent', 'background', 'surface',
+      'text', 'muted', 'border', 'error', 'success', 'warning', 'info']) {
+      expect(prompt).toContain(name)
+    }
+  })
+
+  it('includes deterministic chaos score formula with stacking rules', () => {
+    const prompt = buildAuditPrompt(css)
+    expect(prompt).toContain('+2 if colorClusters')
+    expect(prompt).toContain('+1 if colorClusters')
+    expect(prompt).toContain('+2 if nonScaleValues')
+    expect(prompt).toContain('+1 if nonScaleValues')
+  })
+
+  it('covers directional spacing properties', () => {
+    const prompt = buildAuditPrompt(css)
+    expect(prompt).toContain('margin-top')
+    expect(prompt).toContain('padding-left')
+    expect(prompt).toContain('column-gap')
+    expect(prompt).toContain('row-gap')
+  })
+
+  it('truncates very large CSS inputs to 60000 characters', () => {
+    const largeCss = 'a { color: red; } '.repeat(5000)
+    const prompt = buildAuditPrompt(largeCss)
+    const start = prompt.indexOf('<css_source>') + '<css_source>\n'.length
+    const end = prompt.indexOf('</css_source>')
+    const embeddedCss = prompt.slice(start, end).trimEnd()
+    expect(embeddedCss.length).toBeLessThanOrEqual(60000)
+  })
+
+  it('instructs Claude to return only JSON with no markdown fences', () => {
+    const prompt = buildAuditPrompt(css)
+    expect(prompt).toContain('No markdown fences')
   })
 })
 

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -14,35 +14,69 @@ export function preprocessCss(raw) {
     .trim()
 }
 
+export const AUDIT_SYSTEM_PROMPT = `You are an expert design-system auditor with deep knowledge of CSS architecture, design tokens, and visual consistency. Your role is to analyze CSS codebases, identify color, typography, and spacing patterns, and surface actionable data for design system extraction.
+
+You produce precise, complete JSON reports. You never skip values, never estimate counts, and never invent data not present in the source. When uncertain about a color cluster's semantic role, choose the closest match from the allowed list rather than leaving it blank.`
+
 export function buildAuditPrompt(css) {
   const processed = preprocessCss(css)
-  return `You are a design-system auditor. Analyze the CSS/SCSS/HTML below and return a JSON AuditReport.
-
-CSS SOURCE:
+  return `<css_source>
 ${processed.slice(0, 60000)}
+</css_source>
 
-Instructions:
-1. COLORS — Find every hex, rgb(), rgba(), hsl() value. Group near-duplicates (within ~15% on H, S, or L) into clusters. Per cluster:
-   - "representative": most-used or most-saturated value
-   - "samples": each distinct value with usageCount (how many times that exact value appears) and up to 3 contexts (CSS selectors or property names)
-   - "suggestedName": semantic role — choose from: primary, secondary, accent, background, surface, text, muted, border, error, success, warning, info
-   - "id": "cluster-N" (sequential integer, starting at 0)
-   Keep clusters to a maximum of 14.
+<instructions>
+Analyze the CSS source above and produce a JSON AuditReport. Work through each step completely and in order before writing the output.
 
-2. FONTS — List every font-family value. Mark isSystemFont: true for: Arial, Helvetica, Georgia, Times, Courier, Verdana, Tahoma, Trebuchet, system-ui, -apple-system, BlinkMacSystemFont, sans-serif, serif, monospace, cursive, fantasy. Provide up to 5 usage contexts per font.
+STEP 1 — COLORS
+Scan every color value: hex (#rgb, #rrggbb, #rrggbbaa), rgb(), rgba(), hsl(), hsla(). For each distinct value, count its exact appearances and record up to 3 CSS selectors or property names where it is used (contexts).
 
-3. SPACING — Collect every distinct numeric spacing value (px only) from margin, padding, gap, top, right, bottom, left properties. Exclude: 0, values with %, auto, vh, vw, em, rem. Suggest a clean 4px-based scale using these steps: 1→4px, 2→8px, 3→12px, 4→16px, 5→20px, 6→24px, 8→32px, 10→40px, 12→48px, 16→64px, 20→80px, 24→96px. List nonScaleValues: found values NOT divisible by 4.
+Group values into clusters of near-duplicates using this rule: two values are near-duplicates when their difference on any single HSL channel is ≤ 15 (hue degrees or percentage points on saturation/lightness). Per cluster:
+- "id": "cluster-N" where N is a zero-based sequential integer
+- "representative": the single most-used value; if tied, pick the most-saturated one
+- "samples": every distinct value in the cluster, each with "hex" (converted to #rrggbb format), "usageCount", and up to 3 "contexts"
+- "suggestedName": the semantic role — pick exactly one from: primary, secondary, accent, background, surface, text, muted, border, error, success, warning, info
 
-4. chaosScore: integer 1-10. 1-3 = clean, 4-6 = moderate debt, 7-10 = real chaos. Base on: colorClusters.length > 8 adds points, nonScaleValues.length > 5 adds points, fonts.filter(f=>!f.isSystemFont).length > 3 adds points.
+Cap at 14 clusters maximum. If more exist, merge the two smallest (by total usageCount) into their nearest neighbor until you reach 14.
 
-5. summary: 1-2 sentences describing the main CSS quality issues found.
+STEP 2 — FONTS
+Collect every distinct font-family value. For each:
+- "family": exact font name as written in the CSS
+- "usages": up to 5 CSS selectors or rule contexts where this font appears
+- "isSystemFont": true only for these names: Arial, Helvetica, Georgia, Times, Times New Roman, Courier, Courier New, Verdana, Tahoma, Trebuchet MS, Impact, system-ui, -apple-system, BlinkMacSystemFont, ui-sans-serif, ui-serif, ui-monospace, sans-serif, serif, monospace, cursive, fantasy
 
-Return ONLY a valid JSON object. No markdown fences, no backticks, no explanation outside the JSON.
+STEP 3 — SPACING
+Collect every distinct numeric px value from these CSS properties: margin, margin-top, margin-right, margin-bottom, margin-left, padding, padding-top, padding-right, padding-bottom, padding-left, gap, column-gap, row-gap, top, right, bottom, left.
+Exclude: 0, percentages (%), auto, and any non-px unit (em, rem, vh, vw, vmin, vmax, ch, ex).
 
+- "found": all distinct values sorted ascending as strings (e.g. ["4px", "7px", "8px"])
+- "suggestedScale": map of scale step → px value, include only steps that match at least one found value: 1→4px, 2→8px, 3→12px, 4→16px, 5→20px, 6→24px, 8→32px, 10→40px, 12→48px, 16→64px, 20→80px, 24→96px
+- "nonScaleValues": values from "found" that are NOT divisible by 4
+
+STEP 4 — CHAOS SCORE
+Compute a deterministic integer from 1–10. Start at 1, then add:
+- +2 if colorClusters.length > 8
+- +1 if colorClusters.length > 5 (stacks with the above)
+- +2 if nonScaleValues.length > 10
+- +1 if nonScaleValues.length > 5 (stacks with the above)
+- +2 if count of non-system fonts (isSystemFont === false) > 3
+- +1 if count of non-system fonts > 1 (stacks with the above)
+Cap the final result at 10.
+
+STEP 5 — SUMMARY
+Write 1–2 sentences naming the top quality issues. Be specific: cite actual counts (e.g. "9 color clusters including 4 near-duplicate grays", "17 off-scale spacing values").
+
+STEP 6 — BRAND
+Infer a project name from CSS comments, HTML title elements, BEM block prefixes, CSS variable namespaces (e.g. --myapp-*), or @layer names. Return "" if nothing identifiable is found.
+</instructions>
+
+<output_format>
+Return ONLY a valid JSON object matching the structure in the example below. No markdown fences, no backticks, no text before or after the JSON.
+
+<example>
 {
-  "brand": "project name from comments/title/class names, or empty string",
+  "brand": "project name or empty string",
   "chaosScore": 7,
-  "summary": "The codebase has 6 near-duplicate blue shades and 23 off-scale spacing values.",
+  "summary": "The codebase has 6 near-duplicate blue shades and 23 off-scale spacing values indicating significant design debt.",
   "colorClusters": [
     {
       "id": "cluster-0",
@@ -63,7 +97,9 @@ Return ONLY a valid JSON object. No markdown fences, no backticks, no explanatio
     "suggestedScale": { "1": "4px", "2": "8px", "4": "16px", "6": "24px" },
     "nonScaleValues": ["7px", "13px"]
   }
-}`
+}
+</example>
+</output_format>`
 }
 
 export function buildResolvePrompt(css, decisions) {
@@ -389,10 +425,16 @@ export function stripFences(raw) {
 }
 
 /* v8 ignore start */
-export async function callAnthropic({ apiKey, prompt, maxTokens = 3000 }) {
+export async function callAnthropic({ apiKey, prompt, system, maxTokens = 3000 }) {
   if (!apiKey) {
     throw new Error('ANTHROPIC_API_KEY is required')
   }
+  const body = {
+    model: MODEL,
+    max_tokens: maxTokens,
+    messages: [{ role: 'user', content: prompt }],
+  }
+  if (system) body.system = system
   const res = await fetch(ANTHROPIC_URL, {
     method: 'POST',
     headers: {
@@ -400,11 +442,7 @@ export async function callAnthropic({ apiKey, prompt, maxTokens = 3000 }) {
       'x-api-key': apiKey,
       'anthropic-version': '2023-06-01',
     },
-    body: JSON.stringify({
-      model: MODEL,
-      max_tokens: maxTokens,
-      messages: [{ role: 'user', content: prompt }],
-    }),
+    body: JSON.stringify(body),
   })
   const data = await res.json()
   if (!res.ok) {

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -425,6 +425,7 @@ export function stripFences(raw) {
 }
 
 /* v8 ignore start */
+/** @param {{ apiKey: string|undefined, prompt: string, system?: string, maxTokens?: number }} opts */
 export async function callAnthropic({ apiKey, prompt, system, maxTokens = 3000 }) {
   if (!apiKey) {
     throw new Error('ANTHROPIC_API_KEY is required')


### PR DESCRIPTION
- Extract role into AUDIT_SYSTEM_PROMPT (system prompt separation)
- Wrap sections in XML tags: css_source, instructions, output_format, example
- Replace vague chaos score with deterministic additive formula
- Expand spacing to all directional variants (margin-top, padding-left, etc.)
- Expand system font list with ui-* variants and common web-safe fonts
- Add hex normalization and explicit cluster merge rule
- Add optional system param to callAnthropic() and wire it in audit route

https://claude.ai/code/session_01PQscP9T2kRccT814JjW4sv