### PR TITLE
test: add callAnthropic tests with record/replay fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,3 @@ mint-ds.tokens.json
 
 # Superpowers internal planning docs
 docs/superpowers/
-
-# AGENTS.md
-AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ mint-ds.tokens.json
 
 # Superpowers internal planning docs
 docs/superpowers/
+
+# AGENTS.md
+AGENTS.md

--- a/lib/__fixtures__/anthropic/audit-200-simple-css.json
+++ b/lib/__fixtures__/anthropic/audit-200-simple-css.json
@@ -1,0 +1,37 @@
+{
+  "_meta": {
+    "recordedAt": "2026-05-26T10:29:31.958Z",
+    "scenario": "audit-200-simple-css"
+  },
+  "response": {
+    "status": 200,
+    "ok": true,
+    "body": {
+      "model": "claude-sonnet-4-20250514",
+      "id": "msg_01TQwDvwRr9A8tM3jebAYESH",
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "{\n  \"brand\": \"\",\n  \"chaosScore\": 1,\n  \"summary\": \"The codebase is minimal with only 1 color cluster and no spacing values, indicating good design consistency.\",\n  \"colorClusters\": [\n    {\n      \"id\": \"cluster-0\",\n      \"suggestedName\": \"error\",\n      \"representative\": \"#ff0000\",\n      \"samples\": [\n        { \"hex\": \"#ff0000\", \"usageCount\": 1, \"contexts\": [\"body\"] }\n      ]\n    }\n  ],\n  \"fonts\": [],\n  \"spacing\": {\n    \"found\": [],\n    \"suggestedScale\": {},\n    \"nonScaleValues\": []\n  }\n}"
+        }
+      ],
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "stop_details": null,
+      "usage": {
+        "input_tokens": 1559,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation": {
+          "ephemeral_5m_input_tokens": 0,
+          "ephemeral_1h_input_tokens": 0
+        },
+        "output_tokens": 174,
+        "service_tier": "standard",
+        "inference_geo": "not_available"
+      }
+    }
+  }
+}

--- a/lib/__tests__/call-anthropic.test.mjs
+++ b/lib/__tests__/call-anthropic.test.mjs
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  callAnthropic,
+  buildAuditPrompt,
+  AUDIT_SYSTEM_PROMPT,
+} from '../prompts.mjs'
+import { setupFixture, saveRecordedFixture } from './helpers/anthropic-recorder.mjs'
+
+const RECORD_MODE = process.env.RECORD_FIXTURES === '1'
+
+describe('callAnthropic', () => {
+  it('returns text on successful 200 response', async () => {
+    const fixtureName = 'audit-200-simple-css'
+    const css = 'body { color: #ff0000; font-size: 16px; }'
+    const prompt = buildAuditPrompt(css)
+
+    if (RECORD_MODE) {
+      const apiKey = process.env.ANTHROPIC_API_KEY
+      if (!apiKey) {
+        throw new Error(
+          'ANTHROPIC_API_KEY is required when RECORD_FIXTURES=1'
+        )
+      }
+
+      const realFetch = globalThis.fetch.bind(globalThis)
+      let captured
+
+      globalThis.fetch = async (...args) => {
+        const response = await realFetch(...args)
+        const body = await response.clone().json()
+        captured = { status: response.status, ok: response.ok, body }
+        return response
+      }
+
+      let result
+      try {
+        result = await callAnthropic({
+          apiKey,
+          prompt,
+          system: AUDIT_SYSTEM_PROMPT,
+          maxTokens: 3000,
+        })
+      } finally {
+        globalThis.fetch = realFetch
+      }
+
+      if (!captured) {
+        throw new Error('No response captured. Did the API call complete?')
+      }
+
+      await saveRecordedFixture(fixtureName, captured)
+
+      expect(typeof result).toBe('string')
+      expect(result.length).toBeGreaterThan(0)
+    } else {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      await setupFixture(fixtureName, fetchSpy)
+
+      const result = await callAnthropic({
+        apiKey: 'fake-key',
+        prompt,
+        system: AUDIT_SYSTEM_PROMPT,
+        maxTokens: 3000,
+      })
+
+      expect(typeof result).toBe('string')
+      expect(result.length).toBeGreaterThan(0)
+
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it('throws when apiKey is missing', async () => {
+    await expect(
+      callAnthropic({ apiKey: undefined, prompt: 'test' })
+    ).rejects.toThrow('ANTHROPIC_API_KEY is required')
+  })
+
+  it.each([
+    [400, 'invalid_request_error', 'Bad request'],
+    [401, 'authentication_error', 'Invalid key'],
+    [402, 'billing_error', 'Payment issue'],
+    [403, 'permission_error', 'No permission'],
+    [404, 'not_found_error', 'Resource not found'],
+    [413, 'request_too_large', 'Request too large'],
+    [429, 'rate_limit_error', 'Rate limited'],
+    [500, 'api_error', 'Internal error'],
+    [504, 'timeout_error', 'Request timeout'],
+    [529, 'overloaded_error', 'API overloaded'],
+  ])(
+    'throws on %i %s',
+    async (status, type, message) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status,
+        json: async () => ({
+          error: { type, message },
+        }),
+      })
+
+      await expect(
+        callAnthropic({ apiKey: 'sk-test', prompt: 'test' })
+      ).rejects.toThrow(message)
+
+      fetchSpy.mockRestore()
+    }
+  )
+
+  it('throws generic error when response message is missing', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    })
+
+    await expect(
+      callAnthropic({ apiKey: 'sk-test', prompt: 'test' })
+    ).rejects.toThrow('Anthropic API error (500)')
+
+    fetchSpy.mockRestore()
+  })
+})

