### PR TITLE
feat: detect inconsistent line-height values in CSS audit

### DIFF
--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -182,6 +182,7 @@ function defaultDecisions(audit) {
     })),
     fonts: (audit.fonts || []).filter((f) => !f.isSystemFont).map((f) => f.family),
     spacingScale: audit.spacing?.suggestedScale || {},
+    lineHeights: audit.lineHeights?.suggestedScale || {},
   }
 }
 

--- a/components/AuditView.tsx
+++ b/components/AuditView.tsx
@@ -35,6 +35,7 @@ export default function AuditView({ audit, onResolve }: Props) {
   )
 
   const spacingScale = audit.spacing.suggestedScale
+  const lineHeights = audit.lineHeights?.suggestedScale ?? {}
 
   const chaosColor =
     audit.chaosScore <= 3 ? '#4ade80' : audit.chaosScore <= 6 ? '#fbbf24' : '#f87171'
@@ -46,7 +47,7 @@ export default function AuditView({ audit, onResolve }: Props) {
   }
 
   const handleResolve = () => {
-    onResolve({ colors: colorDecisions, fonts: fontDecisions, spacingScale })
+    onResolve({ colors: colorDecisions, fonts: fontDecisions, spacingScale, lineHeights })
   }
 
   const includedColors = colorDecisions.filter((d) => d.include).length

--- a/lib/__tests__/playground-cache.test.ts
+++ b/lib/__tests__/playground-cache.test.ts
@@ -56,6 +56,7 @@ const AUDIT: AuditReport = {
   colorClusters: [],
   fonts: [],
   spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+  lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
 }
 
 const TOKENS: DSTokens = {
@@ -71,6 +72,7 @@ const DECISIONS: UserDecisions = {
   colors: [{ clusterId: 'c1', name: 'primary', value: '#6366f1', include: true }],
   fonts: ['Inter'],
   spacingScale: { '1': '4px', '2': '8px' },
+  lineHeights: {},
 }
 
 const CSS = 'body { color: #6366f1; font-size: 16px; }'

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -110,7 +110,7 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('</example>')
   })
 
-  it('includes all six analysis steps', () => {
+  it('includes all seven analysis steps', () => {
     const content = buildAuditPrompt(css).content
     expect(content).toContain('STEP 1')
     expect(content).toContain('STEP 2')
@@ -118,6 +118,7 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('STEP 4')
     expect(content).toContain('STEP 5')
     expect(content).toContain('STEP 6')
+    expect(content).toContain('STEP 7')
   })
 
   it('covers all required JSON output fields in the example', () => {
@@ -128,6 +129,7 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('"colorClusters"')
     expect(content).toContain('"fonts"')
     expect(content).toContain('"spacing"')
+    expect(content).toContain('"lineHeights"')
   })
 
   it('includes all allowed semantic color names', () => {
@@ -144,6 +146,7 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('+1 if colorClusters')
     expect(content).toContain('+2 if nonScaleValues')
     expect(content).toContain('+1 if nonScaleValues')
+    expect(content).toContain('unitlessMix')
   })
 
   it('covers directional spacing properties', () => {
@@ -166,6 +169,17 @@ describe('buildAuditPrompt', () => {
   it('instructs Claude to return only JSON with no markdown fences', () => {
     expect(buildAuditPrompt(css).content).toContain('No markdown fences')
   })
+
+  it('includes a LINE-HEIGHT step with unitlessMix flag', () => {
+    const content = buildAuditPrompt(css).content
+    expect(content).toContain('LINE-HEIGHT')
+    expect(content).toContain('unitlessMix')
+    expect(content).toContain('tight')
+    expect(content).toContain('snug')
+    expect(content).toContain('normal')
+    expect(content).toContain('relaxed')
+    expect(content).toContain('loose')
+  })
 })
 
 describe('buildResolvePrompt', () => {
@@ -174,6 +188,7 @@ describe('buildResolvePrompt', () => {
     colors: [{ include: true, name: 'primary', value: '#6366f1' }],
     fonts: ['Inter'],
     spacingScale: { '1': '4px', '2': '8px' },
+    lineHeights: { tight: 1.2, normal: 1.5 },
   }
 
   it('returns an object with content and null system', () => {
@@ -197,6 +212,16 @@ describe('buildResolvePrompt', () => {
 
   it('includes DSTokens instructions', () => {
     expect(buildResolvePrompt(css, decisions).content).toContain('DSTokens')
+  })
+
+  it('includes line-height normalization instructions with canonical keys', () => {
+    const content = buildResolvePrompt(css, decisions).content
+    expect(content).toContain('tight')
+    expect(content).toContain('snug')
+    expect(content).toContain('normal')
+    expect(content).toContain('relaxed')
+    expect(content).toContain('loose')
+    expect(content).toContain('lineHeights')
   })
 })
 

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -44,7 +44,23 @@ Exclude: 0, percentages (%), auto, and any non-px unit (em, rem, vh, vw, vmin, v
 - "suggestedScale": map of scale step → px value, include only steps that match at least one found value: 1→4px, 2→8px, 3→12px, 4→16px, 5→20px, 6→24px, 8→32px, 10→40px, 12→48px, 16→64px, 20→80px, 24→96px
 - "nonScaleValues": values from "found" that are NOT divisible by 4
 
-STEP 4 — CHAOS SCORE
+STEP 4 — LINE-HEIGHT
+Collect every distinct line-height value from the CSS. Scan for:
+- The line-height property (all values — unitless numbers like 1.2, length values like 20px, percentages)
+- The shorthand "font: …/<value>" where space-slash precedes the line-height (e.g. "font: 14px/1.5 Inter" or "font: 700 16px/24px sans-serif")
+
+Normalize all values to their canonical representation:
+- Keep unitless numbers as numbers (1.2, 1.5, 1.75)
+- Convert px values to numbers by dividing by the author's body font-size if detectable, otherwise divide by 16
+- Round to 2 decimal places
+
+- "found": all distinct normalized values sorted ascending as numbers (e.g. [1.2, 1.25, 1.5, 1.75])
+- "suggestedScale": map each found value to the closest canonical key from this fixed set:
+  tight (1.0–1.2), snug (1.21–1.4), normal (1.41–1.6), relaxed (1.61–1.8), loose (1.81+)
+  Only include values that actually appear in "found". If multiple found values map to the same key, keep the one closest to the key's midpoint.
+- "unitlessMix": true if some values in "found" are unitless numbers AND others are px-derived (e.g. [1.2, 20] means 1.2 is unitless and 20 was px-derived)
+
+STEP 5 — CHAOS SCORE
 Compute a deterministic integer from 1–10. Start at 1, then add:
 - +2 if colorClusters.length > 8
 - +1 if colorClusters.length > 5 (stacks with the above)
@@ -52,12 +68,13 @@ Compute a deterministic integer from 1–10. Start at 1, then add:
 - +1 if nonScaleValues.length > 5 (stacks with the above)
 - +2 if count of non-system fonts (isSystemFont === false) > 3
 - +1 if count of non-system fonts > 1 (stacks with the above)
+- +1 if lineHeights.unitlessMix is true
 Cap the final result at 10.
 
-STEP 5 — SUMMARY
-Write 1–2 sentences naming the top quality issues. Be specific: cite actual counts (e.g. "9 color clusters including 4 near-duplicate grays", "17 off-scale spacing values").
+STEP 6 — SUMMARY
+Write 1–2 sentences naming the top quality issues. Be specific: cite actual counts (e.g. "9 color clusters including 4 near-duplicate grays", "17 off-scale spacing values", "5 line-height values mixing unitless and px units").
 
-STEP 6 — BRAND
+STEP 7 — BRAND
 Infer a project name from CSS comments, HTML title elements, BEM block prefixes, CSS variable namespaces (e.g. --myapp-*), or @layer names. Return "" if nothing identifiable is found.
 </instructions>
 
@@ -88,6 +105,11 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
     "found": ["4px", "7px", "8px", "13px", "16px", "24px"],
     "suggestedScale": { "1": "4px", "2": "8px", "4": "16px", "6": "24px" },
     "nonScaleValues": ["7px", "13px"]
+  },
+  "lineHeights": {
+    "found": [1.2, 1.25, 1.5, 1.75],
+    "suggestedScale": { "tight": 1.2, "snug": 1.25, "normal": 1.5, "relaxed": 1.75 },
+    "unitlessMix": true
   }
 }
 </example>
@@ -112,7 +134,8 @@ Rules:
 - Extract box-shadow values from the CSS. Normalize to: sm, md, lg, xl. Include only found values.
 - Extract font-size values from the CSS. Normalize to semantic keys: xs, sm, base, lg, xl, 2xl, 3xl, 4xl, 5xl. Base ≈ 16px. Include only found values.
 - Extract font-weight values from the CSS. Normalize to: thin (100), light (300), normal (400), medium (500), semibold (600), bold (700), extrabold (800). Include only found values.
-- Extract line-height values from the CSS. Normalize to: tight (1–1.2), snug (1.3–1.4), normal (1.5), relaxed (1.6–1.7), loose (2+). Include only found values.
+- decisions.lineHeights: use as the line-height token map. Validate against the CSS — drop any key whose normalized CSS value differs by more than 0.15 from the decisions value. If the CSS contains additional line-height values not in the decisions, add them using the canonical key mapping (tight: 1.0–1.2, snug: 1.21–1.4, normal: 1.41–1.6, relaxed: 1.61–1.8, loose: 1.81+).
+- Extract line-height values from the CSS if decisions.lineHeights is empty. Normalize to: tight (1–1.2), snug (1.3–1.4), normal (1.5), relaxed (1.6–1.7), loose (2+). Include only found values.
 - Generate a 50–900 scale (50, 100, 200, 300, 400, 500, 600, 700, 800, 900) for each included color. The "value" from decisions is the 500. Derive lighter shades by mixing with white and darker shades by mixing with black (adjust luminance accordingly).
 - brand: extract from CSS comments, class name prefixes, or CSS variable prefixes. Empty string if not found.
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -72,6 +72,12 @@ export interface SpacingAudit {
   nonScaleValues: string[]
 }
 
+export interface LineHeightAudit {
+  found: string[]
+  suggestedScale: Record<string, string | number>
+  unitlessMix: boolean
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -79,6 +85,7 @@ export interface AuditReport {
   colorClusters: ColorCluster[]
   fonts: FontEntry[]
   spacing: SpacingAudit
+  lineHeights: LineHeightAudit
 }
 
 export interface ColorDecision {
@@ -92,6 +99,7 @@ export interface UserDecisions {
   colors: ColorDecision[]
   fonts: string[]
   spacingScale: Record<string, string>
+  lineHeights: Record<string, string | number>
 }
 
 // ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Audit step now collects every `line-height` declaration and `font: …/<lh>` shorthand, clusters near-duplicates against a canonical scale, and flags unitless-vs-px mixing
- New field `lineHeights` in `AuditReport` (`found`, `suggestedScale`, `unitlessMix`)
- Wired through `UserDecisions` → `buildResolvePrompt` so the resolve step uses audited line-heights as a starting point
- Chaos score gains +1 when `unitlessMix` is true

## Before vs After — AuditReport shape

### Before

```json
{
  "brand": "", "chaosScore": 1, "summary": "...",
  "colorClusters": [...], "fonts": [...],
  "spacing": { "found": [...], "suggestedScale": {...}, "nonScaleValues": [...] }
}
```

### After

```json
{
  "brand": "", "chaosScore": 1, "summary": "...",
  "colorClusters": [...], "fonts": [...],
  "spacing": { "found": [...], "suggestedScale": {...}, "nonScaleValues": [...] },
  "lineHeights": {
    "found": [1.2, 1.25, 1.5, 1.75],
    "suggestedScale": { "tight": 1.2, "snug": 1.25, "normal": 1.5, "relaxed": 1.75 },
    "unitlessMix": true
  }
}
```

## Real-world validation

The full pipeline was validated end-to-end against a real LLM (DeepSeek V4 Flash) using `DEEPSEEK_API_KEY`. Sample CSS with mixed unitless line-heights produced:

> `audit.lineHeights.found: [1.2, 1.5, 1.6, 1.75]` → `resolve.tokens.typography.lineHeights: {"tight": 1.2, "normal": 1.5, "relaxed": 1.75}`

## How to test

1. Paste any CSS with `line-height` declarations into the playground or run `npx mint-ds audit ./path`
2. Check that the audit report now includes `lineHeights`
3. Resolve tokens and verify `typography.lineHeights` appears in `mint-ds.tokens.json`
4. Export to any target — line-heights should be present in the generated output

## Checklist

- [x] `npx tsc --noEmit` passes with no errors
- [x] Tested with real CSS input through the full audit → tokens → export flow
- [ ] UI is responsive on mobile (tested at 375px width) — *no UI layout changes, only data flow*
- [x] No new Spanish strings introduced — all user-facing text is English
- [x] No hardcoded colors or values that should be CSS variables