--- a/lib/__tests__/helpers/anthropic-recorder.mjs
+++ b/lib/__tests__/helpers/anthropic-recorder.mjs
@@ -1,0 +1,67 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES_DIR = path.resolve(__dirname, '../../__fixtures__/anthropic')
+
+async function ensureDir(dir) {
+  await fs.mkdir(dir, { recursive: true })
+}
+
+/** Load a previously recorded fixture from disk.
+ *  Throws a helpful error with recording instructions if the fixture is missing. */
+export async function loadFixture(name) {
+  const filePath = path.join(FIXTURES_DIR, `${name}.json`)
+  try {
+    const raw = await fs.readFile(filePath, 'utf8')
+    return JSON.parse(raw)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        `Fixture "${name}" not found at ${filePath}\n\n` +
+          `To record it, run:\n` +
+          `  RECORD_FIXTURES=1 npx vitest run lib/__tests__/call-anthropic.test.mjs`
+      )
+    }
+    throw err
+  }
+}
+
+/** Persist a captured HTTP response to disk as a JSON fixture.
+ *  `captured` must be an object with { status, ok, body }. */
+export async function saveRecordedFixture(name, captured) {
+  if (!captured) {
+    throw new Error(
+      `No response captured for fixture "${name}". Did fetch run?`
+    )
+  }
+
+  await ensureDir(FIXTURES_DIR)
+
+  const fixture = {
+    _meta: {
+      recordedAt: new Date().toISOString(),
+      scenario: name,
+    },
+    response: captured,
+  }
+
+  const filePath = path.join(FIXTURES_DIR, `${name}.json`)
+  await fs.writeFile(
+    filePath,
+    JSON.stringify(fixture, null, 2) + '\n',
+    'utf8'
+  )
+}
+
+/** Wire a Vitest fetch spy to replay a saved fixture instead of making real network calls. */
+export async function setupFixture(name, fetchSpy) {
+  const fixture = await loadFixture(name)
+
+  fetchSpy.mockImplementation(async () => ({
+    ok: fixture.response.ok,
+    status: fixture.response.status,
+    json: async () => fixture.response.body,
+  }))
+}

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -419,7 +419,6 @@ export function stripFences(raw) {
     .trim()
 }
 
-/* v8 ignore start */
 /** @param {{ apiKey: string|undefined, prompt: string, system?: string, maxTokens?: number }} opts */
 export async function callAnthropic({ apiKey, prompt, system, maxTokens = 3000 }) {
   if (!apiKey) {
@@ -448,4 +447,3 @@ export async function callAnthropic({ apiKey, prompt, system, maxTokens = 3000 }
   const block = (data.content || []).find((b) => b && b.type === 'text')
   return block ? block.text : ''
 }
-/* v8 ignore end */

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:record": "RECORD_FIXTURES=1 vitest run",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "prepare": "husky",


### PR DESCRIPTION
## Summary
Add comprehensive tests for `callAnthropic` in `lib/prompts.mjs` with a record/replay fixture system for real API responses.

## What's changed
- **Removed** `/* v8 ignore start/end */` comments around `callAnthropic` so coverage tracks it
- **Added** `lib/__tests__/call-anthropic.test.mjs` with 13 tests:
  - Successful 200 response (using `buildAuditPrompt` with simple CSS)
  - Missing `apiKey` guard
  - All 10 documented Anthropic HTTP error codes (400–529)
  - Generic error fallback when response message is missing
- **Added** `lib/__tests__/helpers/anthropic-recorder.mjs` — lightweight fixture recorder
- **Added** `lib/__fixtures__/anthropic/` directory for stored responses
- **Added** `test:record` npm script (`RECORD_FIXTURES=1 vitest run`)

## Verification
- All 78 tests pass
- `prompts.mjs` coverage: 100% statements, 88.57% branches