### PR TITLE
chore: setup Prettier for code formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Something in mint-ds doesn't work the way you expected
-title: "[Bug]: "
-labels: ["bug", "needs-triage"]
+title: '[Bug]: '
+labels: ['bug', 'needs-triage']
 body:
   - type: markdown
     attributes:
@@ -29,7 +29,7 @@ body:
     attributes:
       label: mint-ds version
       description: Run `mint-ds --version` — or `node bin/mint-ds.mjs --version` if you're working from a clone. Use `n/a` for web-only or docs bugs.
-      placeholder: "0.1.0"
+      placeholder: '0.1.0'
     validations:
       required: true
 
@@ -38,14 +38,14 @@ body:
     attributes:
       label: Node.js version
       description: Output of `node --version`. Skip if this is a web-only or docs bug.
-      placeholder: "v20.11.1"
+      placeholder: 'v20.11.1'
 
   - type: input
     id: env
     attributes:
       label: OS & shell
       description: e.g. `macOS 14.4 / zsh`, `Ubuntu 22.04 / bash`, `Windows 11 / PowerShell 7`, `WSL2 Ubuntu / bash`. For web bugs, give the browser instead (e.g. `Firefox 124 on macOS 14`).
-      placeholder: "macOS 14.4 / zsh"
+      placeholder: 'macOS 14.4 / zsh'
 
   - type: textarea
     id: reproduction

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Propose a new export target, CLI flag, playground improvement, or other enhancement
-title: "[Feature]: "
-labels: ["enhancement", "needs-triage"]
+title: '[Feature]: '
+labels: ['enhancement', 'needs-triage']
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run format:check
+
       - run: npm run lint
 
       - run: npm run typecheck

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+examples/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "printWidth": 80,
+  "useTabs": false,
+  "endOfLine": "lf",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,10 @@ Mint is a Next.js 15 app with three API routes and a single-page wizard UI.
 
 **The wizard has three steps:**
 
-| Step | Component | API call |
-|------|-----------|----------|
-| 1 — Input | `CssInput.tsx` | — |
-| 2 — Audit | `AuditView.tsx` | `POST /api/audit` |
+| Step       | Component                      | API call                                |
+| ---------- | ------------------------------ | --------------------------------------- |
+| 1 — Input  | `CssInput.tsx`                 | —                                       |
+| 2 — Audit  | `AuditView.tsx`                | `POST /api/audit`                       |
 | 3 — Tokens | `TokenPreview` + `ExportPanel` | `POST /api/resolve`, `POST /api/export` |
 
 **State machine lives in `app/page.tsx`** as a `WizardStep` union (`'input' | 'audit' | 'tokens'`). All API calls go through `handleAudit` and `handleResolve` there.
@@ -43,6 +43,7 @@ Mint is a Next.js 15 app with three API routes and a single-page wizard UI.
 ### Modifying Claude prompts
 
 All three prompts live in their respective route files:
+
 - `app/api/audit/route.ts` — CSS analysis prompt
 - `app/api/resolve/route.ts` — token generation prompt
 - `app/api/export/route.ts` — code generation prompt (one case per target)
@@ -57,7 +58,7 @@ Add CSS utility classes to the `Responsive layout utilities` section at the bott
 
 - **Language** — all user-facing strings must be English
 - **Types** — no `any`, no implicit `any`. Extend `lib/types.ts` for new shapes
-- **Comments** — only when the *why* is non-obvious. No docstrings, no task references
+- **Comments** — only when the _why_ is non-obvious. No docstrings, no task references
 - **Inline styles vs CSS** — use CSS classes for layout (grid, flex, padding breakpoints), inline styles for dynamic/token-driven values
 - **No new dependencies** without discussion — the current stack is intentionally minimal
 
@@ -95,16 +96,16 @@ All four commands run automatically in CI on every PR. The pre-commit hook runs 
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/) so the changelog and GitHub Releases can be generated automatically.
 
-| Prefix | When to use |
-|--------|-------------|
-| `feat:` | New user-facing feature |
-| `fix:` | Bug fix |
-| `perf:` | Performance improvement |
-| `refactor:` | Code change with no behavior change |
-| `docs:` | Documentation only |
-| `chore:` | Tooling, deps, config (hidden in changelog) |
-| `test:` | Tests only (hidden in changelog) |
-| `ci:` | CI/CD changes (hidden in changelog) |
+| Prefix      | When to use                                 |
+| ----------- | ------------------------------------------- |
+| `feat:`     | New user-facing feature                     |
+| `fix:`      | Bug fix                                     |
+| `perf:`     | Performance improvement                     |
+| `refactor:` | Code change with no behavior change         |
+| `docs:`     | Documentation only                          |
+| `chore:`    | Tooling, deps, config (hidden in changelog) |
+| `test:`     | Tests only (hidden in changelog)            |
+| `ci:`       | CI/CD changes (hidden in changelog)         |
 
 Breaking changes: add `!` after the prefix or a `BREAKING CHANGE:` footer, e.g. `feat!: redesign token schema`.
 
@@ -123,6 +124,7 @@ GITHUB_TOKEN=<your-token> npm run release
 ```
 
 `release-it` will:
+
 1. Bump the version in `package.json` (patch / minor / major — it asks)
 2. Append the new section to `CHANGELOG.md`
 3. Commit both files with `chore: release vX.Y.Z`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A bundled example of the kind of CSS that grows organically over a few years: th
 
 ### Before — `examples/frankenstein/styles.css`
 
+<!-- prettier-ignore-start -->
 ```css
 :root {
   --color-primary:       #1976d2;
@@ -52,17 +53,18 @@ p, span, li  { font-family: Arial, sans-serif; }
 .modal-footer{ margin-top: 17px; }
 .tooltip     { padding: 5px 9px; }
 ```
+<!-- prettier-ignore-end -->
 
 ### What Mint sees
 
-| Signal | What's in the source | What Mint outputs |
-|---|---|---|
-| **Colors** | 6 aliases for `#1976d2`, 3 for `#e53935`, 3 for `#f5f5f5`, 3 for `#212121`, 3 for `#dddddd` — all formatted differently (hex caps, hex lower, `rgb`, `rgba`, `hsl`, `#DDD` shorthand) | 7 named colors (`primary`, `error`, `background`, `text`, `border`, `surface`, `muted`), each with a 50–900 scale |
-| **Fonts** | 5 `font-family` declarations, all Arial-family permutations | 1 body family |
-| **Spacing** | 20+ values mixed across `px` / `rem` / `em`, including primes `7`, `11`, `13`, `17`, `19` | 5-step scale snapped to 4px: `4 / 8 / 12 / 20 / 24` |
-| **Border radius** | `4px` and `8px` scattered with `!important` | `sm: 4px`, `md: 8px` |
-| **Shadows** | `.shadow` and `.shadow-md` define the same value twice | one `sm` token |
-| **Weights** | `bold` and `700` declared as separate utilities (same thing) | `bold: 700`, `extrabold: 800` |
+| Signal            | What's in the source                                                                                                                                                                  | What Mint outputs                                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Colors**        | 6 aliases for `#1976d2`, 3 for `#e53935`, 3 for `#f5f5f5`, 3 for `#212121`, 3 for `#dddddd` — all formatted differently (hex caps, hex lower, `rgb`, `rgba`, `hsl`, `#DDD` shorthand) | 7 named colors (`primary`, `error`, `background`, `text`, `border`, `surface`, `muted`), each with a 50–900 scale |
+| **Fonts**         | 5 `font-family` declarations, all Arial-family permutations                                                                                                                           | 1 body family                                                                                                     |
+| **Spacing**       | 20+ values mixed across `px` / `rem` / `em`, including primes `7`, `11`, `13`, `17`, `19`                                                                                             | 5-step scale snapped to 4px: `4 / 8 / 12 / 20 / 24`                                                               |
+| **Border radius** | `4px` and `8px` scattered with `!important`                                                                                                                                           | `sm: 4px`, `md: 8px`                                                                                              |
+| **Shadows**       | `.shadow` and `.shadow-md` define the same value twice                                                                                                                                | one `sm` token                                                                                                    |
+| **Weights**       | `bold` and `700` declared as separate utilities (same thing)                                                                                                                          | `bold: 700`, `extrabold: 800`                                                                                     |
 
 ### After — `examples/frankenstein/mint-ds.tokens.json`
 
@@ -77,25 +79,56 @@ p, span, li  { font-family: Arial, sans-serif; }
       "name": "primary",
       "value": "#1976d2",
       "scale": {
-        "50":  "#e3f2fd", "100": "#bbdefb", "200": "#90caf9",
-        "300": "#64b5f6", "400": "#42a5f5", "500": "#1976d2",
-        "600": "#1565c0", "700": "#0d47a1", "800": "#0a3f8f", "900": "#08357d"
+        "50": "#e3f2fd",
+        "100": "#bbdefb",
+        "200": "#90caf9",
+        "300": "#64b5f6",
+        "400": "#42a5f5",
+        "500": "#1976d2",
+        "600": "#1565c0",
+        "700": "#0d47a1",
+        "800": "#0a3f8f",
+        "900": "#08357d"
       }
     },
-    { "name": "error",      "value": "#e53935", "scale": { "50": "#ffebee", "...": "...", "900": "#a01818" } },
-    { "name": "background", "value": "#f5f5f5", "scale": { "50": "#fefefe", "...": "...", "900": "#a8a8a8" } },
-    { "name": "text",       "value": "#212121", "scale": { "50": "#f5f5f5", "...": "...", "900": "#141414" } },
-    { "name": "border",     "value": "#dddddd", "scale": { "50": "#f9f9f9", "...": "...", "900": "#6c6c6c" } },
-    { "name": "surface",    "value": "#ffffff", "scale": { "50": "#ffffff", "...": "...", "900": "#999999" } },
-    { "name": "muted",      "value": "#666666", "scale": { "50": "#f2f2f2", "...": "...", "900": "#333333" } }
+    {
+      "name": "error",
+      "value": "#e53935",
+      "scale": { "50": "#ffebee", "...": "...", "900": "#a01818" }
+    },
+    {
+      "name": "background",
+      "value": "#f5f5f5",
+      "scale": { "50": "#fefefe", "...": "...", "900": "#a8a8a8" }
+    },
+    {
+      "name": "text",
+      "value": "#212121",
+      "scale": { "50": "#f5f5f5", "...": "...", "900": "#141414" }
+    },
+    {
+      "name": "border",
+      "value": "#dddddd",
+      "scale": { "50": "#f9f9f9", "...": "...", "900": "#6c6c6c" }
+    },
+    {
+      "name": "surface",
+      "value": "#ffffff",
+      "scale": { "50": "#ffffff", "...": "...", "900": "#999999" }
+    },
+    {
+      "name": "muted",
+      "value": "#666666",
+      "scale": { "50": "#f2f2f2", "...": "...", "900": "#333333" }
+    }
   ],
   "typography": {
     "fontFamilies": { "body": "Helvetica Neue" },
-    "fontWeights":  { "bold": 700, "extrabold": 800 }
+    "fontWeights": { "bold": 700, "extrabold": 800 }
   },
-  "spacing":      { "1": "4px", "2": "8px", "3": "12px", "5": "20px", "6": "24px" },
+  "spacing": { "1": "4px", "2": "8px", "3": "12px", "5": "20px", "6": "24px" },
   "borderRadius": { "sm": "4px", "md": "8px" },
-  "shadows":      { "sm": "0 2px 4px rgba(0,0,0,0.1)" }
+  "shadows": { "sm": "0 2px 4px rgba(0,0,0,0.1)" }
 }
 ```
 
@@ -115,29 +148,31 @@ module.exports = {
     './src/**/*.{html,js,jsx,ts,tsx,vue}',
     './components/**/*.{html,js,jsx,ts,tsx,vue}',
     './pages/**/*.{html,js,jsx,ts,tsx,vue}',
-    './app/**/*.{html,js,jsx,ts,tsx,vue}'
+    './app/**/*.{html,js,jsx,ts,tsx,vue}',
   ],
   darkMode: 'class',
   theme: {
     extend: {
       colors: {
         primary: {
-          50: '#e3f2fd', 100: '#bbdefb', /* …300–800 */ 900: '#08357d',
-          DEFAULT: '#1976d2'
+          50: '#e3f2fd',
+          100: '#bbdefb',
+          /* …300–800 */ 900: '#08357d',
+          DEFAULT: '#1976d2',
         },
         // error, background, text, border, surface, muted — same shape
       },
       fontFamily: {
         display: ['Helvetica Neue', 'sans-serif'],
-        body:    ['Helvetica Neue', 'sans-serif']
+        body: ['Helvetica Neue', 'sans-serif'],
       },
-      spacing:      { '1': '4px', '2': '8px', '3': '12px', '5': '20px', '6': '24px' },
+      spacing: { 1: '4px', 2: '8px', 3: '12px', 5: '20px', 6: '24px' },
       borderRadius: { sm: '4px', md: '8px' },
-      boxShadow:    { sm: '0 2px 4px rgba(0,0,0,0.1)' }
-    }
+      boxShadow: { sm: '0 2px 4px rgba(0,0,0,0.1)' },
+    },
   },
   safelist: ['bg-primary-500', 'text-error-500', /* … */ 'font-extrabold'],
-  plugins: []
+  plugins: [],
 }
 ```
 
@@ -218,12 +253,12 @@ Useful for one-off runs, CI jobs, or when you don't want the key persisted in yo
 
 **Option 2 — set the `ANTHROPIC_API_KEY` env var.** Syntax depends on your shell:
 
-| Shell | Command |
-|-------|---------|
-| bash / zsh / sh (macOS, Linux, WSL) | `export ANTHROPIC_API_KEY=sk-ant-...` |
-| fish | `set -gx ANTHROPIC_API_KEY sk-ant-...` |
-| PowerShell (Windows / pwsh) | `$env:ANTHROPIC_API_KEY = "sk-ant-..."` |
-| Windows CMD | `set ANTHROPIC_API_KEY=sk-ant-...` |
+| Shell                               | Command                                 |
+| ----------------------------------- | --------------------------------------- |
+| bash / zsh / sh (macOS, Linux, WSL) | `export ANTHROPIC_API_KEY=sk-ant-...`   |
+| fish                                | `set -gx ANTHROPIC_API_KEY sk-ant-...`  |
+| PowerShell (Windows / pwsh)         | `$env:ANTHROPIC_API_KEY = "sk-ant-..."` |
+| Windows CMD                         | `set ANTHROPIC_API_KEY=sk-ant-...`      |
 
 These commands set the key only for the current shell session. To persist it, add the line to your shell rc file (`~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, your PowerShell `$PROFILE`, etc.) or use the system Environment Variables dialog on Windows.
 
@@ -231,21 +266,21 @@ These commands set the key only for the current shell session. To persist it, ad
 
 ### All commands
 
-| Command | Description |
-|---------|-------------|
-| `mint-ds audit <dir>` | Walk `<dir>` for `.css`, `.scss`, `.sass`, `.less`, `.html` files, audit them with Claude, and write `mint-ds.tokens.json` |
-| `mint-ds export --target <name>` | Read `mint-ds.tokens.json` and generate the chosen format |
-| `mint-ds cache --clear` | Delete the local `mint-ds.cache.json` cache file |
-| `mint-ds --help` | Show full usage |
+| Command                          | Description                                                                                                                |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `mint-ds audit <dir>`            | Walk `<dir>` for `.css`, `.scss`, `.sass`, `.less`, `.html` files, audit them with Claude, and write `mint-ds.tokens.json` |
+| `mint-ds export --target <name>` | Read `mint-ds.tokens.json` and generate the chosen format                                                                  |
+| `mint-ds cache --clear`          | Delete the local `mint-ds.cache.json` cache file                                                                           |
+| `mint-ds --help`                 | Show full usage                                                                                                            |
 
 ### Audit options
 
-| Flag | Description |
-|------|-------------|
-| `--out <file>` | Tokens output path (default: `mint-ds.tokens.json`) |
-| `--report <file>` | Also write the raw `AuditReport` JSON for inspection |
-| `--quiet` | Skip the chaos summary printout |
-| `--no-cache` | Skip the cache lookup and overwrite any existing cache entry for this CSS |
+| Flag              | Description                                                               |
+| ----------------- | ------------------------------------------------------------------------- |
+| `--out <file>`    | Tokens output path (default: `mint-ds.tokens.json`)                       |
+| `--report <file>` | Also write the raw `AuditReport` JSON for inspection                      |
+| `--quiet`         | Skip the chaos summary printout                                           |
+| `--no-cache`      | Skip the cache lookup and overwrite any existing cache entry for this CSS |
 
 ### Cache
 
@@ -264,12 +299,12 @@ Add `mint-ds.cache.json` to `.gitignore` if you don't want to commit it.
 
 ### Export options
 
-| Flag | Description |
-|------|-------------|
+| Flag              | Description                                                                                                                                                                                    |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--target <name>` | **Required.** Accepts: `tailwind`, `react`, `vue`, `svelte`, `astro`, `css`, `scss`, `ts`, `css-modules`, `styled`, `emotion` (full names like `tailwind-config`, `react-component` also work) |
-| `--tokens <file>` | Tokens input path (default: `mint-ds.tokens.json`) |
-| `--out <file>` | Override the default output filename |
-| `--stdout` | Print to stdout instead of writing a file |
+| `--tokens <file>` | Tokens input path (default: `mint-ds.tokens.json`)                                                                                                                                             |
+| `--out <file>`    | Override the default output filename                                                                                                                                                           |
+| `--stdout`        | Print to stdout instead of writing a file                                                                                                                                                      |
 
 ### Local development without publishing
 
@@ -285,11 +320,11 @@ node bin/mint-ds.mjs export --target tailwind
 
 ## Export formats
 
-| Category | Formats |
-|----------|---------|
-| Tokens | CSS Custom Properties, SCSS Variables, JS/TS Object |
+| Category   | Formats                                                        |
+| ---------- | -------------------------------------------------------------- |
+| Tokens     | CSS Custom Properties, SCSS Variables, JS/TS Object            |
 | Frameworks | Tailwind Config, Styled Components, Emotion Theme, CSS Modules |
-| Components | React + TypeScript, Vue 3 SFC, Svelte, Astro |
+| Components | React + TypeScript, Vue 3 SFC, Svelte, Astro                   |
 
 ## Stack
 
@@ -320,9 +355,9 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## Environment variables
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `ANTHROPIC_API_KEY` | Yes | Anthropic API key — get one at [console.anthropic.com](https://console.anthropic.com) |
+| Variable            | Required | Description                                                                           |
+| ------------------- | -------- | ------------------------------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY` | Yes      | Anthropic API key — get one at [console.anthropic.com](https://console.anthropic.com) |
 
 ## Project structure
 

--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server'
 import { buildAuditPrompt } from '@/lib/prompts.mjs'
 import { getCssAuditor } from '@/lib/css-auditor.mjs'
 
-
 export async function POST(req: NextRequest) {
   const { css } = await req.json()
 

--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -3,9 +3,9 @@ import type { DSTokens, ExportTarget } from '@/lib/types'
 import { buildExportPrompt } from '@/lib/prompts.mjs'
 import { getCssAuditor } from '@/lib/css-auditor.mjs'
 
-
 export async function POST(req: NextRequest) {
-  const { tokens, target }: { tokens: DSTokens; target: ExportTarget } = await req.json()
+  const { tokens, target }: { tokens: DSTokens; target: ExportTarget } =
+    await req.json()
 
   const prompt = buildExportPrompt(tokens, target)
   if (!prompt) {

--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getCssAuditor } from '@/lib/css-auditor.mjs'
 
-
 export async function POST(req: NextRequest) {
   const { html } = await req.json()
 

--- a/app/api/resolve/route.ts
+++ b/app/api/resolve/route.ts
@@ -4,10 +4,14 @@ import { buildResolvePrompt } from '@/lib/prompts.mjs'
 import { getCssAuditor } from '@/lib/css-auditor.mjs'
 
 export async function POST(req: NextRequest) {
-  const { css, decisions }: { css: string; decisions: UserDecisions } = await req.json()
+  const { css, decisions }: { css: string; decisions: UserDecisions } =
+    await req.json()
 
   if (!css || !decisions) {
-    return NextResponse.json({ error: 'CSS and decisions required' }, { status: 400 })
+    return NextResponse.json(
+      { error: 'CSS and decisions required' },
+      { status: 400 }
+    )
   }
 
   try {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,10 +3,15 @@ import './globals.css'
 
 export const metadata: Metadata = {
   title: 'Mint — CSS Audit & Design System Generator',
-  description: 'Audit your legacy CSS, curate the chaos, and generate a clean design system exportable to CSS, Tailwind, SCSS, React, Vue, Svelte, and more.',
+  description:
+    'Audit your legacy CSS, curate the chaos, and generate a clean design system exportable to CSS, Tailwind, SCSS, React, Vue, Svelte, and more.',
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
   return (
     <html lang="en">
       <body>{children}</body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,13 @@ import ExportPanel from '@/components/ExportPanel'
 import CoffeeLoader from '@/components/CoffeeLoader'
 import StepBar from '@/components/StepBar'
 import CliPromo from '@/components/CliPromo'
-import { readAuditCache, writeAuditCache, readResolveCache, writeResolveCache, clearPlaygroundCache } from '@/lib/playground-cache'
+import {
+  readAuditCache,
+  writeAuditCache,
+  readResolveCache,
+  writeResolveCache,
+  clearPlaygroundCache,
+} from '@/lib/playground-cache'
 
 type WizardStep = 'input' | 'audit' | 'tokens'
 type PreviewTab = 'visual' | 'json' | 'export'
@@ -78,7 +84,10 @@ export default function Home() {
   useEffect(() => {
     if (!historyHydrated) return
     try {
-      localStorage.setItem('mint-audit-history', JSON.stringify(auditHistory.slice(0, 10)))
+      localStorage.setItem(
+        'mint-audit-history',
+        JSON.stringify(auditHistory.slice(0, 10))
+      )
     } catch {
       // storage may be full or disabled
     }
@@ -87,7 +96,10 @@ export default function Home() {
   useEffect(() => {
     if (!historyOpen) return
     const handler = (e: MouseEvent) => {
-      if (historyRef.current && !historyRef.current.contains(e.target as Node)) {
+      if (
+        historyRef.current &&
+        !historyRef.current.contains(e.target as Node)
+      ) {
         setHistoryOpen(false)
       }
     }
@@ -204,7 +216,9 @@ export default function Home() {
   if (step === 'input') {
     const hasHistory = auditHistory.length > 0
     return (
-      <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <div
+        style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}
+      >
         {loading && <CoffeeLoader />}
 
         <Hero />
@@ -219,7 +233,11 @@ export default function Home() {
         </main>
 
         {hasHistory && (
-          <RecentAudits history={auditHistory} onRestore={restoreAudit} onClear={clearHistory} />
+          <RecentAudits
+            history={auditHistory}
+            onRestore={restoreAudit}
+            onClear={clearHistory}
+          />
         )}
         {error && <ErrorToast message={error} />}
       </div>
@@ -228,29 +246,81 @@ export default function Home() {
 
   // ── Step: audit ──────────────────────────────────────────────────────────────
   if (step === 'audit' && audit) {
-    const chaosColor = audit.chaosScore <= 3 ? '#4ade80' : audit.chaosScore <= 6 ? '#fbbf24' : '#f87171'
+    const chaosColor =
+      audit.chaosScore <= 3
+        ? '#4ade80'
+        : audit.chaosScore <= 6
+          ? '#fbbf24'
+          : '#f87171'
 
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      <div
+        style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}
+      >
         {loading && <CoffeeLoader />}
 
         <header className="mint-header" style={{ position: 'relative' }}>
           <button
             onClick={reset}
-            style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '5px 10px', borderRadius: 7, border: '1px solid var(--border)', background: 'transparent', color: 'var(--text-muted)', fontSize: 12, fontFamily: 'var(--font)', cursor: 'pointer' }}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '5px 10px',
+              borderRadius: 7,
+              border: '1px solid var(--border)',
+              background: 'transparent',
+              color: 'var(--text-muted)',
+              fontSize: 12,
+              fontFamily: 'var(--font)',
+              cursor: 'pointer',
+            }}
           >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M19 12H5M12 19l-7-7 7-7" /></svg>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M19 12H5M12 19l-7-7 7-7" />
+            </svg>
             New
           </button>
 
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <div style={{ width: 7, height: 7, borderRadius: '50%', background: chaosColor, flexShrink: 0 }} />
-            <span style={{ fontSize: 13, fontWeight: 500 }}>{audit.brand || 'Asset Audit'}</span>
-            <span className="mint-header-detail" style={{ fontSize: 11, color: 'var(--text-faint)' }}>
-              — {audit.colorClusters.length} clusters · chaos {audit.chaosScore}/10
+            <div
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                background: chaosColor,
+                flexShrink: 0,
+              }}
+            />
+            <span style={{ fontSize: 13, fontWeight: 500 }}>
+              {audit.brand || 'Asset Audit'}
+            </span>
+            <span
+              className="mint-header-detail"
+              style={{ fontSize: 11, color: 'var(--text-faint)' }}
+            >
+              — {audit.colorClusters.length} clusters · chaos {audit.chaosScore}
+              /10
             </span>
             {auditFromCache && (
-              <span style={{ fontSize: 10, padding: '1px 6px', borderRadius: 4, background: 'rgba(99,102,241,0.12)', color: '#818cf8', fontWeight: 500, letterSpacing: '0.04em' }}>
+              <span
+                style={{
+                  fontSize: 10,
+                  padding: '1px 6px',
+                  borderRadius: 4,
+                  background: 'rgba(99,102,241,0.12)',
+                  color: '#818cf8',
+                  fontWeight: 500,
+                  letterSpacing: '0.04em',
+                }}
+              >
                 cached
               </span>
             )}
@@ -268,37 +338,61 @@ export default function Home() {
                   padding: '4px 10px',
                   borderRadius: 7,
                   border: `1px solid ${historyOpen ? 'rgba(99,102,241,0.4)' : 'var(--border)'}`,
-                  background: historyOpen ? 'rgba(99,102,241,0.08)' : 'transparent',
+                  background: historyOpen
+                    ? 'rgba(99,102,241,0.08)'
+                    : 'transparent',
                   color: historyOpen ? '#818cf8' : 'var(--text-muted)',
                   fontSize: 11,
                   fontFamily: 'var(--font)',
                   cursor: 'pointer',
                 }}
               >
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                  <circle cx="12" cy="12" r="10" /><path d="M12 6v6l4 2" />
+                <svg
+                  width="11"
+                  height="11"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M12 6v6l4 2" />
                 </svg>
                 History ({auditHistory.length})
-                <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                <svg
+                  width="9"
+                  height="9"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                >
                   <path d={historyOpen ? 'M18 15l-6-6-6 6' : 'M6 9l6 6 6-6'} />
                 </svg>
               </button>
 
               {historyOpen && (
-                <div style={{
-                  position: 'absolute',
-                  top: 34,
-                  left: 0,
-                  zIndex: 100,
-                  minWidth: 240,
-                  borderRadius: 10,
-                  border: '1px solid var(--border)',
-                  background: 'var(--panel)',
-                  boxShadow: '0 8px 24px rgba(0,0,0,0.3)',
-                  overflow: 'hidden',
-                }}>
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 34,
+                    left: 0,
+                    zIndex: 100,
+                    minWidth: 240,
+                    borderRadius: 10,
+                    border: '1px solid var(--border)',
+                    background: 'var(--panel)',
+                    boxShadow: '0 8px 24px rgba(0,0,0,0.3)',
+                    overflow: 'hidden',
+                  }}
+                >
                   {auditHistory.map((entry, idx) => {
-                    const ec = entry.chaosScore <= 3 ? '#4ade80' : entry.chaosScore <= 6 ? '#fbbf24' : '#f87171'
+                    const ec =
+                      entry.chaosScore <= 3
+                        ? '#4ade80'
+                        : entry.chaosScore <= 6
+                          ? '#fbbf24'
+                          : '#f87171'
                     const isCurrent = entry.audit === audit
                     return (
                       <button
@@ -310,25 +404,61 @@ export default function Home() {
                           gap: 10,
                           width: '100%',
                           padding: '10px 14px',
-                          borderBottom: idx < auditHistory.length - 1 ? '1px solid var(--border)' : 'none',
-                          background: isCurrent ? 'rgba(99,102,241,0.07)' : 'transparent',
+                          borderBottom:
+                            idx < auditHistory.length - 1
+                              ? '1px solid var(--border)'
+                              : 'none',
+                          background: isCurrent
+                            ? 'rgba(99,102,241,0.07)'
+                            : 'transparent',
                           border: 'none',
                           cursor: 'pointer',
                           textAlign: 'left',
                           fontFamily: 'var(--font)',
                         }}
                       >
-                        <div style={{ width: 7, height: 7, borderRadius: '50%', background: ec, flexShrink: 0 }} />
+                        <div
+                          style={{
+                            width: 7,
+                            height: 7,
+                            borderRadius: '50%',
+                            background: ec,
+                            flexShrink: 0,
+                          }}
+                        />
                         <div style={{ flex: 1, minWidth: 0 }}>
-                          <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          <div
+                            style={{
+                              fontSize: 12,
+                              fontWeight: 500,
+                              color: 'var(--text)',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
                             {entry.brand}
                           </div>
-                          <div style={{ fontSize: 10, color: 'var(--text-faint)' }}>
-                            chaos {entry.chaosScore}/10 · {entry.audit.colorClusters.length} clusters
+                          <div
+                            style={{ fontSize: 10, color: 'var(--text-faint)' }}
+                          >
+                            chaos {entry.chaosScore}/10 ·{' '}
+                            {entry.audit.colorClusters.length} clusters
                           </div>
                         </div>
                         {isCurrent && (
-                          <span style={{ fontSize: 9, padding: '1px 5px', borderRadius: 4, background: 'rgba(99,102,241,0.15)', color: '#818cf8', fontWeight: 500, letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+                          <span
+                            style={{
+                              fontSize: 9,
+                              padding: '1px 5px',
+                              borderRadius: 4,
+                              background: 'rgba(99,102,241,0.15)',
+                              color: '#818cf8',
+                              fontWeight: 500,
+                              letterSpacing: '0.05em',
+                              textTransform: 'uppercase',
+                            }}
+                          >
                             current
                           </span>
                         )}
@@ -347,11 +477,19 @@ export default function Home() {
 
         <div className="mint-body" style={{ flex: 1, overflowY: 'auto' }}>
           <div style={{ marginBottom: 24 }}>
-            <div style={{ fontSize: 18, fontWeight: 600, letterSpacing: '-0.01em', marginBottom: 6 }}>
+            <div
+              style={{
+                fontSize: 18,
+                fontWeight: 600,
+                letterSpacing: '-0.01em',
+                marginBottom: 6,
+              }}
+            >
               Review the analysis
             </div>
             <div style={{ fontSize: 13, color: 'var(--text-muted)' }}>
-              Claude identified these tokens. Decide what to keep before generating the design system.
+              Claude identified these tokens. Decide what to keep before
+              generating the design system.
             </div>
           </div>
           <AuditView audit={audit} onResolve={handleResolve} />
@@ -371,34 +509,98 @@ export default function Home() {
     ]
 
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      <div
+        style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}
+      >
         <header className="mint-header">
           <button
             onClick={reset}
-            style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '5px 10px', borderRadius: 7, border: '1px solid var(--border)', background: 'transparent', color: 'var(--text-muted)', fontSize: 12, fontFamily: 'var(--font)', cursor: 'pointer' }}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '5px 10px',
+              borderRadius: 7,
+              border: '1px solid var(--border)',
+              background: 'transparent',
+              color: 'var(--text-muted)',
+              fontSize: 12,
+              fontFamily: 'var(--font)',
+              cursor: 'pointer',
+            }}
           >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M19 12H5M12 19l-7-7 7-7" /></svg>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M19 12H5M12 19l-7-7 7-7" />
+            </svg>
             New
           </button>
 
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <div style={{ width: 7, height: 7, borderRadius: '50%', background: '#4ade80', flexShrink: 0 }} />
-            <span style={{ fontSize: 13, fontWeight: 500 }}>{tokens.brand || 'Design System'}</span>
-            <span className="mint-header-detail" style={{ fontSize: 11, color: 'var(--text-faint)' }}>
-              — {tokens.colors.length} colors · {Object.keys(tokens.spacing).length} spacing · {Object.keys(tokens.borderRadius).length} radii
+            <div
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                background: '#4ade80',
+                flexShrink: 0,
+              }}
+            />
+            <span style={{ fontSize: 13, fontWeight: 500 }}>
+              {tokens.brand || 'Design System'}
+            </span>
+            <span
+              className="mint-header-detail"
+              style={{ fontSize: 11, color: 'var(--text-faint)' }}
+            >
+              — {tokens.colors.length} colors ·{' '}
+              {Object.keys(tokens.spacing).length} spacing ·{' '}
+              {Object.keys(tokens.borderRadius).length} radii
             </span>
             {resolveFromCache && (
-              <span style={{ fontSize: 10, padding: '1px 6px', borderRadius: 4, background: 'rgba(99,102,241,0.12)', color: '#818cf8', fontWeight: 500, letterSpacing: '0.04em' }}>
+              <span
+                style={{
+                  fontSize: 10,
+                  padding: '1px 6px',
+                  borderRadius: 4,
+                  background: 'rgba(99,102,241,0.12)',
+                  color: '#818cf8',
+                  fontWeight: 500,
+                  letterSpacing: '0.04em',
+                }}
+              >
                 cached
               </span>
             )}
           </div>
 
-          <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div
+            style={{
+              marginLeft: 'auto',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 16,
+            }}
+          >
             <div className="mint-stepbar-hide">
               <StepBar current={3} />
             </div>
-            <div style={{ display: 'flex', gap: 2, background: 'var(--surface)', borderRadius: 8, padding: 3, border: '1px solid var(--border)' }}>
+            <div
+              style={{
+                display: 'flex',
+                gap: 2,
+                background: 'var(--surface)',
+                borderRadius: 8,
+                padding: 3,
+                border: '1px solid var(--border)',
+              }}
+            >
               {TABS.map(({ key, label }) => (
                 <button
                   key={key}
@@ -407,8 +609,10 @@ export default function Home() {
                     padding: '4px 14px',
                     borderRadius: 6,
                     border: 'none',
-                    background: previewTab === key ? 'var(--surface-2)' : 'transparent',
-                    color: previewTab === key ? 'var(--text)' : 'var(--text-muted)',
+                    background:
+                      previewTab === key ? 'var(--surface-2)' : 'transparent',
+                    color:
+                      previewTab === key ? 'var(--text)' : 'var(--text-muted)',
                     fontSize: 12,
                     fontFamily: 'var(--font)',
                     fontWeight: previewTab === key ? 500 : 400,
@@ -418,7 +622,17 @@ export default function Home() {
                 >
                   {label}
                   {key === 'export' && previewTab !== 'export' && (
-                    <span style={{ position: 'absolute', top: 4, right: 4, width: 5, height: 5, borderRadius: '50%', background: '#818cf8' }} />
+                    <span
+                      style={{
+                        position: 'absolute',
+                        top: 4,
+                        right: 4,
+                        width: 5,
+                        height: 5,
+                        borderRadius: '50%',
+                        background: '#818cf8',
+                      }}
+                    />
                   )}
                 </button>
               ))}
@@ -438,11 +652,19 @@ export default function Home() {
           {previewTab === 'export' && (
             <div style={{ maxWidth: 960, margin: '0 auto' }}>
               <div style={{ marginBottom: 28 }}>
-                <div style={{ fontSize: 18, fontWeight: 600, letterSpacing: '-0.01em', marginBottom: 6 }}>
+                <div
+                  style={{
+                    fontSize: 18,
+                    fontWeight: 600,
+                    letterSpacing: '-0.01em',
+                    marginBottom: 6,
+                  }}
+                >
                   Export tokens
                 </div>
                 <div style={{ fontSize: 13, color: 'var(--text-muted)' }}>
-                  Pick a format and Claude generates a ready-to-use file for your project.
+                  Pick a format and Claude generates a ready-to-use file for
+                  your project.
                 </div>
               </div>
               <ExportPanel tokens={tokens} />
@@ -459,19 +681,65 @@ export default function Home() {
 function Hero() {
   return (
     <div style={{ textAlign: 'center', padding: '48px 16px 24px' }}>
-      <div style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 12, marginBottom: 14 }}>
+      <div
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 12,
+          marginBottom: 14,
+        }}
+      >
         <svg width="34" height="34" viewBox="0 0 28 28" fill="none">
           <rect width="28" height="28" rx="8" fill="rgba(99,102,241,0.18)" />
-          <path d="M8 9h12M8 14h6M8 19h9" stroke="#818cf8" strokeWidth="1.5" strokeLinecap="round" />
-          <circle cx="20" cy="19" r="3.5" fill="rgba(99,102,241,0.3)" stroke="#818cf8" strokeWidth="1" />
-          <path d="M19 19l1 1 2-2" stroke="#818cf8" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" />
+          <path
+            d="M8 9h12M8 14h6M8 19h9"
+            stroke="#818cf8"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+          <circle
+            cx="20"
+            cy="19"
+            r="3.5"
+            fill="rgba(99,102,241,0.3)"
+            stroke="#818cf8"
+            strokeWidth="1"
+          />
+          <path
+            d="M19 19l1 1 2-2"
+            stroke="#818cf8"
+            strokeWidth="1"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         </svg>
-        <span style={{ fontSize: 26, fontWeight: 600, letterSpacing: '-0.025em' }}>Mint</span>
+        <span
+          style={{ fontSize: 26, fontWeight: 600, letterSpacing: '-0.025em' }}
+        >
+          Mint
+        </span>
       </div>
-      <p style={{ fontSize: 14, color: 'var(--text-muted)', maxWidth: 520, lineHeight: 1.6, margin: '0 auto' }}>
+      <p
+        style={{
+          fontSize: 14,
+          color: 'var(--text-muted)',
+          maxWidth: 520,
+          lineHeight: 1.6,
+          margin: '0 auto',
+        }}
+      >
         Audit your legacy CSS, curate the chaos, and ship a clean design system.
       </p>
-      <p style={{ fontSize: 12, color: 'var(--text-faint)', marginTop: 10, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+      <p
+        style={{
+          fontSize: 12,
+          color: 'var(--text-faint)',
+          marginTop: 10,
+          letterSpacing: '0.04em',
+          textTransform: 'uppercase',
+        }}
+      >
         Available in two flavors — pick yours
       </p>
     </div>
@@ -484,13 +752,27 @@ interface FlavorSwitcherProps {
 }
 
 function FlavorSwitcher({ flavor, onChange }: FlavorSwitcherProps) {
-  const options: { key: Flavor; title: string; subtitle: string; icon: React.ReactNode }[] = [
+  const options: {
+    key: Flavor
+    title: string
+    subtitle: string
+    icon: React.ReactNode
+  }[] = [
     {
       key: 'playground',
       title: 'Playground',
       subtitle: 'Try Mint right in your browser — paste a snippet & go.',
       icon: (
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.7"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <rect x="3" y="4" width="18" height="14" rx="2" />
           <path d="M2 20h20" />
           <path d="M9 9l-2 2 2 2M13 9l2 2-2 2" />
@@ -502,7 +784,16 @@ function FlavorSwitcher({ flavor, onChange }: FlavorSwitcherProps) {
       title: 'CLI',
       subtitle: 'Run Mint over a whole repo from your terminal — CI-ready.',
       icon: (
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.7"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <polyline points="4 17 10 11 4 5" />
           <line x1="12" y1="19" x2="20" y2="19" />
         </svg>
@@ -515,7 +806,12 @@ function FlavorSwitcher({ flavor, onChange }: FlavorSwitcherProps) {
       role="tablist"
       aria-label="Choose flavor"
       className="mint-grid-2"
-      style={{ maxWidth: 720, width: '100%', margin: '0 auto', padding: '8px 16px 0' }}
+      style={{
+        maxWidth: 720,
+        width: '100%',
+        margin: '0 auto',
+        padding: '8px 16px 0',
+      }}
     >
       {options.map((opt) => {
         const active = flavor === opt.key
@@ -541,29 +837,58 @@ function FlavorSwitcher({ flavor, onChange }: FlavorSwitcherProps) {
               boxShadow: active ? '0 0 0 4px rgba(99,102,241,0.10)' : 'none',
             }}
           >
-            <span style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 36,
-              height: 36,
-              borderRadius: 9,
-              background: active ? 'rgba(99,102,241,0.20)' : 'var(--surface)',
-              color: active ? '#a5b0ff' : 'var(--text-muted)',
-              flexShrink: 0,
-            }}>
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 36,
+                height: 36,
+                borderRadius: 9,
+                background: active ? 'rgba(99,102,241,0.20)' : 'var(--surface)',
+                color: active ? '#a5b0ff' : 'var(--text-muted)',
+                flexShrink: 0,
+              }}
+            >
               {opt.icon}
             </span>
             <span style={{ flex: 1, minWidth: 0 }}>
-              <span style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 3 }}>
-                <span style={{ fontSize: 14, fontWeight: 600 }}>{opt.title}</span>
+              <span
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  marginBottom: 3,
+                }}
+              >
+                <span style={{ fontSize: 14, fontWeight: 600 }}>
+                  {opt.title}
+                </span>
                 {active && (
-                  <span style={{ fontSize: 9, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', padding: '2px 6px', borderRadius: 4, background: 'rgba(129,140,248,0.20)', color: 'var(--accent-strong)' }}>
+                  <span
+                    style={{
+                      fontSize: 9,
+                      fontWeight: 600,
+                      letterSpacing: '0.08em',
+                      textTransform: 'uppercase',
+                      padding: '2px 6px',
+                      borderRadius: 4,
+                      background: 'rgba(129,140,248,0.20)',
+                      color: 'var(--accent-strong)',
+                    }}
+                  >
                     Selected
                   </span>
                 )}
               </span>
-              <span style={{ display: 'block', fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+              <span
+                style={{
+                  display: 'block',
+                  fontSize: 12,
+                  color: 'var(--text-muted)',
+                  lineHeight: 1.5,
+                }}
+              >
                 {opt.subtitle}
               </span>
             </span>
@@ -577,9 +902,24 @@ function FlavorSwitcher({ flavor, onChange }: FlavorSwitcherProps) {
 function CliFlavorPanel() {
   return (
     <div style={{ padding: '24px 0 0' }}>
-      <div style={{ maxWidth: 720, margin: '0 auto 18px', padding: '0 16px', textAlign: 'center' }}>
-        <p style={{ fontSize: 13, color: 'var(--text-muted)', lineHeight: 1.6, margin: 0 }}>
-          The full audit + export pipeline ships as a CLI you can drop into any project or CI job.
+      <div
+        style={{
+          maxWidth: 720,
+          margin: '0 auto 18px',
+          padding: '0 16px',
+          textAlign: 'center',
+        }}
+      >
+        <p
+          style={{
+            fontSize: 13,
+            color: 'var(--text-muted)',
+            lineHeight: 1.6,
+            margin: 0,
+          }}
+        >
+          The full audit + export pipeline ships as a CLI you can drop into any
+          project or CI job.
         </p>
       </div>
 
@@ -609,31 +949,109 @@ function PreReleaseNotice() {
           overflow: 'hidden',
         }}
       >
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10, padding: '12px 16px 8px' }}>
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 2 }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 10,
+            padding: '12px 16px 8px',
+          }}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#fbbf24"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{ flexShrink: 0, marginTop: 2 }}
+          >
             <path d="M12 9v4M12 17h.01" />
             <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
           </svg>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 13, fontWeight: 600, color: '#fbbf24', marginBottom: 3 }}>
+            <div
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: '#fbbf24',
+                marginBottom: 3,
+              }}
+            >
               Pre-release — mint-ds isn&apos;t on npm yet
             </div>
-            <div style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.55 }}>
-              The <code style={{ fontFamily: 'var(--mono)', fontSize: 11.5, padding: '1px 5px', borderRadius: 4, background: 'rgba(255,255,255,0.06)' }}>npx mint-ds</code> commands below won&apos;t resolve until we publish. In the meantime, run it from a clone or use <code style={{ fontFamily: 'var(--mono)', fontSize: 11.5, padding: '1px 5px', borderRadius: 4, background: 'rgba(255,255,255,0.06)' }}>npm link</code>.
+            <div
+              style={{
+                fontSize: 12,
+                color: 'var(--text-muted)',
+                lineHeight: 1.55,
+              }}
+            >
+              The{' '}
+              <code
+                style={{
+                  fontFamily: 'var(--mono)',
+                  fontSize: 11.5,
+                  padding: '1px 5px',
+                  borderRadius: 4,
+                  background: 'rgba(255,255,255,0.06)',
+                }}
+              >
+                npx mint-ds
+              </code>{' '}
+              commands below won&apos;t resolve until we publish. In the
+              meantime, run it from a clone or use{' '}
+              <code
+                style={{
+                  fontFamily: 'var(--mono)',
+                  fontSize: 11.5,
+                  padding: '1px 5px',
+                  borderRadius: 4,
+                  background: 'rgba(255,255,255,0.06)',
+                }}
+              >
+                npm link
+              </code>
+              .
             </div>
           </div>
         </div>
 
-        <pre style={{ margin: 0, padding: '4px 16px 14px', fontFamily: 'var(--mono)', fontSize: 11.5, lineHeight: 1.8, color: 'var(--text-muted)', background: 'transparent', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-          <span style={{ color: 'var(--text-faint)' }}># Clone &amp; run from source</span>{'\n'}
-          <span style={{ color: 'var(--text-faint)' }}>$</span> git clone https://github.com/nujovich/mint.git &amp;&amp; cd mint{'\n'}
-          <span style={{ color: 'var(--text-faint)' }}>$</span> export ANTHROPIC_API_KEY=sk-ant-...{'\n'}
-          <span style={{ color: 'var(--text-faint)' }}>$</span> node bin/mint-ds.mjs audit ./examples/frankenstein{'\n'}
-          <span style={{ color: 'var(--text-faint)' }}>$</span> node bin/mint-ds.mjs export --target tailwind{'\n'}
+        <pre
+          style={{
+            margin: 0,
+            padding: '4px 16px 14px',
+            fontFamily: 'var(--mono)',
+            fontSize: 11.5,
+            lineHeight: 1.8,
+            color: 'var(--text-muted)',
+            background: 'transparent',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          <span style={{ color: 'var(--text-faint)' }}>
+            # Clone &amp; run from source
+          </span>
           {'\n'}
-          <span style={{ color: 'var(--text-faint)' }}># Or expose `mint-ds` globally with npm link</span>{'\n'}
+          <span style={{ color: 'var(--text-faint)' }}>$</span> git clone
+          https://github.com/nujovich/mint.git &amp;&amp; cd mint{'\n'}
+          <span style={{ color: 'var(--text-faint)' }}>$</span> export
+          ANTHROPIC_API_KEY=sk-ant-...{'\n'}
+          <span style={{ color: 'var(--text-faint)' }}>$</span> node
+          bin/mint-ds.mjs audit ./examples/frankenstein{'\n'}
+          <span style={{ color: 'var(--text-faint)' }}>$</span> node
+          bin/mint-ds.mjs export --target tailwind{'\n'}
+          {'\n'}
+          <span style={{ color: 'var(--text-faint)' }}>
+            # Or expose `mint-ds` globally with npm link
+          </span>
+          {'\n'}
           <span style={{ color: 'var(--text-faint)' }}>$</span> npm link{'\n'}
-          <span style={{ color: 'var(--text-faint)' }}>$</span> mint-ds audit ./examples/frankenstein
+          <span style={{ color: 'var(--text-faint)' }}>$</span> mint-ds audit
+          ./examples/frankenstein
         </pre>
       </div>
     </section>
@@ -642,7 +1060,21 @@ function PreReleaseNotice() {
 
 function ErrorToast({ message }: { message: string }) {
   return (
-    <div style={{ position: 'fixed', bottom: 20, left: '50%', transform: 'translateX(-50%)', padding: '10px 18px', borderRadius: 8, background: 'rgba(239,68,68,0.12)', border: '1px solid rgba(239,68,68,0.25)', color: '#fca5a5', fontSize: 12, zIndex: 1000 }}>
+    <div
+      style={{
+        position: 'fixed',
+        bottom: 20,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        padding: '10px 18px',
+        borderRadius: 8,
+        background: 'rgba(239,68,68,0.12)',
+        border: '1px solid rgba(239,68,68,0.25)',
+        color: '#fca5a5',
+        fontSize: 12,
+        zIndex: 1000,
+      }}
+    >
       {message}
     </div>
   )
@@ -664,8 +1096,24 @@ function RecentAudits({ history, onRestore, onClear }: RecentAuditsProps) {
         padding: '0 16px 56px',
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 12 }}>
-        <h2 style={{ fontSize: 12, fontWeight: 600, letterSpacing: '0.07em', color: 'var(--text-faint)', textTransform: 'uppercase', margin: 0 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          marginBottom: 12,
+        }}
+      >
+        <h2
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            letterSpacing: '0.07em',
+            color: 'var(--text-faint)',
+            textTransform: 'uppercase',
+            margin: 0,
+          }}
+        >
           Recent audits
         </h2>
         <button
@@ -684,9 +1132,23 @@ function RecentAudits({ history, onRestore, onClear }: RecentAuditsProps) {
         </button>
       </div>
 
-      <ul style={{ listStyle: 'none', display: 'grid', gap: 8, gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))', padding: 0, margin: 0 }}>
+      <ul
+        style={{
+          listStyle: 'none',
+          display: 'grid',
+          gap: 8,
+          gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+          padding: 0,
+          margin: 0,
+        }}
+      >
         {history.map((entry) => {
-          const ec = entry.chaosScore <= 3 ? '#5ee29a' : entry.chaosScore <= 6 ? '#fcd34d' : '#fca5a5'
+          const ec =
+            entry.chaosScore <= 3
+              ? '#5ee29a'
+              : entry.chaosScore <= 6
+                ? '#fcd34d'
+                : '#fca5a5'
           return (
             <li key={entry.id}>
               <button
@@ -706,19 +1168,49 @@ function RecentAudits({ history, onRestore, onClear }: RecentAuditsProps) {
                   fontFamily: 'var(--font)',
                   transition: 'border-color 0.15s, transform 0.15s',
                 }}
-                onMouseEnter={(e) => { e.currentTarget.style.borderColor = 'var(--border-hover)' }}
-                onMouseLeave={(e) => { e.currentTarget.style.borderColor = 'var(--border)' }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.borderColor = 'var(--border-hover)'
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.borderColor = 'var(--border)'
+                }}
               >
-                <div style={{ width: 8, height: 8, borderRadius: '50%', background: ec, flexShrink: 0 }} />
+                <div
+                  style={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    background: ec,
+                    flexShrink: 0,
+                  }}
+                />
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 500,
+                      color: 'var(--text)',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
                     {entry.brand}
                   </div>
                   <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>
-                    chaos {entry.chaosScore}/10 · {entry.audit.colorClusters.length} clusters
+                    chaos {entry.chaosScore}/10 ·{' '}
+                    {entry.audit.colorClusters.length} clusters
                   </div>
                 </div>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ color: 'var(--text-faint)', flexShrink: 0 }}>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  style={{ color: 'var(--text-faint)', flexShrink: 0 }}
+                >
                   <path d="M9 18l6-6-6-6" />
                 </svg>
               </button>

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -18,10 +18,16 @@ import {
 } from '../lib/prompts.mjs'
 import { getCssAuditor } from '../lib/css-auditor.mjs'
 
-
 const require = createRequire(import.meta.url)
 const { version: VERSION } = require('../package.json')
-const SOURCE_EXTS = new Set(['.css', '.scss', '.sass', '.less', '.html', '.htm'])
+const SOURCE_EXTS = new Set([
+  '.css',
+  '.scss',
+  '.sass',
+  '.less',
+  '.html',
+  '.htm',
+])
 const DEFAULT_TOKENS_FILE = 'mint-ds.tokens.json'
 const CACHE_FILE = 'mint-ds.cache.json'
 const MAX_CSS_CHARS = 120_000
@@ -52,14 +58,25 @@ const styles = process.stdout.isTTY
       red: (s) => `\x1b[31m${s}\x1b[0m`,
     }
   : {
-      dim: (s) => s, bold: (s) => s, cyan: (s) => s, green: (s) => s, yellow: (s) => s, red: (s) => s,
+      dim: (s) => s,
+      bold: (s) => s,
+      cyan: (s) => s,
+      green: (s) => s,
+      yellow: (s) => s,
+      red: (s) => s,
     }
 
-function log(...args) { process.stderr.write(args.join(' ') + '\n') }
-function die(msg, code = 1) { log(styles.red('✗ ' + msg)); process.exit(code) }
+function log(...args) {
+  process.stderr.write(args.join(' ') + '\n')
+}
+function die(msg, code = 1) {
+  log(styles.red('✗ ' + msg))
+  process.exit(code)
+}
 
 function printHelp() {
-  process.stdout.write(`${styles.bold('mint-ds')} — CSS audit & design system generator (v${VERSION})
+  process.stdout
+    .write(`${styles.bold('mint-ds')} — CSS audit & design system generator (v${VERSION})
 
 ${styles.bold('USAGE')}
   npx mint-ds <command> [options]
@@ -130,11 +147,19 @@ async function* walk(dir) {
     throw err
   }
   for (const entry of entries) {
-    if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'dist') continue
+    if (
+      entry.name.startsWith('.') ||
+      entry.name === 'node_modules' ||
+      entry.name === 'dist'
+    )
+      continue
     const full = path.join(dir, entry.name)
     if (entry.isDirectory()) {
       yield* walk(full)
-    } else if (entry.isFile() && SOURCE_EXTS.has(path.extname(entry.name).toLowerCase())) {
+    } else if (
+      entry.isFile() &&
+      SOURCE_EXTS.has(path.extname(entry.name).toLowerCase())
+    ) {
       yield full
     }
   }
@@ -148,7 +173,9 @@ async function collectSources(target) {
   const files = []
   if (stat.isFile()) {
     if (!SOURCE_EXTS.has(path.extname(root).toLowerCase())) {
-      die(`Unsupported file type: ${target} (expected .css/.scss/.sass/.less/.html)`)
+      die(
+        `Unsupported file type: ${target} (expected .css/.scss/.sass/.less/.html)`
+      )
     }
     files.push(root)
   } else {
@@ -164,7 +191,11 @@ async function collectSources(target) {
     const body = await fs.readFile(file, 'utf8')
     const chunk = `/* === ${rel} === */\n${body}\n\n`
     if (combined.length + chunk.length > MAX_CSS_CHARS) {
-      log(styles.yellow(`! Reached ${MAX_CSS_CHARS} char budget — skipping remaining files (${files.length - files.indexOf(file)} left)`))
+      log(
+        styles.yellow(
+          `! Reached ${MAX_CSS_CHARS} char budget — skipping remaining files (${files.length - files.indexOf(file)} left)`
+        )
+      )
       break
     }
     combined += chunk
@@ -180,7 +211,9 @@ function defaultDecisions(audit) {
       value: c.representative,
       include: true,
     })),
-    fonts: (audit.fonts || []).filter((f) => !f.isSystemFont).map((f) => f.family),
+    fonts: (audit.fonts || [])
+      .filter((f) => !f.isSystemFont)
+      .map((f) => f.family),
     spacingScale: audit.spacing?.suggestedScale || {},
     lineHeights: audit.lineHeights?.suggestedScale || {},
   }
@@ -204,7 +237,11 @@ async function cmdAudit(argv) {
 
   log(styles.cyan('→') + ` Reading sources from ${styles.bold(target)}…`)
   const { files, css } = await collectSources(target)
-  log(styles.dim(`  ${files.length} file(s), ${(css.length / 1000).toFixed(1)}k chars`))
+  log(
+    styles.dim(
+      `  ${files.length} file(s), ${(css.length / 1000).toFixed(1)}k chars`
+    )
+  )
 
   const processedCss = preprocessCss(css)
   const cssHash = hashCss(processedCss)
@@ -213,9 +250,16 @@ async function cmdAudit(argv) {
     const cache = await readCache()
     if (cache[cssHash]) {
       const { tokens } = cache[cssHash]
-      await fs.writeFile(outFile, JSON.stringify(tokens, null, 2) + '\n', 'utf8')
+      await fs.writeFile(
+        outFile,
+        JSON.stringify(tokens, null, 2) + '\n',
+        'utf8'
+      )
       log(styles.dim(`  cache hit (${cssHash.slice(0, 8)}…)`))
-      log(styles.green('✓') + ` Tokens written to ${styles.bold(outFile)} (from cache)`)
+      log(
+        styles.green('✓') +
+          ` Tokens written to ${styles.bold(outFile)} (from cache)`
+      )
       log(styles.dim(`  next: npx mint-ds export --target tailwind`))
       return
     }
@@ -226,14 +270,20 @@ async function cmdAudit(argv) {
   const audit = await cssAuditor.audit(buildAuditPrompt(css))
 
   if (reportFile) {
-    await fs.writeFile(reportFile, JSON.stringify(audit, null, 2) + '\n', 'utf8')
+    await fs.writeFile(
+      reportFile,
+      JSON.stringify(audit, null, 2) + '\n',
+      'utf8'
+    )
     log(styles.dim(`  audit report → ${reportFile}`))
   }
 
   log(styles.cyan('→') + ' Processing results...')
   let tokens
   try {
-    tokens = await cssAuditor.parse(buildResolvePrompt(css, defaultDecisions(audit)))
+    tokens = await cssAuditor.parse(
+      buildResolvePrompt(css, defaultDecisions(audit))
+    )
   } catch {
     die('Error parsing response')
   }
@@ -248,9 +298,16 @@ async function cmdAudit(argv) {
 
   if (!quiet) {
     log('')
-    log(styles.bold(audit.brand || 'Audit') + styles.dim(`  ·  chaos ${chaosBadge(audit.chaosScore)}`))
+    log(
+      styles.bold(audit.brand || 'Audit') +
+        styles.dim(`  ·  chaos ${chaosBadge(audit.chaosScore)}`)
+    )
     if (audit.summary) log(styles.dim('  ' + audit.summary))
-    log(styles.dim(`  ${audit.colorClusters?.length ?? 0} clusters · ${audit.fonts?.length ?? 0} fonts · ${audit.spacing?.found?.length ?? 0} spacing values`))
+    log(
+      styles.dim(
+        `  ${audit.colorClusters?.length ?? 0} clusters · ${audit.fonts?.length ?? 0} fonts · ${audit.spacing?.found?.length ?? 0} spacing values`
+      )
+    )
     log('')
   }
   log(styles.green('✓') + ` Tokens written to ${styles.bold(outFile)}`)
@@ -270,7 +327,11 @@ async function cmdCache(argv) {
     } else {
       log(styles.bold(`${entries.length} cached audit(s):`))
       for (const hash of entries) {
-        log(styles.dim(`  ${hash.slice(0, 8)}…  saved ${cache[hash].savedAt ?? 'unknown'}`))
+        log(
+          styles.dim(
+            `  ${hash.slice(0, 8)}…  saved ${cache[hash].savedAt ?? 'unknown'}`
+          )
+        )
       }
     }
   }
@@ -279,17 +340,22 @@ async function cmdCache(argv) {
 async function cmdExport(argv) {
   const { flags } = parseFlags(argv)
   const targetInput = flags.target
-  if (!targetInput || targetInput === true) die('Usage: mint-ds export --target <name>  (e.g. tailwind, react, css)')
+  if (!targetInput || targetInput === true)
+    die('Usage: mint-ds export --target <name>  (e.g. tailwind, react, css)')
 
   const target = resolveTarget(String(targetInput))
   if (!target) {
-    die(`Unknown --target "${targetInput}". Try one of: ${ADVERTISED_TARGETS.join(', ')}`)
+    die(
+      `Unknown --target "${targetInput}". Try one of: ${ADVERTISED_TARGETS.join(', ')}`
+    )
   }
 
   const tokensPath = String(flags.tokens || DEFAULT_TOKENS_FILE)
   const tokensRaw = await fs.readFile(tokensPath, 'utf8').catch(() => null)
   if (tokensRaw === null) {
-    die(`Tokens file not found: ${tokensPath}\n  Run "mint-ds audit <dir>" first, or pass --tokens <file>.`)
+    die(
+      `Tokens file not found: ${tokensPath}\n  Run "mint-ds audit <dir>" first, or pass --tokens <file>.`
+    )
   }
 
   let tokens
@@ -309,11 +375,12 @@ async function cmdExport(argv) {
   }
 
   const meta = EXPORT_OUTPUT[target]
-  const outFile = flags.out
-    ? String(flags.out)
-    : `${meta.filename}.${meta.ext}`
+  const outFile = flags.out ? String(flags.out) : `${meta.filename}.${meta.ext}`
   await fs.writeFile(outFile, code + '\n', 'utf8')
-  log(styles.green('✓') + ` Wrote ${styles.bold(outFile)} (${(code.length / 1000).toFixed(1)}k chars)`)
+  log(
+    styles.green('✓') +
+      ` Wrote ${styles.bold(outFile)} (${(code.length / 1000).toFixed(1)}k chars)`
+  )
 }
 
 async function main() {
@@ -332,7 +399,10 @@ async function main() {
     if (cmd === 'audit') await cmdAudit(rest)
     else if (cmd === 'export') await cmdExport(rest)
     else if (cmd === 'cache') await cmdCache(rest)
-    else { printHelp(); die(`Unknown command: ${cmd}`) }
+    else {
+      printHelp()
+      die(`Unknown command: ${cmd}`)
+    }
   } catch (err) {
     die(err && err.message ? err.message : String(err))
   }

--- a/components/AuditView.tsx
+++ b/components/AuditView.tsx
@@ -8,14 +8,20 @@ interface Props {
   onResolve: (decisions: UserDecisions) => void
 }
 
-function nearestScaleValue(pxStr: string, scale: Record<string, string>): string | null {
+function nearestScaleValue(
+  pxStr: string,
+  scale: Record<string, string>
+): string | null {
   const val = parseInt(pxStr)
   if (isNaN(val)) return null
   let best: string | null = null
   let bestDiff = Infinity
   for (const sv of Object.values(scale)) {
     const diff = Math.abs(val - parseInt(sv))
-    if (diff < bestDiff) { bestDiff = diff; best = sv }
+    if (diff < bestDiff) {
+      bestDiff = diff
+      best = sv
+    }
   }
   return best
 }
@@ -38,48 +44,126 @@ export default function AuditView({ audit, onResolve }: Props) {
   const lineHeights = audit.lineHeights?.suggestedScale ?? {}
 
   const chaosColor =
-    audit.chaosScore <= 3 ? '#4ade80' : audit.chaosScore <= 6 ? '#fbbf24' : '#f87171'
+    audit.chaosScore <= 3
+      ? '#4ade80'
+      : audit.chaosScore <= 6
+        ? '#fbbf24'
+        : '#f87171'
 
   const toggleFont = (family: string) => {
     setFontDecisions((prev) =>
-      prev.includes(family) ? prev.filter((f) => f !== family) : [...prev, family]
+      prev.includes(family)
+        ? prev.filter((f) => f !== family)
+        : [...prev, family]
     )
   }
 
   const handleResolve = () => {
-    onResolve({ colors: colorDecisions, fonts: fontDecisions, spacingScale, lineHeights })
+    onResolve({
+      colors: colorDecisions,
+      fonts: fontDecisions,
+      spacingScale,
+      lineHeights,
+    })
   }
 
   const includedColors = colorDecisions.filter((d) => d.include).length
 
   return (
-    <div style={{ maxWidth: 860, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 24, paddingBottom: 60 }}>
-
+    <div
+      style={{
+        maxWidth: 860,
+        margin: '0 auto',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 24,
+        paddingBottom: 60,
+      }}
+    >
       {/* Chaos card */}
-      <div style={{ padding: '20px 24px', borderRadius: 12, border: '1px solid var(--border)', background: 'var(--panel)' }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+      <div
+        style={{
+          padding: '20px 24px',
+          borderRadius: 12,
+          border: '1px solid var(--border)',
+          background: 'var(--panel)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginBottom: 12,
+          }}
+        >
           <div style={{ fontSize: 13, fontWeight: 500 }}>Chaos Score</div>
-          <div style={{ fontSize: 22, fontWeight: 700, color: chaosColor, fontVariantNumeric: 'tabular-nums' }}>
-            {audit.chaosScore}<span style={{ fontSize: 14, fontWeight: 400, color: 'var(--text-faint)' }}>/10</span>
+          <div
+            style={{
+              fontSize: 22,
+              fontWeight: 700,
+              color: chaosColor,
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            {audit.chaosScore}
+            <span
+              style={{
+                fontSize: 14,
+                fontWeight: 400,
+                color: 'var(--text-faint)',
+              }}
+            >
+              /10
+            </span>
           </div>
         </div>
-        <div style={{ height: 6, borderRadius: 99, background: 'var(--surface-2)', overflow: 'hidden', marginBottom: 12 }}>
-          <div style={{ height: '100%', width: `${audit.chaosScore * 10}%`, background: chaosColor, borderRadius: 99, transition: 'width 0.6s ease' }} />
+        <div
+          style={{
+            height: 6,
+            borderRadius: 99,
+            background: 'var(--surface-2)',
+            overflow: 'hidden',
+            marginBottom: 12,
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: `${audit.chaosScore * 10}%`,
+              background: chaosColor,
+              borderRadius: 99,
+              transition: 'width 0.6s ease',
+            }}
+          />
         </div>
-        <p style={{ fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.6, margin: 0 }}>{audit.summary}</p>
+        <p
+          style={{
+            fontSize: 12,
+            color: 'var(--text-muted)',
+            lineHeight: 1.6,
+            margin: 0,
+          }}
+        >
+          {audit.summary}
+        </p>
       </div>
 
       {/* Color clusters */}
       <section>
         <SectionLabel>
-          Colors — {audit.colorClusters.length} clusters · {includedColors} included
+          Colors — {audit.colorClusters.length} clusters · {includedColors}{' '}
+          included
         </SectionLabel>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           {audit.colorClusters.map((cluster, i) => {
             const decision = colorDecisions[i]
             const included = decision.include
 
-            const dimmedStyle = { opacity: included ? 1 : 0.5, transition: 'opacity 0.2s' }
+            const dimmedStyle = {
+              opacity: included ? 1 : 0.5,
+              transition: 'opacity 0.2s',
+            }
 
             return (
               <div
@@ -94,13 +178,23 @@ export default function AuditView({ audit, onResolve }: Props) {
                 }}
               >
                 {/* Swatches */}
-                <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', flex: '0 0 auto', ...dimmedStyle }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    gap: 4,
+                    flexWrap: 'wrap',
+                    flex: '0 0 auto',
+                    ...dimmedStyle,
+                  }}
+                >
                   {cluster.samples.slice(0, 6).map((s) => (
                     <button
                       key={s.hex}
                       onClick={() =>
                         setColorDecisions((prev) =>
-                          prev.map((d, idx) => idx === i ? { ...d, value: s.hex } : d)
+                          prev.map((d, idx) =>
+                            idx === i ? { ...d, value: s.hex } : d
+                          )
                         )
                       }
                       title={`${s.hex} · used ${s.usageCount}×`}
@@ -109,8 +203,14 @@ export default function AuditView({ audit, onResolve }: Props) {
                         height: 32,
                         borderRadius: 6,
                         background: s.hex,
-                        border: decision.value === s.hex ? '2px solid #fff' : '2px solid transparent',
-                        boxShadow: decision.value === s.hex ? '0 0 0 2px rgba(99,102,241,0.7)' : '0 0 0 1px rgba(0,0,0,0.2)',
+                        border:
+                          decision.value === s.hex
+                            ? '2px solid #fff'
+                            : '2px solid transparent',
+                        boxShadow:
+                          decision.value === s.hex
+                            ? '0 0 0 2px rgba(99,102,241,0.7)'
+                            : '0 0 0 1px rgba(0,0,0,0.2)',
                         cursor: 'pointer',
                         flexShrink: 0,
                       }}
@@ -120,12 +220,21 @@ export default function AuditView({ audit, onResolve }: Props) {
 
                 {/* Name + contexts */}
                 <div style={{ flex: 1, minWidth: 0, ...dimmedStyle }}>
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      marginBottom: 6,
+                    }}
+                  >
                     <input
                       value={decision.name}
                       onChange={(e) =>
                         setColorDecisions((prev) =>
-                          prev.map((d, idx) => idx === i ? { ...d, name: e.target.value } : d)
+                          prev.map((d, idx) =>
+                            idx === i ? { ...d, name: e.target.value } : d
+                          )
                         )
                       }
                       style={{
@@ -140,27 +249,67 @@ export default function AuditView({ audit, onResolve }: Props) {
                         width: 130,
                       }}
                     />
-                    <span style={{ fontSize: 11, color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>
+                    <span
+                      style={{
+                        fontSize: 11,
+                        color: 'var(--text-faint)',
+                        fontFamily: 'var(--mono)',
+                      }}
+                    >
                       {decision.value}
                     </span>
                   </div>
                   <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
-                    {cluster.samples.flatMap((s) => s.contexts).slice(0, 4).map((ctx, ci) => (
-                      <span key={ci} style={{ fontSize: 10, padding: '1px 6px', borderRadius: 4, background: 'var(--surface-2)', color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>
-                        {ctx}
-                      </span>
-                    ))}
+                    {cluster.samples
+                      .flatMap((s) => s.contexts)
+                      .slice(0, 4)
+                      .map((ctx, ci) => (
+                        <span
+                          key={ci}
+                          style={{
+                            fontSize: 10,
+                            padding: '1px 6px',
+                            borderRadius: 4,
+                            background: 'var(--surface-2)',
+                            color: 'var(--text-faint)',
+                            fontFamily: 'var(--mono)',
+                          }}
+                        >
+                          {ctx}
+                        </span>
+                      ))}
                   </div>
                 </div>
 
                 {/* Status icon — shows current state */}
-                <div style={{ display: 'flex', flexShrink: 0, alignItems: 'center', paddingTop: 2 }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexShrink: 0,
+                    alignItems: 'center',
+                    paddingTop: 2,
+                  }}
+                >
                   {included ? (
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#4ade80" strokeWidth="2.5">
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="#4ade80"
+                      strokeWidth="2.5"
+                    >
                       <path d="M20 6L9 17l-5-5" />
                     </svg>
                   ) : (
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f87171" strokeWidth="2.5">
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="#f87171"
+                      strokeWidth="2.5"
+                    >
                       <path d="M18 6L6 18M6 6l12 12" />
                     </svg>
                   )}
@@ -170,7 +319,9 @@ export default function AuditView({ audit, onResolve }: Props) {
                 <button
                   onClick={() =>
                     setColorDecisions((prev) =>
-                      prev.map((d, idx) => idx === i ? { ...d, include: !d.include } : d)
+                      prev.map((d, idx) =>
+                        idx === i ? { ...d, include: !d.include } : d
+                      )
                     )
                   }
                   style={{
@@ -200,7 +351,10 @@ export default function AuditView({ audit, onResolve }: Props) {
 
       {/* Typography */}
       <section>
-        <SectionLabel>Typography — {audit.fonts.length} {audit.fonts.length === 1 ? 'family' : 'families'}</SectionLabel>
+        <SectionLabel>
+          Typography — {audit.fonts.length}{' '}
+          {audit.fonts.length === 1 ? 'family' : 'families'}
+        </SectionLabel>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           {audit.fonts.map((font) => {
             const isChecked = fontDecisions.includes(font.family)
@@ -229,18 +383,43 @@ export default function AuditView({ audit, onResolve }: Props) {
                   style={{ accentColor: '#6366f1', width: 14, height: 14 }}
                 />
                 <div style={{ flex: 1 }}>
-                  <span style={{ fontSize: 13, fontWeight: 500, fontFamily: `"${font.family}", sans-serif` }}>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 500,
+                      fontFamily: `"${font.family}", sans-serif`,
+                    }}
+                  >
                     {font.family}
                   </span>
                   {isSystem && (
-                    <span style={{ marginLeft: 8, fontSize: 10, color: 'var(--text-faint)', padding: '1px 5px', borderRadius: 4, background: 'var(--surface-2)' }}>
+                    <span
+                      style={{
+                        marginLeft: 8,
+                        fontSize: 10,
+                        color: 'var(--text-faint)',
+                        padding: '1px 5px',
+                        borderRadius: 4,
+                        background: 'var(--surface-2)',
+                      }}
+                    >
                       system
                     </span>
                   )}
                 </div>
                 <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
                   {font.usages.slice(0, 3).map((u, i) => (
-                    <span key={i} style={{ fontSize: 10, padding: '1px 6px', borderRadius: 4, background: 'var(--surface-2)', color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>
+                    <span
+                      key={i}
+                      style={{
+                        fontSize: 10,
+                        padding: '1px 6px',
+                        borderRadius: 4,
+                        background: 'var(--surface-2)',
+                        color: 'var(--text-faint)',
+                        fontFamily: 'var(--mono)',
+                      }}
+                    >
                       {u}
                     </span>
                   ))}
@@ -254,44 +433,67 @@ export default function AuditView({ audit, onResolve }: Props) {
       {/* Spacing */}
       <section>
         <SectionLabel>
-          Spacing — {audit.spacing.found.length} {audit.spacing.found.length === 1 ? 'value' : 'values'} · {audit.spacing.nonScaleValues.length} off-scale
+          Spacing — {audit.spacing.found.length}{' '}
+          {audit.spacing.found.length === 1 ? 'value' : 'values'} ·{' '}
+          {audit.spacing.nonScaleValues.length} off-scale
         </SectionLabel>
 
         {/* 4px grid explanation */}
-        <div style={{
-          padding: '10px 14px',
-          borderRadius: 8,
-          background: 'rgba(251,191,36,0.06)',
-          border: '1px solid rgba(251,191,36,0.15)',
-          fontSize: 11,
-          color: 'var(--text-muted)',
-          lineHeight: 1.65,
-          marginBottom: 12,
-        }}>
-          <strong style={{ color: 'var(--text)', fontWeight: 500 }}>Why a 4px grid?</strong>
-          {' '}Values divisible by 4 align to the same grid used by Tailwind CSS, Material Design, and Apple HIG — keeping layouts consistent and predictable. Values highlighted in{' '}
-          <span style={{ color: '#fbbf24' }}>amber</span> are not divisible by 4 and are candidates for rounding to the nearest scale step.
+        <div
+          style={{
+            padding: '10px 14px',
+            borderRadius: 8,
+            background: 'rgba(251,191,36,0.06)',
+            border: '1px solid rgba(251,191,36,0.15)',
+            fontSize: 11,
+            color: 'var(--text-muted)',
+            lineHeight: 1.65,
+            marginBottom: 12,
+          }}
+        >
+          <strong style={{ color: 'var(--text)', fontWeight: 500 }}>
+            Why a 4px grid?
+          </strong>{' '}
+          Values divisible by 4 align to the same grid used by Tailwind CSS,
+          Material Design, and Apple HIG — keeping layouts consistent and
+          predictable. Values highlighted in{' '}
+          <span style={{ color: '#fbbf24' }}>amber</span> are not divisible by 4
+          and are candidates for rounding to the nearest scale step.
         </div>
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           {/* Found chips */}
           <div>
-            <div style={{ fontSize: 11, color: 'var(--text-faint)', marginBottom: 8 }}>Found values</div>
+            <div
+              style={{
+                fontSize: 11,
+                color: 'var(--text-faint)',
+                marginBottom: 8,
+              }}
+            >
+              Found values
+            </div>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
               {audit.spacing.found.map((val) => {
                 const isOffScale = audit.spacing.nonScaleValues.includes(val)
-                const nearest = isOffScale ? nearestScaleValue(val, spacingScale) : null
+                const nearest = isOffScale
+                  ? nearestScaleValue(val, spacingScale)
+                  : null
 
                 return (
                   <span
                     key={val}
-                    title={nearest ? `Nearest scale value: ${nearest}` : undefined}
+                    title={
+                      nearest ? `Nearest scale value: ${nearest}` : undefined
+                    }
                     style={{
                       fontSize: 11,
                       padding: '3px 9px',
                       borderRadius: 6,
                       fontFamily: 'var(--mono)',
-                      background: isOffScale ? 'rgba(251,191,36,0.08)' : 'var(--surface)',
+                      background: isOffScale
+                        ? 'rgba(251,191,36,0.08)'
+                        : 'var(--surface)',
                       border: `1px solid ${isOffScale ? 'rgba(251,191,36,0.3)' : 'var(--border)'}`,
                       color: isOffScale ? '#fbbf24' : 'var(--text-muted)',
                       display: 'inline-flex',
@@ -303,7 +505,9 @@ export default function AuditView({ audit, onResolve }: Props) {
                     {nearest && (
                       <>
                         <span style={{ opacity: 0.5 }}>→</span>
-                        <span style={{ color: 'rgba(251,191,36,0.7)' }}>{nearest}</span>
+                        <span style={{ color: 'rgba(251,191,36,0.7)' }}>
+                          {nearest}
+                        </span>
                       </>
                     )}
                   </span>
@@ -314,15 +518,46 @@ export default function AuditView({ audit, onResolve }: Props) {
 
           {/* Suggested scale */}
           <div>
-            <div style={{ fontSize: 11, color: 'var(--text-faint)', marginBottom: 8 }}>Suggested scale (4px grid)</div>
+            <div
+              style={{
+                fontSize: 11,
+                color: 'var(--text-faint)',
+                marginBottom: 8,
+              }}
+            >
+              Suggested scale (4px grid)
+            </div>
             <div className="mint-scale-grid">
               {Object.entries(spacingScale).map(([key, val]) => (
                 <div
                   key={key}
-                  style={{ padding: '6px 10px', borderRadius: 7, background: 'var(--panel)', border: '1px solid var(--border)', textAlign: 'center' }}
+                  style={{
+                    padding: '6px 10px',
+                    borderRadius: 7,
+                    background: 'var(--panel)',
+                    border: '1px solid var(--border)',
+                    textAlign: 'center',
+                  }}
                 >
-                  <div style={{ fontSize: 10, color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>{key}</div>
-                  <div style={{ fontSize: 12, fontWeight: 500, fontFamily: 'var(--mono)', color: 'var(--text)' }}>{val}</div>
+                  <div
+                    style={{
+                      fontSize: 10,
+                      color: 'var(--text-faint)',
+                      fontFamily: 'var(--mono)',
+                    }}
+                  >
+                    {key}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 12,
+                      fontWeight: 500,
+                      fontFamily: 'var(--mono)',
+                      color: 'var(--text)',
+                    }}
+                  >
+                    {val}
+                  </div>
                 </div>
               ))}
             </div>
@@ -350,7 +585,14 @@ export default function AuditView({ audit, onResolve }: Props) {
             cursor: includedColors > 0 ? 'pointer' : 'not-allowed',
           }}
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
             <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
           </svg>
           Generate clean tokens
@@ -362,7 +604,16 @@ export default function AuditView({ audit, onResolve }: Props) {
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.07em', color: 'var(--text-faint)', textTransform: 'uppercase', marginBottom: 10 }}>
+    <div
+      style={{
+        fontSize: 11,
+        fontWeight: 600,
+        letterSpacing: '0.07em',
+        color: 'var(--text-faint)',
+        textTransform: 'uppercase',
+        marginBottom: 10,
+      }}
+    >
       {children}
     </div>
   )

--- a/components/CliPromo.tsx
+++ b/components/CliPromo.tsx
@@ -41,9 +41,26 @@ export default function CliPromo() {
         }}
       >
         {/* Header */}
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px', borderBottom: '1px solid var(--border)' }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '12px 16px',
+            borderBottom: '1px solid var(--border)',
+          }}
+        >
           <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent-strong)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="var(--accent-strong)"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <polyline points="4 17 10 11 4 5" />
               <line x1="12" y1="19" x2="20" y2="19" />
             </svg>
@@ -52,17 +69,44 @@ export default function CliPromo() {
               · run Mint against a whole folder
             </span>
           </div>
-          <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-faint)' }}>
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 600,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: 'var(--text-faint)',
+            }}
+          >
             Node ≥ 20
           </span>
         </div>
 
         {/* Commands */}
-        <pre style={{ margin: 0, padding: '14px 18px', fontFamily: 'var(--mono)', fontSize: 12.5, lineHeight: 1.85, color: 'var(--text)', background: 'transparent', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+        <pre
+          style={{
+            margin: 0,
+            padding: '14px 18px',
+            fontFamily: 'var(--mono)',
+            fontSize: 12.5,
+            lineHeight: 1.85,
+            color: 'var(--text)',
+            background: 'transparent',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
           {COMMANDS.map((cmd, i) => (
             <div key={i} style={{ display: 'flex', gap: 10 }}>
-              <span style={{ color: 'var(--text-faint)', userSelect: 'none' }}>$</span>
-              <span><span style={{ color: 'var(--accent-strong)' }}>{cmd.split(' ')[0]}</span> {cmd.split(' ').slice(1).join(' ')}</span>
+              <span style={{ color: 'var(--text-faint)', userSelect: 'none' }}>
+                $
+              </span>
+              <span>
+                <span style={{ color: 'var(--accent-strong)' }}>
+                  {cmd.split(' ')[0]}
+                </span>{' '}
+                {cmd.split(' ').slice(1).join(' ')}
+              </span>
             </div>
           ))}
         </pre>
@@ -71,7 +115,15 @@ export default function CliPromo() {
         <AuthBlock />
 
         {/* Actions */}
-        <div style={{ display: 'flex', gap: 8, padding: '10px 12px', borderTop: '1px solid var(--border)', background: 'var(--surface)' }}>
+        <div
+          style={{
+            display: 'flex',
+            gap: 8,
+            padding: '10px 12px',
+            borderTop: '1px solid var(--border)',
+            background: 'var(--surface)',
+          }}
+        >
           <button
             onClick={copy}
             style={{
@@ -92,14 +144,28 @@ export default function CliPromo() {
           >
             {copied ? (
               <>
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                >
                   <path d="M20 6L9 17l-5-5" />
                 </svg>
                 Copied
               </>
             ) : (
               <>
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
                   <rect x="9" y="9" width="13" height="13" rx="2" />
                   <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
                 </svg>
@@ -132,7 +198,6 @@ export default function CliPromo() {
             </svg>
             View docs on GitHub
           </a>
-
         </div>
       </div>
     </section>
@@ -140,9 +205,21 @@ export default function CliPromo() {
 }
 
 const AUTH_SHELLS: { label: string; prompt: string; cmd: string }[] = [
-  { label: 'bash · zsh · WSL', prompt: '$', cmd: 'export ANTHROPIC_API_KEY=sk-ant-...' },
-  { label: 'PowerShell',       prompt: '>', cmd: '$env:ANTHROPIC_API_KEY = "sk-ant-..."' },
-  { label: 'Windows CMD',      prompt: '>', cmd: 'set ANTHROPIC_API_KEY=sk-ant-...' },
+  {
+    label: 'bash · zsh · WSL',
+    prompt: '$',
+    cmd: 'export ANTHROPIC_API_KEY=sk-ant-...',
+  },
+  {
+    label: 'PowerShell',
+    prompt: '>',
+    cmd: '$env:ANTHROPIC_API_KEY = "sk-ant-..."',
+  },
+  {
+    label: 'Windows CMD',
+    prompt: '>',
+    cmd: 'set ANTHROPIC_API_KEY=sk-ant-...',
+  },
 ]
 
 function AuthBlock() {
@@ -150,12 +227,45 @@ function AuthBlock() {
   const active = AUTH_SHELLS[shellIdx]
 
   return (
-    <div style={{ borderTop: '1px solid var(--border)', padding: '12px 16px 14px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 8, marginBottom: 8 }}>
-        <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--text-faint)' }}>
+    <div
+      style={{
+        borderTop: '1px solid var(--border)',
+        padding: '12px 16px 14px',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: 8,
+          marginBottom: 8,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            color: 'var(--text-faint)',
+          }}
+        >
           Authentication
         </span>
-        <div role="tablist" aria-label="Shell" style={{ display: 'flex', gap: 2, background: 'var(--surface)', borderRadius: 7, padding: 2, border: '1px solid var(--border)' }}>
+        <div
+          role="tablist"
+          aria-label="Shell"
+          style={{
+            display: 'flex',
+            gap: 2,
+            background: 'var(--surface)',
+            borderRadius: 7,
+            padding: 2,
+            border: '1px solid var(--border)',
+          }}
+        >
           {AUTH_SHELLS.map((s, i) => (
             <button
               key={s.label}
@@ -180,16 +290,44 @@ function AuthBlock() {
         </div>
       </div>
 
-      <pre style={{ margin: 0, fontFamily: 'var(--mono)', fontSize: 12, lineHeight: 1.7, color: 'var(--text)', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+      <pre
+        style={{
+          margin: 0,
+          fontFamily: 'var(--mono)',
+          fontSize: 12,
+          lineHeight: 1.7,
+          color: 'var(--text)',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        }}
+      >
         <div style={{ display: 'flex', gap: 10 }}>
-          <span style={{ color: 'var(--text-faint)', userSelect: 'none' }}>{active.prompt}</span>
+          <span style={{ color: 'var(--text-faint)', userSelect: 'none' }}>
+            {active.prompt}
+          </span>
           <span>{active.cmd}</span>
         </div>
       </pre>
 
-      <p style={{ marginTop: 8, fontSize: 11.5, color: 'var(--text-muted)', lineHeight: 1.55 }}>
+      <p
+        style={{
+          marginTop: 8,
+          fontSize: 11.5,
+          color: 'var(--text-muted)',
+          lineHeight: 1.55,
+        }}
+      >
         Or pass the key per-command with{' '}
-        <code style={{ fontFamily: 'var(--mono)', fontSize: 11, padding: '1px 5px', borderRadius: 4, background: 'var(--surface)', color: 'var(--accent-strong)' }}>
+        <code
+          style={{
+            fontFamily: 'var(--mono)',
+            fontSize: 11,
+            padding: '1px 5px',
+            borderRadius: 4,
+            background: 'var(--surface)',
+            color: 'var(--accent-strong)',
+          }}
+        >
           --api-key sk-ant-...
         </code>{' '}
         — handy for CI or one-off runs.

--- a/components/CodeViewer.tsx
+++ b/components/CodeViewer.tsx
@@ -31,50 +31,177 @@ export default function CodeViewer({ code, filename, ext, onClose }: Props) {
   const lineCount = code.split('\n').length
 
   return (
-    <div style={{ background: 'var(--panel)', border: '1px solid var(--border-hover)', borderRadius: 10, overflow: 'hidden', marginTop: 16, animation: 'slideDown 0.2s ease' }}>
-
+    <div
+      style={{
+        background: 'var(--panel)',
+        border: '1px solid var(--border-hover)',
+        borderRadius: 10,
+        overflow: 'hidden',
+        marginTop: 16,
+        animation: 'slideDown 0.2s ease',
+      }}
+    >
       {/* Bar */}
-      <div style={{ display: 'flex', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--border)', gap: 10 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          padding: '10px 14px',
+          borderBottom: '1px solid var(--border)',
+          gap: 10,
+        }}
+      >
         <div style={{ display: 'flex', gap: 5 }}>
-          <div style={{ width: 10, height: 10, borderRadius: '50%', background: 'rgba(255,255,255,0.07)' }} />
-          <div style={{ width: 10, height: 10, borderRadius: '50%', background: 'rgba(255,255,255,0.07)' }} />
-          <div style={{ width: 10, height: 10, borderRadius: '50%', background: 'rgba(255,255,255,0.07)' }} />
+          <div
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              background: 'rgba(255,255,255,0.07)',
+            }}
+          />
+          <div
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              background: 'rgba(255,255,255,0.07)',
+            }}
+          />
+          <div
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              background: 'rgba(255,255,255,0.07)',
+            }}
+          />
         </div>
-        <span style={{ fontSize: 11, color: 'var(--text-faint)', fontFamily: 'var(--mono)', marginRight: 'auto' }}>
+        <span
+          style={{
+            fontSize: 11,
+            color: 'var(--text-faint)',
+            fontFamily: 'var(--mono)',
+            marginRight: 'auto',
+          }}
+        >
           {filename}.{ext}
         </span>
-        <span style={{ fontSize: 11, color: 'var(--text-faint)' }}>{lineCount} líneas</span>
+        <span style={{ fontSize: 11, color: 'var(--text-faint)' }}>
+          {lineCount} líneas
+        </span>
 
         <button
           onClick={copy}
-          style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '4px 10px', borderRadius: 6, border: '1px solid var(--border-hover)', background: 'transparent', color: copied ? '#4ade80' : 'var(--text-muted)', fontSize: 11, fontFamily: 'var(--font)' }}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
+            padding: '4px 10px',
+            borderRadius: 6,
+            border: '1px solid var(--border-hover)',
+            background: 'transparent',
+            color: copied ? '#4ade80' : 'var(--text-muted)',
+            fontSize: 11,
+            fontFamily: 'var(--font)',
+          }}
         >
           {copied ? (
-            <><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"><path d="M20 6L9 17l-5-5" /></svg>Copiado</>
+            <>
+              <svg
+                width="11"
+                height="11"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+              >
+                <path d="M20 6L9 17l-5-5" />
+              </svg>
+              Copiado
+            </>
           ) : (
-            <><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" /></svg>Copiar</>
+            <>
+              <svg
+                width="11"
+                height="11"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <rect x="9" y="9" width="13" height="13" rx="2" />
+                <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+              </svg>
+              Copiar
+            </>
           )}
         </button>
 
         <button
           onClick={download}
-          style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '4px 10px', borderRadius: 6, border: '1px solid rgba(99,102,241,0.3)', background: 'rgba(99,102,241,0.08)', color: 'rgba(129,140,248,0.9)', fontSize: 11, fontFamily: 'var(--font)' }}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
+            padding: '4px 10px',
+            borderRadius: 6,
+            border: '1px solid rgba(99,102,241,0.3)',
+            background: 'rgba(99,102,241,0.08)',
+            color: 'rgba(129,140,248,0.9)',
+            fontSize: 11,
+            fontFamily: 'var(--font)',
+          }}
         >
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" /></svg>
+          <svg
+            width="11"
+            height="11"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
+          </svg>
           Descargar
         </button>
 
         <button
           onClick={onClose}
-          style={{ display: 'flex', padding: '4px', borderRadius: 6, border: 'none', background: 'transparent', color: 'var(--text-faint)', fontFamily: 'var(--font)' }}
+          style={{
+            display: 'flex',
+            padding: '4px',
+            borderRadius: 6,
+            border: 'none',
+            background: 'transparent',
+            color: 'var(--text-faint)',
+            fontFamily: 'var(--font)',
+          }}
         >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12" /></svg>
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
         </button>
       </div>
 
       {/* Code */}
       <div style={{ overflowX: 'auto', maxHeight: 440 }}>
-        <pre style={{ padding: '16px', fontSize: 12, lineHeight: 1.75, color: '#9090c0', minWidth: 'max-content' }}>
+        <pre
+          style={{
+            padding: '16px',
+            fontSize: 12,
+            lineHeight: 1.75,
+            color: '#9090c0',
+            minWidth: 'max-content',
+          }}
+        >
           {code}
         </pre>
       </div>

--- a/components/CoffeeLoader.tsx
+++ b/components/CoffeeLoader.tsx
@@ -2,53 +2,137 @@
 
 export default function CoffeeLoader() {
   return (
-    <div style={{
-      position: 'fixed',
-      inset: 0,
-      background: 'rgba(14, 14, 20, 0.88)',
-      backdropFilter: 'blur(12px)',
-      zIndex: 9999,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      gap: 28,
-      fontFamily: 'var(--font)',
-    }}>
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(14, 14, 20, 0.88)',
+        backdropFilter: 'blur(12px)',
+        zIndex: 9999,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 28,
+        fontFamily: 'var(--font)',
+      }}
+    >
       <div className="coffee-float">
         <svg width="96" height="96" viewBox="0 0 96 96" fill="none">
           {/* Steam wisps */}
-          <path className="steam steam-1" d="M32 44 Q28 34 33 24 Q38 14 34 6" stroke="#c8a96e" strokeWidth="3" strokeLinecap="round" fill="none" />
-          <path className="steam steam-2" d="M46 42 Q42 31 47 20 Q52 9 48 1" stroke="#c8a96e" strokeWidth="3" strokeLinecap="round" fill="none" />
-          <path className="steam steam-3" d="M60 44 Q56 34 61 24 Q66 14 62 6" stroke="#c8a96e" strokeWidth="3" strokeLinecap="round" fill="none" />
+          <path
+            className="steam steam-1"
+            d="M32 44 Q28 34 33 24 Q38 14 34 6"
+            stroke="#c8a96e"
+            strokeWidth="3"
+            strokeLinecap="round"
+            fill="none"
+          />
+          <path
+            className="steam steam-2"
+            d="M46 42 Q42 31 47 20 Q52 9 48 1"
+            stroke="#c8a96e"
+            strokeWidth="3"
+            strokeLinecap="round"
+            fill="none"
+          />
+          <path
+            className="steam steam-3"
+            d="M60 44 Q56 34 61 24 Q66 14 62 6"
+            stroke="#c8a96e"
+            strokeWidth="3"
+            strokeLinecap="round"
+            fill="none"
+          />
           {/* Cup body */}
           <rect x="12" y="47" width="64" height="38" rx="11" fill="#c8a96e" />
           {/* Coffee surface */}
           <ellipse cx="44" cy="49" rx="29" ry="6" fill="#7a4a28" />
           {/* Highlight on coffee */}
-          <ellipse cx="36" cy="47" rx="8" ry="2.5" fill="rgba(255,255,255,0.12)" transform="rotate(-10 36 47)" />
+          <ellipse
+            cx="36"
+            cy="47"
+            rx="8"
+            ry="2.5"
+            fill="rgba(255,255,255,0.12)"
+            transform="rotate(-10 36 47)"
+          />
           {/* Handle */}
-          <path d="M76 57 Q92 57 92 67 Q92 77 76 77" stroke="#c8a96e" fill="none" strokeWidth="7" strokeLinecap="round" />
+          <path
+            d="M76 57 Q92 57 92 67 Q92 77 76 77"
+            stroke="#c8a96e"
+            fill="none"
+            strokeWidth="7"
+            strokeLinecap="round"
+          />
           {/* Saucer */}
-          <ellipse cx="44" cy="88" rx="42" ry="6" fill="#c8a96e" opacity="0.35" />
-          <ellipse cx="44" cy="88" rx="32" ry="4" fill="#c8a96e" opacity="0.25" />
+          <ellipse
+            cx="44"
+            cy="88"
+            rx="42"
+            ry="6"
+            fill="#c8a96e"
+            opacity="0.35"
+          />
+          <ellipse
+            cx="44"
+            cy="88"
+            rx="32"
+            ry="4"
+            fill="#c8a96e"
+            opacity="0.25"
+          />
         </svg>
       </div>
 
       <div style={{ textAlign: 'center' }}>
-        <div style={{ fontSize: 17, fontWeight: 600, color: '#eaeaf8', marginBottom: 8, letterSpacing: '-0.01em' }}>
+        <div
+          style={{
+            fontSize: 17,
+            fontWeight: 600,
+            color: '#eaeaf8',
+            marginBottom: 8,
+            letterSpacing: '-0.01em',
+          }}
+        >
           Claude is cooking something good...
         </div>
         <div style={{ fontSize: 13, color: '#8888c0', lineHeight: 1.7 }}>
           Go grab a real coffee ☕<br />
-          <span style={{ color: '#606090' }}>Claude handles everything in the meantime</span>
+          <span style={{ color: '#606090' }}>
+            Claude handles everything in the meantime
+          </span>
         </div>
       </div>
 
       <div style={{ display: 'flex', gap: 6, marginTop: 4 }}>
-        <div className="dot dot-1" style={{ width: 6, height: 6, borderRadius: '50%', background: '#c8a96e' }} />
-        <div className="dot dot-2" style={{ width: 6, height: 6, borderRadius: '50%', background: '#c8a96e' }} />
-        <div className="dot dot-3" style={{ width: 6, height: 6, borderRadius: '50%', background: '#c8a96e' }} />
+        <div
+          className="dot dot-1"
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: '#c8a96e',
+          }}
+        />
+        <div
+          className="dot dot-2"
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: '#c8a96e',
+          }}
+        />
+        <div
+          className="dot dot-3"
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: '#c8a96e',
+          }}
+        />
       </div>
 
       <style>{`

--- a/components/CssInput.tsx
+++ b/components/CssInput.tsx
@@ -9,7 +9,12 @@ interface Props {
   headerless?: boolean
 }
 
-export default function CssInput({ onAudit, loading, compact = false, headerless = false }: Props) {
+export default function CssInput({
+  onAudit,
+  loading,
+  compact = false,
+  headerless = false,
+}: Props) {
   const [css, setCss] = useState('')
   const [dragging, setDragging] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -28,33 +33,111 @@ export default function CssInput({ onAudit, loading, compact = false, headerless
   const hasContent = css.trim().length > 100
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: headerless ? 'flex-start' : (compact ? 'flex-start' : 'center'), minHeight: headerless ? 'auto' : (compact ? 'auto' : '100vh'), padding: headerless ? '0 16px' : (compact ? '48px 16px 24px' : '40px 16px') }}>
-
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: headerless
+          ? 'flex-start'
+          : compact
+            ? 'flex-start'
+            : 'center',
+        minHeight: headerless ? 'auto' : compact ? 'auto' : '100vh',
+        padding: headerless
+          ? '0 16px'
+          : compact
+            ? '48px 16px 24px'
+            : '40px 16px',
+      }}
+    >
       {/* Header — hidden when the parent page provides its own hero */}
       {!headerless && (
         <div style={{ textAlign: 'center', marginBottom: compact ? 24 : 40 }}>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10, marginBottom: 12 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 10,
+              marginBottom: 12,
+            }}
+          >
             <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
-              <rect width="28" height="28" rx="8" fill="rgba(99,102,241,0.15)" />
-              <path d="M8 9h12M8 14h6M8 19h9" stroke="#818cf8" strokeWidth="1.5" strokeLinecap="round" />
-              <circle cx="20" cy="19" r="3.5" fill="rgba(99,102,241,0.3)" stroke="#818cf8" strokeWidth="1" />
-              <path d="M19 19l1 1 2-2" stroke="#818cf8" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" />
+              <rect
+                width="28"
+                height="28"
+                rx="8"
+                fill="rgba(99,102,241,0.15)"
+              />
+              <path
+                d="M8 9h12M8 14h6M8 19h9"
+                stroke="#818cf8"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+              <circle
+                cx="20"
+                cy="19"
+                r="3.5"
+                fill="rgba(99,102,241,0.3)"
+                stroke="#818cf8"
+                strokeWidth="1"
+              />
+              <path
+                d="M19 19l1 1 2-2"
+                stroke="#818cf8"
+                strokeWidth="1"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
             </svg>
-            <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: '-0.02em' }}>Mint</span>
-            <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.08em', textTransform: 'uppercase', padding: '2px 7px', borderRadius: 5, background: 'rgba(129,140,248,0.18)', color: 'var(--accent-strong)' }}>
+            <span
+              style={{
+                fontSize: 18,
+                fontWeight: 600,
+                letterSpacing: '-0.02em',
+              }}
+            >
+              Mint
+            </span>
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                padding: '2px 7px',
+                borderRadius: 5,
+                background: 'rgba(129,140,248,0.18)',
+                color: 'var(--accent-strong)',
+              }}
+            >
               Playground
             </span>
           </div>
-          <p style={{ fontSize: 13, color: 'var(--text-muted)', maxWidth: 460, lineHeight: 1.6 }}>
-            Paste your CSS, SCSS, or HTML to try Mint right here.<br />
-            Prefer your terminal? The full audit + export pipeline ships as a CLI — see below.
+          <p
+            style={{
+              fontSize: 13,
+              color: 'var(--text-muted)',
+              maxWidth: 460,
+              lineHeight: 1.6,
+            }}
+          >
+            Paste your CSS, SCSS, or HTML to try Mint right here.
+            <br />
+            Prefer your terminal? The full audit + export pipeline ships as a
+            CLI — see below.
           </p>
         </div>
       )}
 
       {/* Drop zone + textarea */}
       <div
-        onDragOver={(e) => { e.preventDefault(); setDragging(true) }}
+        onDragOver={(e) => {
+          e.preventDefault()
+          setDragging(true)
+        }}
         onDragLeave={() => setDragging(false)}
         onDrop={handleDrop}
         className="mint-input-wrap"
@@ -67,15 +150,47 @@ export default function CssInput({ onAudit, loading, compact = false, headerless
         }}
       >
         {/* Top bar */}
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px', borderBottom: '1px solid var(--border)' }}>
-          <span style={{ fontSize: 11, color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>styles.css · _tokens.scss · index.html</span>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '12px 16px',
+            borderBottom: '1px solid var(--border)',
+          }}
+        >
+          <span
+            style={{
+              fontSize: 11,
+              color: 'var(--text-faint)',
+              fontFamily: 'var(--mono)',
+            }}
+          >
+            styles.css · _tokens.scss · index.html
+          </span>
           <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
             {charCount > 0 && (
-              <span style={{ fontSize: 11, color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: 'var(--text-faint)',
+                  fontFamily: 'var(--mono)',
+                }}
+              >
                 {(charCount / 1000).toFixed(1)}k chars
               </span>
             )}
-            <label style={{ fontSize: 11, color: 'rgba(99,102,241,0.8)', cursor: 'pointer', padding: '3px 8px', borderRadius: 6, border: '1px solid rgba(99,102,241,0.25)', background: 'rgba(99,102,241,0.06)' }}>
+            <label
+              style={{
+                fontSize: 11,
+                color: 'rgba(99,102,241,0.8)',
+                cursor: 'pointer',
+                padding: '3px 8px',
+                borderRadius: 6,
+                border: '1px solid rgba(99,102,241,0.25)',
+                background: 'rgba(99,102,241,0.06)',
+              }}
+            >
               Upload File
               <input
                 type="file"
@@ -114,14 +229,35 @@ export default function CssInput({ onAudit, loading, compact = false, headerless
         />
 
         {dragging && (
-          <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: 12, background: 'rgba(99,102,241,0.08)', backdropFilter: 'blur(2px)' }}>
-            <span style={{ fontSize: 13, color: 'rgba(99,102,241,0.9)' }}>Soltá el archivo acá</span>
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 12,
+              background: 'rgba(99,102,241,0.08)',
+              backdropFilter: 'blur(2px)',
+            }}
+          >
+            <span style={{ fontSize: 13, color: 'rgba(99,102,241,0.9)' }}>
+              Soltá el archivo acá
+            </span>
           </div>
         )}
       </div>
 
       {/* Action */}
-      <div style={{ marginTop: 20, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+      <div
+        style={{
+          marginTop: 20,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 10,
+        }}
+      >
         <button
           onClick={() => onAudit(css)}
           disabled={!hasContent || loading}
@@ -142,14 +278,29 @@ export default function CssInput({ onAudit, loading, compact = false, headerless
         >
           {loading ? (
             <>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ animation: 'spin 1s linear infinite' }}>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                style={{ animation: 'spin 1s linear infinite' }}
+              >
                 <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
               </svg>
               Analyzing CSS...
             </>
           ) : (
             <>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
                 <circle cx="11" cy="11" r="8" />
                 <path d="M21 21l-4.35-4.35M11 8v6M8 11h6" />
               </svg>

--- a/components/ExportPanel.tsx
+++ b/components/ExportPanel.tsx
@@ -54,7 +54,12 @@ export default function ExportPanel({ tokens }: Props) {
     } catch (err) {
       setExports((prev) => ({
         ...prev,
-        [target]: { target, code: '', loading: false, error: (err as Error).message },
+        [target]: {
+          target,
+          code: '',
+          loading: false,
+          error: (err as Error).message,
+        },
       }))
     }
   }
@@ -74,7 +79,16 @@ export default function ExportPanel({ tokens }: Props) {
       <div style={{ display: 'flex', flexDirection: 'column', gap: 36 }}>
         {grouped.map(({ category, targets }) => (
           <div key={category}>
-            <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.08em', color: 'var(--text-faint)', textTransform: 'uppercase', marginBottom: 12 }}>
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                letterSpacing: '0.08em',
+                color: 'var(--text-faint)',
+                textTransform: 'uppercase',
+                marginBottom: 12,
+              }}
+            >
               {category}
             </div>
             <div className="mint-export-grid">
@@ -95,7 +109,11 @@ export default function ExportPanel({ tokens }: Props) {
                       padding: '12px 16px',
                       borderRadius: 10,
                       border: `1px solid ${isActive ? 'rgba(99,102,241,0.45)' : isDone ? 'rgba(74,222,128,0.25)' : 'var(--border)'}`,
-                      background: isActive ? 'rgba(99,102,241,0.09)' : isDone ? 'rgba(74,222,128,0.05)' : 'var(--surface)',
+                      background: isActive
+                        ? 'rgba(99,102,241,0.09)'
+                        : isDone
+                          ? 'rgba(74,222,128,0.05)'
+                          : 'var(--surface)',
                       color: 'var(--text)',
                       textAlign: 'left',
                       fontFamily: 'var(--font)',
@@ -104,43 +122,118 @@ export default function ExportPanel({ tokens }: Props) {
                     }}
                     onMouseEnter={(e) => {
                       if (!isActive) {
-                        (e.currentTarget as HTMLButtonElement).style.borderColor = 'var(--border-hover)'
-                        ;(e.currentTarget as HTMLButtonElement).style.background = 'var(--surface-2)'
+                        ;(
+                          e.currentTarget as HTMLButtonElement
+                        ).style.borderColor = 'var(--border-hover)'
+                        ;(
+                          e.currentTarget as HTMLButtonElement
+                        ).style.background = 'var(--surface-2)'
                       }
                     }}
                     onMouseLeave={(e) => {
                       if (!isActive) {
-                        const border = isDone ? 'rgba(74,222,128,0.25)' : 'var(--border)'
-                        const bg = isDone ? 'rgba(74,222,128,0.05)' : 'var(--surface)'
-                        ;(e.currentTarget as HTMLButtonElement).style.borderColor = border
-                        ;(e.currentTarget as HTMLButtonElement).style.background = bg
+                        const border = isDone
+                          ? 'rgba(74,222,128,0.25)'
+                          : 'var(--border)'
+                        const bg = isDone
+                          ? 'rgba(74,222,128,0.05)'
+                          : 'var(--surface)'
+                        ;(
+                          e.currentTarget as HTMLButtonElement
+                        ).style.borderColor = border
+                        ;(
+                          e.currentTarget as HTMLButtonElement
+                        ).style.background = bg
                       }
                     }}
                   >
                     {/* Status dot */}
-                    <div style={{ width: 8, height: 8, borderRadius: '50%', flexShrink: 0, background: isDone ? '#4ade80' : isLoading ? '#fbbf24' : 'var(--text-faint)', transition: 'background 0.2s' }} />
+                    <div
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: '50%',
+                        flexShrink: 0,
+                        background: isDone
+                          ? '#4ade80'
+                          : isLoading
+                            ? '#fbbf24'
+                            : 'var(--text-faint)',
+                        transition: 'background 0.2s',
+                      }}
+                    />
 
                     <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontSize: 13, fontWeight: 500, marginBottom: 2 }}>{cfg.label}</div>
-                      <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>{cfg.description}</div>
+                      <div
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 500,
+                          marginBottom: 2,
+                        }}
+                      >
+                        {cfg.label}
+                      </div>
+                      <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>
+                        {cfg.description}
+                      </div>
                     </div>
 
                     {/* Ext badge */}
-                    <span style={{ fontSize: 10, padding: '2px 8px', borderRadius: 5, background: 'var(--surface-2)', color: 'var(--text-faint)', fontFamily: 'var(--mono)', flexShrink: 0, border: '1px solid var(--border)' }}>
+                    <span
+                      style={{
+                        fontSize: 10,
+                        padding: '2px 8px',
+                        borderRadius: 5,
+                        background: 'var(--surface-2)',
+                        color: 'var(--text-faint)',
+                        fontFamily: 'var(--mono)',
+                        flexShrink: 0,
+                        border: '1px solid var(--border)',
+                      }}
+                    >
                       .{cfg.ext}
                     </span>
 
                     {/* State icon */}
                     {isLoading ? (
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" strokeWidth="2" style={{ animation: 'spin 1s linear infinite', flexShrink: 0 }}>
+                      <svg
+                        width="13"
+                        height="13"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="#fbbf24"
+                        strokeWidth="2"
+                        style={{
+                          animation: 'spin 1s linear infinite',
+                          flexShrink: 0,
+                        }}
+                      >
                         <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
                       </svg>
                     ) : isDone ? (
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={isActive ? 'rgba(99,102,241,0.8)' : '#4ade80'} strokeWidth="2" style={{ flexShrink: 0 }}>
-                        <path d={isActive ? 'M18 15l-6-6-6 6' : 'M6 9l6 6 6-6'} />
+                      <svg
+                        width="13"
+                        height="13"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke={isActive ? 'rgba(99,102,241,0.8)' : '#4ade80'}
+                        strokeWidth="2"
+                        style={{ flexShrink: 0 }}
+                      >
+                        <path
+                          d={isActive ? 'M18 15l-6-6-6 6' : 'M6 9l6 6 6-6'}
+                        />
                       </svg>
                     ) : (
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--text-faint)" strokeWidth="2" style={{ flexShrink: 0 }}>
+                      <svg
+                        width="13"
+                        height="13"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="var(--text-faint)"
+                        strokeWidth="2"
+                        style={{ flexShrink: 0 }}
+                      >
                         <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
                       </svg>
                     )}
@@ -150,11 +243,24 @@ export default function ExportPanel({ tokens }: Props) {
             </div>
 
             {/* Error inline */}
-            {activeExport?.error && activeTarget && EXPORT_TARGETS.find((t) => t.target === activeTarget)?.category === category && (
-              <div style={{ marginTop: 10, padding: '10px 14px', borderRadius: 8, background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.2)', fontSize: 12, color: '#f87171' }}>
-                {activeExport.error}
-              </div>
-            )}
+            {activeExport?.error &&
+              activeTarget &&
+              EXPORT_TARGETS.find((t) => t.target === activeTarget)
+                ?.category === category && (
+                <div
+                  style={{
+                    marginTop: 10,
+                    padding: '10px 14px',
+                    borderRadius: 8,
+                    background: 'rgba(239,68,68,0.08)',
+                    border: '1px solid rgba(239,68,68,0.2)',
+                    fontSize: 12,
+                    color: '#f87171',
+                  }}
+                >
+                  {activeExport.error}
+                </div>
+              )}
           </div>
         ))}
 

--- a/components/HtmlInput.tsx
+++ b/components/HtmlInput.tsx
@@ -29,26 +29,63 @@ export default function HtmlInput({ onParse, loading }: Props) {
   const hasContent = html.trim().length > 100
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '100vh', padding: '40px 20px' }}>
-
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        padding: '40px 20px',
+      }}
+    >
       {/* Header */}
       <div style={{ textAlign: 'center', marginBottom: 40 }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10, marginBottom: 12 }}>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 10,
+            marginBottom: 12,
+          }}
+        >
           <svg width="28" height="28" viewBox="0 0 28 28" fill="none">
             <rect width="28" height="28" rx="8" fill="rgba(99,102,241,0.15)" />
-            <path d="M8 10h12M8 14h8M8 18h10" stroke="#818cf8" strokeWidth="1.5" strokeLinecap="round" />
+            <path
+              d="M8 10h12M8 14h8M8 18h10"
+              stroke="#818cf8"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
           </svg>
-          <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: '-0.02em' }}>Mint</span>
+          <span
+            style={{ fontSize: 18, fontWeight: 600, letterSpacing: '-0.02em' }}
+          >
+            Mint
+          </span>
         </div>
-        <p style={{ fontSize: 13, color: 'var(--text-muted)', maxWidth: 400, lineHeight: 1.6 }}>
-          Pegá el HTML de tu design system generado con Claude Code.<br />
-          Extraemos los tokens automáticamente y los exportamos a cualquier formato.
+        <p
+          style={{
+            fontSize: 13,
+            color: 'var(--text-muted)',
+            maxWidth: 400,
+            lineHeight: 1.6,
+          }}
+        >
+          Pegá el HTML de tu design system generado con Claude Code.
+          <br />
+          Extraemos los tokens automáticamente y los exportamos a cualquier
+          formato.
         </p>
       </div>
 
       {/* Drop zone + textarea */}
       <div
-        onDragOver={(e) => { e.preventDefault(); setDragging(true) }}
+        onDragOver={(e) => {
+          e.preventDefault()
+          setDragging(true)
+        }}
         onDragLeave={() => setDragging(false)}
         onDrop={handleDrop}
         style={{
@@ -62,15 +99,47 @@ export default function HtmlInput({ onParse, loading }: Props) {
         }}
       >
         {/* Top bar */}
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px', borderBottom: '1px solid var(--border)' }}>
-          <span style={{ fontSize: 11, color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>design-system.html</span>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '12px 16px',
+            borderBottom: '1px solid var(--border)',
+          }}
+        >
+          <span
+            style={{
+              fontSize: 11,
+              color: 'var(--text-faint)',
+              fontFamily: 'var(--mono)',
+            }}
+          >
+            design-system.html
+          </span>
           <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
             {charCount > 0 && (
-              <span style={{ fontSize: 11, color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: 'var(--text-faint)',
+                  fontFamily: 'var(--mono)',
+                }}
+              >
                 {(charCount / 1000).toFixed(1)}k chars
               </span>
             )}
-            <label style={{ fontSize: 11, color: 'rgba(99,102,241,0.8)', cursor: 'pointer', padding: '3px 8px', borderRadius: 6, border: '1px solid rgba(99,102,241,0.25)', background: 'rgba(99,102,241,0.06)' }}>
+            <label
+              style={{
+                fontSize: 11,
+                color: 'rgba(99,102,241,0.8)',
+                cursor: 'pointer',
+                padding: '3px 8px',
+                borderRadius: 6,
+                border: '1px solid rgba(99,102,241,0.25)',
+                background: 'rgba(99,102,241,0.06)',
+              }}
+            >
               Upload File
               <input
                 type="file"
@@ -109,14 +178,35 @@ export default function HtmlInput({ onParse, loading }: Props) {
         />
 
         {dragging && (
-          <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', borderRadius: 12, background: 'rgba(99,102,241,0.08)', backdropFilter: 'blur(2px)' }}>
-            <span style={{ fontSize: 13, color: 'rgba(99,102,241,0.9)' }}>Soltá el archivo acá</span>
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 12,
+              background: 'rgba(99,102,241,0.08)',
+              backdropFilter: 'blur(2px)',
+            }}
+          >
+            <span style={{ fontSize: 13, color: 'rgba(99,102,241,0.9)' }}>
+              Soltá el archivo acá
+            </span>
           </div>
         )}
       </div>
 
       {/* Action */}
-      <div style={{ marginTop: 20, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10 }}>
+      <div
+        style={{
+          marginTop: 20,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 10,
+        }}
+      >
         <button
           onClick={() => onParse(html)}
           disabled={!hasContent || loading}
@@ -136,14 +226,29 @@ export default function HtmlInput({ onParse, loading }: Props) {
         >
           {loading ? (
             <>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ animation: 'spin 1s linear infinite' }}>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                style={{ animation: 'spin 1s linear infinite' }}
+              >
                 <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
               </svg>
               Extrayendo tokens...
             </>
           ) : (
             <>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
                 <path d="M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18" />
               </svg>
               Extraer tokens

--- a/components/StepBar.tsx
+++ b/components/StepBar.tsx
@@ -2,50 +2,79 @@ interface Props {
   current: 1 | 2 | 3
 }
 
-const STEPS = [
-  { label: 'Audit' },
-  { label: 'Tokens' },
-  { label: 'Export' },
-]
+const STEPS = [{ label: 'Audit' }, { label: 'Tokens' }, { label: 'Export' }]
 
 export default function StepBar({ current }: Props) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0 }}>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 0,
+      }}
+    >
       {STEPS.map((step, i) => {
         const stepNum = i + 1
         const isDone = stepNum < current
         const isActive = stepNum === current
 
         return (
-          <div key={step.label} style={{ display: 'flex', alignItems: 'center' }}>
-            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
-              <div style={{
-                width: 10,
-                height: 10,
-                borderRadius: '50%',
-                background: isActive ? '#6366f1' : isDone ? '#4ade80' : 'var(--border-hover)',
-                boxShadow: isActive ? '0 0 0 3px rgba(99,102,241,0.2)' : 'none',
-                transition: 'all 0.2s',
-              }} />
-              <span style={{
-                fontSize: 10,
-                fontWeight: isActive ? 500 : 400,
-                color: isActive ? 'var(--text)' : isDone ? '#4ade80' : 'var(--text-faint)',
-                letterSpacing: '0.03em',
-                whiteSpace: 'nowrap',
-              }}>
+          <div
+            key={step.label}
+            style={{ display: 'flex', alignItems: 'center' }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              <div
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: '50%',
+                  background: isActive
+                    ? '#6366f1'
+                    : isDone
+                      ? '#4ade80'
+                      : 'var(--border-hover)',
+                  boxShadow: isActive
+                    ? '0 0 0 3px rgba(99,102,241,0.2)'
+                    : 'none',
+                  transition: 'all 0.2s',
+                }}
+              />
+              <span
+                style={{
+                  fontSize: 10,
+                  fontWeight: isActive ? 500 : 400,
+                  color: isActive
+                    ? 'var(--text)'
+                    : isDone
+                      ? '#4ade80'
+                      : 'var(--text-faint)',
+                  letterSpacing: '0.03em',
+                  whiteSpace: 'nowrap',
+                }}
+              >
                 {step.label}
               </span>
             </div>
 
             {i < STEPS.length - 1 && (
-              <div style={{
-                width: 48,
-                height: 1,
-                background: isDone ? 'rgba(74,222,128,0.4)' : 'var(--border)',
-                marginBottom: 14,
-                transition: 'background 0.2s',
-              }} />
+              <div
+                style={{
+                  width: 48,
+                  height: 1,
+                  background: isDone ? 'rgba(74,222,128,0.4)' : 'var(--border)',
+                  marginBottom: 14,
+                  transition: 'background 0.2s',
+                }}
+              />
             )}
           </div>
         )

--- a/components/TokenPreview.tsx
+++ b/components/TokenPreview.tsx
@@ -12,33 +12,87 @@ export default function TokenPreview({ tokens }: Props) {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
-
       {/* Color palette */}
       <Section title="Color palette">
         {tokens.colors.map((color) => (
           <div key={color.name} style={{ marginBottom: 16 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, flexWrap: 'wrap' }}>
-              <div style={{ width: 16, height: 16, borderRadius: 4, background: color.value, border: '1px solid rgba(255,255,255,0.1)', flexShrink: 0 }} />
-              <span style={{ fontSize: 12, color: 'var(--text-muted)', textTransform: 'capitalize' }}>{color.name}</span>
-              <span style={{ fontSize: 11, color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>{color.value}</span>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                marginBottom: 6,
+                flexWrap: 'wrap',
+              }}
+            >
+              <div
+                style={{
+                  width: 16,
+                  height: 16,
+                  borderRadius: 4,
+                  background: color.value,
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  flexShrink: 0,
+                }}
+              />
+              <span
+                style={{
+                  fontSize: 12,
+                  color: 'var(--text-muted)',
+                  textTransform: 'capitalize',
+                }}
+              >
+                {color.name}
+              </span>
+              <span
+                style={{
+                  fontSize: 11,
+                  color: 'var(--text-faint)',
+                  fontFamily: 'var(--mono)',
+                }}
+              >
+                {color.value}
+              </span>
               {color.description && (
-                <span style={{ fontSize: 11, color: 'var(--text-faint)' }}>— {color.description}</span>
+                <span style={{ fontSize: 11, color: 'var(--text-faint)' }}>
+                  — {color.description}
+                </span>
               )}
             </div>
 
             {color.scale ? (
-              <div style={{ display: 'flex', gap: 2, borderRadius: 6, overflow: 'hidden' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  gap: 2,
+                  borderRadius: 6,
+                  overflow: 'hidden',
+                }}
+              >
                 {Object.entries(color.scale).map(([stop, hex]) => (
                   <div
                     key={stop}
                     title={`${stop}: ${hex}`}
-                    style={{ flex: 1, height: 28, background: hex, cursor: 'default', transition: 'flex 0.15s' }}
+                    style={{
+                      flex: 1,
+                      height: 28,
+                      background: hex,
+                      cursor: 'default',
+                      transition: 'flex 0.15s',
+                    }}
                   />
                 ))}
               </div>
             ) : (
               <div style={{ display: 'flex', gap: 6 }}>
-                <div style={{ width: 80, height: 28, borderRadius: 6, background: color.value }} />
+                <div
+                  style={{
+                    width: 80,
+                    height: 28,
+                    borderRadius: 6,
+                    background: color.value,
+                  }}
+                />
               </div>
             )}
           </div>
@@ -48,27 +102,108 @@ export default function TokenPreview({ tokens }: Props) {
       {/* Typography */}
       <Section title="Typography">
         <div className="mint-grid-2" style={{ marginBottom: 16 }}>
-          {Object.entries(tokens.typography.fontFamilies).map(([role, family]) => (
-            <div key={role} style={{ background: 'var(--surface)', borderRadius: 8, padding: '10px 14px', border: '1px solid var(--border)' }}>
-              <div style={{ fontSize: 10, color: 'var(--text-faint)', marginBottom: 4, textTransform: 'uppercase', letterSpacing: '0.06em' }}>{role}</div>
-              <div style={{ fontFamily: `'${family}', sans-serif`, fontSize: 18, fontWeight: 600, color: 'var(--text)' }}>Aa</div>
-              <div style={{ fontSize: 11, color: 'var(--text-muted)', fontFamily: 'var(--mono)', marginTop: 4 }}>{family}</div>
-            </div>
-          ))}
+          {Object.entries(tokens.typography.fontFamilies).map(
+            ([role, family]) => (
+              <div
+                key={role}
+                style={{
+                  background: 'var(--surface)',
+                  borderRadius: 8,
+                  padding: '10px 14px',
+                  border: '1px solid var(--border)',
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 10,
+                    color: 'var(--text-faint)',
+                    marginBottom: 4,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                  }}
+                >
+                  {role}
+                </div>
+                <div
+                  style={{
+                    fontFamily: `'${family}', sans-serif`,
+                    fontSize: 18,
+                    fontWeight: 600,
+                    color: 'var(--text)',
+                  }}
+                >
+                  Aa
+                </div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--text-muted)',
+                    fontFamily: 'var(--mono)',
+                    marginTop: 4,
+                  }}
+                >
+                  {family}
+                </div>
+              </div>
+            )
+          )}
         </div>
 
         {/* Type scale */}
-        <div style={{ background: 'var(--surface)', borderRadius: 8, padding: 16, border: '1px solid var(--border)', overflowX: 'auto' }}>
+        <div
+          style={{
+            background: 'var(--surface)',
+            borderRadius: 8,
+            padding: 16,
+            border: '1px solid var(--border)',
+            overflowX: 'auto',
+          }}
+        >
           {Object.entries(tokens.typography.fontSizes)
             .filter((_, i) => i % 2 === 0)
             .slice(0, 6)
             .map(([key, size]) => (
-              <div key={key} style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 8 }}>
-                <span style={{ fontSize: 10, color: 'var(--text-faint)', fontFamily: 'var(--mono)', minWidth: 28 }}>{key}</span>
-                <span style={{ fontFamily: `'${primaryFont}', sans-serif`, fontSize: size, color: 'var(--text)', lineHeight: 1.2, whiteSpace: 'nowrap' }}>
+              <div
+                key={key}
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  gap: 12,
+                  marginBottom: 8,
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: 'var(--text-faint)',
+                    fontFamily: 'var(--mono)',
+                    minWidth: 28,
+                  }}
+                >
+                  {key}
+                </span>
+                <span
+                  style={{
+                    fontFamily: `'${primaryFont}', sans-serif`,
+                    fontSize: size,
+                    color: 'var(--text)',
+                    lineHeight: 1.2,
+                    whiteSpace: 'nowrap',
+                  }}
+                >
                   The quick brown fox
                 </span>
-                <span style={{ fontSize: 10, color: 'var(--text-faint)', fontFamily: 'var(--mono)', marginLeft: 'auto', flexShrink: 0 }}>{size}</span>
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: 'var(--text-faint)',
+                    fontFamily: 'var(--mono)',
+                    marginLeft: 'auto',
+                    flexShrink: 0,
+                  }}
+                >
+                  {size}
+                </span>
               </div>
             ))}
         </div>
@@ -76,27 +211,84 @@ export default function TokenPreview({ tokens }: Props) {
 
       {/* Components preview */}
       <Section title="Components">
-        <ComponentPreview tokens={tokens} displayFont={displayFont} primaryFont={primaryFont} />
+        <ComponentPreview
+          tokens={tokens}
+          displayFont={displayFont}
+          primaryFont={primaryFont}
+        />
       </Section>
 
       {/* Spacing + radius grid */}
       <div className="mint-grid-2">
         <Section title="Spacing">
-          {Object.entries(tokens.spacing).slice(0, 8).map(([key, val]) => (
-            <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 5 }}>
-              <div style={{ height: 8, background: 'rgba(99,102,241,0.35)', borderRadius: 2, width: Math.min(parseInt(val) * 0.8, 100), minWidth: 4 }} />
-              <span style={{ fontSize: 10, color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>{key} · {val}</span>
-            </div>
-          ))}
+          {Object.entries(tokens.spacing)
+            .slice(0, 8)
+            .map(([key, val]) => (
+              <div
+                key={key}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  marginBottom: 5,
+                }}
+              >
+                <div
+                  style={{
+                    height: 8,
+                    background: 'rgba(99,102,241,0.35)',
+                    borderRadius: 2,
+                    width: Math.min(parseInt(val) * 0.8, 100),
+                    minWidth: 4,
+                  }}
+                />
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: 'var(--text-faint)',
+                    fontFamily: 'var(--mono)',
+                  }}
+                >
+                  {key} · {val}
+                </span>
+              </div>
+            ))}
         </Section>
 
         <Section title="Border radius">
-          {Object.entries(tokens.borderRadius).slice(0, 6).map(([key, val]) => (
-            <div key={key} style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 7 }}>
-              <div style={{ width: 28, height: 28, background: 'rgba(99,102,241,0.2)', border: '1.5px solid rgba(99,102,241,0.4)', borderRadius: val === '9999px' ? '9999px' : val, flexShrink: 0 }} />
-              <span style={{ fontSize: 10, color: 'var(--text-faint)', fontFamily: 'var(--mono)' }}>{key} · {val}</span>
-            </div>
-          ))}
+          {Object.entries(tokens.borderRadius)
+            .slice(0, 6)
+            .map(([key, val]) => (
+              <div
+                key={key}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 10,
+                  marginBottom: 7,
+                }}
+              >
+                <div
+                  style={{
+                    width: 28,
+                    height: 28,
+                    background: 'rgba(99,102,241,0.2)',
+                    border: '1.5px solid rgba(99,102,241,0.4)',
+                    borderRadius: val === '9999px' ? '9999px' : val,
+                    flexShrink: 0,
+                  }}
+                />
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: 'var(--text-faint)',
+                    fontFamily: 'var(--mono)',
+                  }}
+                >
+                  {key} · {val}
+                </span>
+              </div>
+            ))}
         </Section>
       </div>
 
@@ -105,9 +297,33 @@ export default function TokenPreview({ tokens }: Props) {
         <Section title="Shadows">
           <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
             {Object.entries(tokens.shadows).map(([key, val]) => (
-              <div key={key} style={{ padding: '16px 20px', background: '#fff', borderRadius: 8, boxShadow: val, display: 'flex', flexDirection: 'column', gap: 4, minWidth: 100 }}>
-                <span style={{ fontSize: 11, fontWeight: 500, color: '#111' }}>{key}</span>
-                <span style={{ fontSize: 10, color: '#888', fontFamily: 'monospace', maxWidth: 120, wordBreak: 'break-all' }}>{val.split(',')[0]}</span>
+              <div
+                key={key}
+                style={{
+                  padding: '16px 20px',
+                  background: '#fff',
+                  borderRadius: 8,
+                  boxShadow: val,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 4,
+                  minWidth: 100,
+                }}
+              >
+                <span style={{ fontSize: 11, fontWeight: 500, color: '#111' }}>
+                  {key}
+                </span>
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: '#888',
+                    fontFamily: 'monospace',
+                    maxWidth: 120,
+                    wordBreak: 'break-all',
+                  }}
+                >
+                  {val.split(',')[0]}
+                </span>
               </div>
             ))}
           </div>
@@ -117,10 +333,25 @@ export default function TokenPreview({ tokens }: Props) {
   )
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
   return (
     <div>
-      <div style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.08em', color: 'var(--text-faint)', textTransform: 'uppercase', marginBottom: 12 }}>
+      <div
+        style={{
+          fontSize: 10,
+          fontWeight: 600,
+          letterSpacing: '0.08em',
+          color: 'var(--text-faint)',
+          textTransform: 'uppercase',
+          marginBottom: 12,
+        }}
+      >
         {title}
       </div>
       {children}
@@ -128,31 +359,71 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   )
 }
 
-function ComponentPreview({ tokens, primaryFont }: { tokens: DSTokens; displayFont: string; primaryFont: string }) {
-  const primary = tokens.colors.find((c) => c.name === 'primary' || c.name === 'brand')?.value ?? '#6366f1'
-  const accent = tokens.colors.find((c) => c.name === 'accent' || c.name === 'secondary')?.value ?? '#f43f5e'
-  const bg = tokens.colors.find((c) => c.name === 'background' || c.name === 'bg')?.value ?? '#ffffff'
-  const textColor = tokens.colors.find((c) => c.name === 'text' || c.name === 'foreground')?.value ?? '#111827'
-  const muted = tokens.colors.find((c) => c.name === 'muted')?.value ?? '#6b7280'
-  const surface = tokens.colors.find((c) => c.name === 'surface')?.value ?? '#f9f9fb'
+function ComponentPreview({
+  tokens,
+  primaryFont,
+}: {
+  tokens: DSTokens
+  displayFont: string
+  primaryFont: string
+}) {
+  const primary =
+    tokens.colors.find((c) => c.name === 'primary' || c.name === 'brand')
+      ?.value ?? '#6366f1'
+  const accent =
+    tokens.colors.find((c) => c.name === 'accent' || c.name === 'secondary')
+      ?.value ?? '#f43f5e'
+  const bg =
+    tokens.colors.find((c) => c.name === 'background' || c.name === 'bg')
+      ?.value ?? '#ffffff'
+  const textColor =
+    tokens.colors.find((c) => c.name === 'text' || c.name === 'foreground')
+      ?.value ?? '#111827'
+  const muted =
+    tokens.colors.find((c) => c.name === 'muted')?.value ?? '#6b7280'
+  const surface =
+    tokens.colors.find((c) => c.name === 'surface')?.value ?? '#f9f9fb'
   const radius = tokens.borderRadius?.md ?? '8px'
   const radiusSm = tokens.borderRadius?.sm ?? '6px'
 
   return (
-    <div style={{ background: bg, borderRadius: 10, padding: 20, border: '1px solid var(--border)' }}>
-
+    <div
+      style={{
+        background: bg,
+        borderRadius: 10,
+        padding: 20,
+        border: '1px solid var(--border)',
+      }}
+    >
       {/* Buttons row */}
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 20 }}>
+      <div
+        style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 20 }}
+      >
         {[
           { label: 'Primary', bg: primary, fg: '#fff', border: 'transparent' },
-          { label: 'Secondary', bg: 'transparent', fg: primary, border: primary },
+          {
+            label: 'Secondary',
+            bg: 'transparent',
+            fg: primary,
+            border: primary,
+          },
           { label: 'Accent', bg: accent, fg: '#fff', border: 'transparent' },
           { label: 'Ghost', bg: surface, fg: textColor, border: 'transparent' },
           { label: 'Disabled', bg: surface, fg: muted, border: 'transparent' },
         ].map(({ label, bg: btnBg, fg, border }) => (
           <button
             key={label}
-            style={{ padding: '7px 16px', borderRadius: radiusSm, background: btnBg, color: fg, border: `1.5px solid ${border}`, fontSize: 12, fontWeight: 500, fontFamily: `'${primaryFont}', sans-serif`, cursor: 'pointer' }}
+            style={{
+              padding: '7px 16px',
+              borderRadius: radiusSm,
+              background: btnBg,
+              color: fg,
+              border: `1.5px solid ${border}`,
+              fontSize: 12,
+              fontWeight: 500,
+              fontFamily: `'${primaryFont}', sans-serif`,
+              cursor: 'pointer',
+            }}
           >
             {label}
           </button>
@@ -162,27 +433,91 @@ function ComponentPreview({ tokens, primaryFont }: { tokens: DSTokens; displayFo
       {/* Cards row */}
       <div className="mint-grid-3" style={{ marginBottom: 20 }}>
         {[
-          { cardBg: bg, fg: textColor, sub: muted, acc: primary + '22', label: 'Default card' },
-          { cardBg: primary, fg: '#fff', sub: 'rgba(255,255,255,0.65)', acc: 'rgba(255,255,255,0.2)', label: 'Primary card' },
-          { cardBg: surface, fg: textColor, sub: muted, acc: accent + '22', label: 'Surface card' },
+          {
+            cardBg: bg,
+            fg: textColor,
+            sub: muted,
+            acc: primary + '22',
+            label: 'Default card',
+          },
+          {
+            cardBg: primary,
+            fg: '#fff',
+            sub: 'rgba(255,255,255,0.65)',
+            acc: 'rgba(255,255,255,0.2)',
+            label: 'Primary card',
+          },
+          {
+            cardBg: surface,
+            fg: textColor,
+            sub: muted,
+            acc: accent + '22',
+            label: 'Surface card',
+          },
         ].map(({ cardBg, fg, sub, acc, label }) => (
-          <div key={label} style={{ background: cardBg, borderRadius: radius, padding: '14px', border: `1px solid ${muted}22` }}>
-            <div style={{ width: 24, height: 24, borderRadius: radiusSm, background: acc, marginBottom: 8 }} />
-            <div style={{ fontSize: 12, fontWeight: 600, color: fg, marginBottom: 3, fontFamily: `'${primaryFont}', sans-serif` }}>{label}</div>
-            <div style={{ fontSize: 11, color: sub }}>Component description</div>
+          <div
+            key={label}
+            style={{
+              background: cardBg,
+              borderRadius: radius,
+              padding: '14px',
+              border: `1px solid ${muted}22`,
+            }}
+          >
+            <div
+              style={{
+                width: 24,
+                height: 24,
+                borderRadius: radiusSm,
+                background: acc,
+                marginBottom: 8,
+              }}
+            />
+            <div
+              style={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: fg,
+                marginBottom: 3,
+                fontFamily: `'${primaryFont}', sans-serif`,
+              }}
+            >
+              {label}
+            </div>
+            <div style={{ fontSize: 11, color: sub }}>
+              Component description
+            </div>
           </div>
         ))}
       </div>
 
       {/* Badges */}
-      <div style={{ display: 'flex', gap: 10, alignItems: 'center', flexWrap: 'wrap', marginBottom: 14 }}>
+      <div
+        style={{
+          display: 'flex',
+          gap: 10,
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          marginBottom: 14,
+        }}
+      >
         {[
           { label: 'Primary', bg: primary + '18', fg: primary },
           { label: 'Accent', bg: accent + '18', fg: accent },
           { label: 'Neutral', bg: muted + '22', fg: muted },
           { label: 'Success', bg: '#16a34a22', fg: '#16a34a' },
         ].map(({ label, bg: badgeBg, fg }) => (
-          <span key={label} style={{ padding: '3px 10px', borderRadius: '9999px', background: badgeBg, color: fg, fontSize: 11, fontWeight: 500 }}>
+          <span
+            key={label}
+            style={{
+              padding: '3px 10px',
+              borderRadius: '9999px',
+              background: badgeBg,
+              color: fg,
+              fontSize: 11,
+              fontWeight: 500,
+            }}
+          >
             {label}
           </span>
         ))}
@@ -191,17 +526,55 @@ function ComponentPreview({ tokens, primaryFont }: { tokens: DSTokens; displayFo
       {/* Inputs */}
       <div className="mint-grid-2">
         <div>
-          <div style={{ fontSize: 11, color: muted, marginBottom: 4, fontFamily: `'${primaryFont}', sans-serif` }}>Email</div>
-          <div style={{ padding: '7px 10px', border: `1px solid ${muted}40`, borderRadius: radiusSm, background: surface, fontSize: 12, color: muted }}>
+          <div
+            style={{
+              fontSize: 11,
+              color: muted,
+              marginBottom: 4,
+              fontFamily: `'${primaryFont}', sans-serif`,
+            }}
+          >
+            Email
+          </div>
+          <div
+            style={{
+              padding: '7px 10px',
+              border: `1px solid ${muted}40`,
+              borderRadius: radiusSm,
+              background: surface,
+              fontSize: 12,
+              color: muted,
+            }}
+          >
             hello@example.com
           </div>
         </div>
         <div>
-          <div style={{ fontSize: 11, color: muted, marginBottom: 4, fontFamily: `'${primaryFont}', sans-serif` }}>Error state</div>
-          <div style={{ padding: '7px 10px', border: `1px solid ${accent}60`, borderRadius: radiusSm, background: surface, fontSize: 12, color: textColor }}>
+          <div
+            style={{
+              fontSize: 11,
+              color: muted,
+              marginBottom: 4,
+              fontFamily: `'${primaryFont}', sans-serif`,
+            }}
+          >
+            Error state
+          </div>
+          <div
+            style={{
+              padding: '7px 10px',
+              border: `1px solid ${accent}60`,
+              borderRadius: radiusSm,
+              background: surface,
+              fontSize: 12,
+              color: textColor,
+            }}
+          >
             invalid field
           </div>
-          <div style={{ fontSize: 10, color: accent, marginTop: 3 }}>This field is required</div>
+          <div style={{ fontSize: 10, color: accent, marginTop: 3 }}>
+            This field is required
+          </div>
         </div>
       </div>
     </div>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,3 @@
 import coreWebVitals from 'eslint-config-next/core-web-vitals'
 
-export default [
-  ...coreWebVitals,
-]
+export default [...coreWebVitals]

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi } from 'vitest'
 import { AnthropicLlmClient } from '../llm_providers/anthropic/client.mjs'
-import { CssAuditor, getCssAuditor, buildCssAuditorFromSettingsAndFlags } from '../css-auditor.mjs'
-import { setupFixture, saveRecordedFixture } from './helpers/anthropic-recorder.mjs'
+import {
+  CssAuditor,
+  buildCssAuditorFromSettingsAndFlags,
+} from '../css-auditor.mjs'
+import {
+  setupFixture,
+  saveRecordedFixture,
+} from './helpers/anthropic-recorder.mjs'
 import { buildAuditPrompt } from '../prompts.mjs'
 
 const RECORD_MODE = process.env.RECORD_FIXTURES === '1'
-
 
 describe('AnthropicLlmClient', () => {
   it('returns text on successful 200 response', async () => {
@@ -16,9 +21,7 @@ describe('AnthropicLlmClient', () => {
     if (RECORD_MODE) {
       const apiKey = process.env.ANTHROPIC_API_KEY
       if (!apiKey) {
-        throw new Error(
-          'ANTHROPIC_API_KEY is required when RECORD_FIXTURES=1'
-        )
+        throw new Error('ANTHROPIC_API_KEY is required when RECORD_FIXTURES=1')
       }
 
       const realFetch = globalThis.fetch.bind(globalThis)
@@ -64,9 +67,9 @@ describe('AnthropicLlmClient', () => {
   })
 
   it('throws when apiKey is missing', async () => {
-    expect(() => new AnthropicLlmClient({ apiKey: undefined, modelName: undefined })).toThrow(
-      'ANTHROPIC_API_KEY is required'
-    )
+    expect(
+      () => new AnthropicLlmClient({ apiKey: undefined, modelName: undefined })
+    ).toThrow('ANTHROPIC_API_KEY is required')
   })
 
   it.each([
@@ -80,24 +83,21 @@ describe('AnthropicLlmClient', () => {
     [500, 'api_error', 'Internal error'],
     [504, 'timeout_error', 'Request timeout'],
     [529, 'overloaded_error', 'API overloaded'],
-  ])(
-    'throws on %i %s',
-    async (status, type, message) => {
-      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-        ok: false,
-        status,
-        json: async () => ({
-          error: { type, message },
-        }),
-      })
+  ])('throws on %i %s', async (status, type, message) => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status,
+      json: async () => ({
+        error: { type, message },
+      }),
+    })
 
-      const client = new AnthropicLlmClient({ apiKey: 'sk-test' })
+    const client = new AnthropicLlmClient({ apiKey: 'sk-test' })
 
-      await expect(client.sendPrompt('test', 3000)).rejects.toThrow(message)
+    await expect(client.sendPrompt('test', 3000)).rejects.toThrow(message)
 
-      fetchSpy.mockRestore()
-    }
-  )
+    fetchSpy.mockRestore()
+  })
 
   it('throws generic error when response message is missing', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
@@ -124,7 +124,10 @@ describe('AnthropicLlmClient', () => {
       }),
     })
 
-    const client = new AnthropicLlmClient({ apiKey: 'sk-test', modelName: 'claude-sonnet-4-20250514' })
+    const client = new AnthropicLlmClient({
+      apiKey: 'sk-test',
+      modelName: 'claude-sonnet-4-20250514',
+    })
     const result = await client.sendPrompt('hello world', 3000)
 
     expect(result).toBe('hello')
@@ -152,8 +155,14 @@ describe('AnthropicLlmClient', () => {
       }),
     })
 
-    const client = new AnthropicLlmClient({ apiKey: 'sk-test', modelName: 'claude-sonnet-4-20250514' })
-    await client.sendPrompt({ content: 'user prompt', system: 'system prompt' }, 3000)
+    const client = new AnthropicLlmClient({
+      apiKey: 'sk-test',
+      modelName: 'claude-sonnet-4-20250514',
+    })
+    await client.sendPrompt(
+      { content: 'user prompt', system: 'system prompt' },
+      3000
+    )
 
     expect(fetchSpy).toHaveBeenCalledWith(
       'https://api.anthropic.com/v1/messages',
@@ -176,7 +185,9 @@ describe('CssAuditor', () => {
     const rawResponse = '{"brand":"test","chaosScore":5}'
     const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
     const mockClient = { sendPrompt: sendPromptSpy }
-    const auditor = new CssAuditor(mockClient, { maxTokens: { audit: 3000, parse: 4000, export: 6000 } })
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
 
     const prompt = { content: 'test', system: 'sys' }
     const result = await auditor.audit(prompt)
@@ -189,7 +200,9 @@ describe('CssAuditor', () => {
     const rawResponse = '```json\n{"brand":"test","chaosScore":5}\n```'
     const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
     const mockClient = { sendPrompt: sendPromptSpy }
-    const auditor = new CssAuditor(mockClient, { maxTokens: { audit: 3000, parse: 4000, export: 6000 } })
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
 
     const result = await auditor.audit('test prompt')
 
@@ -200,7 +213,9 @@ describe('CssAuditor', () => {
     const rawResponse = '{"brand":"test","colors":[]}'
     const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
     const mockClient = { sendPrompt: sendPromptSpy }
-    const auditor = new CssAuditor(mockClient, { maxTokens: { audit: 3000, parse: 4000, export: 6000 } })
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
 
     const prompt = { content: 'test', system: 'sys' }
     const result = await auditor.parse(prompt)
@@ -213,7 +228,9 @@ describe('CssAuditor', () => {
     const rawResponse = '```css\n:root { --color: red; }\n```'
     const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
     const mockClient = { sendPrompt: sendPromptSpy }
-    const auditor = new CssAuditor(mockClient, { maxTokens: { audit: 3000, parse: 4000, export: 6000 } })
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
 
     const prompt = { content: 'test', system: 'sys' }
     const result = await auditor.export(prompt)
@@ -226,7 +243,9 @@ describe('CssAuditor', () => {
     const rawResponse = ':root { --color: red; }'
     const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
     const mockClient = { sendPrompt: sendPromptSpy }
-    const auditor = new CssAuditor(mockClient, { maxTokens: { audit: 3000, parse: 4000, export: 6000 } })
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
 
     const result = await auditor.export('test prompt')
 
@@ -236,11 +255,15 @@ describe('CssAuditor', () => {
 
 describe('CssAuditor.stripFences', () => {
   it('strips a js-fenced code block', () => {
-    expect(CssAuditor.stripFences('```js\nconst x = 1\n```')).toBe('const x = 1')
+    expect(CssAuditor.stripFences('```js\nconst x = 1\n```')).toBe(
+      'const x = 1'
+    )
   })
 
   it('strips a css-fenced code block', () => {
-    expect(CssAuditor.stripFences('```css\nbody { color: red; }\n```')).toBe('body { color: red; }')
+    expect(CssAuditor.stripFences('```css\nbody { color: red; }\n```')).toBe(
+      'body { color: red; }'
+    )
   })
 
   it('returns unfenced input unchanged', () => {
@@ -255,7 +278,9 @@ describe('CssAuditor.stripFences', () => {
 describe('buildCssAuditorFromSettingsAndFlags', () => {
   it('returns CssAuditor wrapping AnthropicLlmClient for anthropic name', () => {
     const testSettings = { llmProviderName: 'anthropic' }
-    const auditor = buildCssAuditorFromSettingsAndFlags(testSettings, { 'api-key': 'sk-test' })
+    const auditor = buildCssAuditorFromSettingsAndFlags(testSettings, {
+      'api-key': 'sk-test',
+    })
     expect(auditor).toBeInstanceOf(CssAuditor)
     expect(auditor.client).toBeInstanceOf(AnthropicLlmClient)
   })

--- a/lib/__tests__/helpers/anthropic-recorder.mjs
+++ b/lib/__tests__/helpers/anthropic-recorder.mjs
@@ -21,7 +21,7 @@ export async function loadFixture(name) {
       throw new Error(
         `Fixture "${name}" not found at ${filePath}\n\n` +
           `To record it, run:\n` +
-           `  RECORD_FIXTURES=1 npx vitest run lib/__tests__/css-auditor.test.mjs`
+          `  RECORD_FIXTURES=1 npx vitest run lib/__tests__/css-auditor.test.mjs`
       )
     }
     throw err
@@ -48,11 +48,7 @@ export async function saveRecordedFixture(name, captured) {
   }
 
   const filePath = path.join(FIXTURES_DIR, `${name}.json`)
-  await fs.writeFile(
-    filePath,
-    JSON.stringify(fixture, null, 2) + '\n',
-    'utf8'
-  )
+  await fs.writeFile(filePath, JSON.stringify(fixture, null, 2) + '\n', 'utf8')
 }
 
 /** Wire a Vitest fetch spy to replay a saved fixture instead of making real network calls. */

--- a/lib/__tests__/playground-cache.test.ts
+++ b/lib/__tests__/playground-cache.test.ts
@@ -62,14 +62,21 @@ const AUDIT: AuditReport = {
 const TOKENS: DSTokens = {
   brand: 'TestBrand',
   colors: [],
-  typography: { fontFamilies: {}, fontSizes: {}, fontWeights: {}, lineHeights: {} },
+  typography: {
+    fontFamilies: {},
+    fontSizes: {},
+    fontWeights: {},
+    lineHeights: {},
+  },
   spacing: {},
   borderRadius: {},
   shadows: {},
 }
 
 const DECISIONS: UserDecisions = {
-  colors: [{ clusterId: 'c1', name: 'primary', value: '#6366f1', include: true }],
+  colors: [
+    { clusterId: 'c1', name: 'primary', value: '#6366f1', include: true },
+  ],
   fonts: ['Inter'],
   spacingScale: { '1': '4px', '2': '8px' },
   lineHeights: {},
@@ -81,19 +88,27 @@ const CSS = 'body { color: #6366f1; font-size: 16px; }'
 
 describe('preprocessCss', () => {
   it('strips block comments', () => {
-    expect(preprocessCss('/* comment */ body { color: red; }')).toBe('body { color: red; }')
+    expect(preprocessCss('/* comment */ body { color: red; }')).toBe(
+      'body { color: red; }'
+    )
   })
 
   it('strips line comments', () => {
-    expect(preprocessCss('// comment\nbody { color: red; }')).toBe('body { color: red; }')
+    expect(preprocessCss('// comment\nbody { color: red; }')).toBe(
+      'body { color: red; }'
+    )
   })
 
   it('collapses multiple whitespace into a single space', () => {
-    expect(preprocessCss('body  {   color:   red;   }')).toBe('body { color: red; }')
+    expect(preprocessCss('body  {   color:   red;   }')).toBe(
+      'body { color: red; }'
+    )
   })
 
   it('trims leading and trailing whitespace', () => {
-    expect(preprocessCss('  body { color: red; }  ')).toBe('body { color: red; }')
+    expect(preprocessCss('  body { color: red; }  ')).toBe(
+      'body { color: red; }'
+    )
   })
 })
 

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -36,15 +36,21 @@ describe('resolveTarget', () => {
 
 describe('preprocessCss', () => {
   it('strips block comments', () => {
-    expect(preprocessCss('/* comment */ body { color: red; }')).toBe('body { color: red; }')
+    expect(preprocessCss('/* comment */ body { color: red; }')).toBe(
+      'body { color: red; }'
+    )
   })
 
   it('strips line comments', () => {
-    expect(preprocessCss('// comment\nbody { color: red; }')).toBe('body { color: red; }')
+    expect(preprocessCss('// comment\nbody { color: red; }')).toBe(
+      'body { color: red; }'
+    )
   })
 
   it('collapses multiple whitespace to a single space', () => {
-    expect(preprocessCss('body  {   color:   red;   }')).toBe('body { color: red; }')
+    expect(preprocessCss('body  {   color:   red;   }')).toBe(
+      'body { color: red; }'
+    )
   })
 
   it('returns already-clean input unchanged', () => {
@@ -134,8 +140,20 @@ describe('buildAuditPrompt', () => {
 
   it('includes all allowed semantic color names', () => {
     const content = buildAuditPrompt(css).content
-    for (const name of ['primary', 'secondary', 'accent', 'background', 'surface',
-      'text', 'muted', 'border', 'error', 'success', 'warning', 'info']) {
+    for (const name of [
+      'primary',
+      'secondary',
+      'accent',
+      'background',
+      'surface',
+      'text',
+      'muted',
+      'border',
+      'error',
+      'success',
+      'warning',
+      'info',
+    ]) {
       expect(content).toContain(name)
     }
   })
@@ -187,7 +205,7 @@ describe('buildResolvePrompt', () => {
   const decisions = {
     colors: [{ include: true, name: 'primary', value: '#6366f1' }],
     fonts: ['Inter'],
-    spacingScale: { '1': '4px', '2': '8px' },
+    spacingScale: { 1: '4px', 2: '8px' },
     lineHeights: { tight: 1.2, normal: 1.5 },
   }
 
@@ -230,7 +248,7 @@ describe('buildExportPrompt', () => {
     brand: 'test',
     colors: [{ name: 'primary', value: '#6366f1', scale: {} }],
     typography: { fontFamilies: { body: 'Inter' } },
-    spacing: { '1': '4px' },
+    spacing: { 1: '4px' },
   }
 
   it('returns an object with content and null system for a known target', () => {
@@ -241,15 +259,21 @@ describe('buildExportPrompt', () => {
   })
 
   it('returns a non-empty content string for css-variables target', () => {
-    expect(buildExportPrompt(tokens, 'css-variables').content.length).toBeGreaterThan(0)
+    expect(
+      buildExportPrompt(tokens, 'css-variables').content.length
+    ).toBeGreaterThan(0)
   })
 
   it('returns a non-empty content string for react-component target', () => {
-    expect(buildExportPrompt(tokens, 'react-component').content.length).toBeGreaterThan(0)
+    expect(
+      buildExportPrompt(tokens, 'react-component').content.length
+    ).toBeGreaterThan(0)
   })
 
   it('embeds the tokens JSON in the output', () => {
-    expect(buildExportPrompt(tokens, 'css-variables').content).toContain('"primary"')
+    expect(buildExportPrompt(tokens, 'css-variables').content).toContain(
+      '"primary"'
+    )
   })
 
   it('returns null for an unknown target', () => {

--- a/lib/css-auditor.mjs
+++ b/lib/css-auditor.mjs
@@ -1,6 +1,6 @@
 import { AnthropicLlmClient } from './llm_providers/anthropic/client.mjs'
 import { llmProviderConfigs } from './llm_providers/config.mjs'
-import { settings } from './settings.mjs' 
+import { settings } from './settings.mjs'
 
 export class CssAuditor {
   constructor(client, config) {
@@ -17,31 +17,46 @@ export class CssAuditor {
   }
 
   async audit(prompt) {
-    const text = await this.client.sendPrompt(prompt, this.config.maxTokens.audit)
+    const text = await this.client.sendPrompt(
+      prompt,
+      this.config.maxTokens.audit
+    )
     return JSON.parse(CssAuditor.stripFences(text))
   }
 
   async parse(prompt) {
-    const text = await this.client.sendPrompt(prompt, this.config.maxTokens.parse)
+    const text = await this.client.sendPrompt(
+      prompt,
+      this.config.maxTokens.parse
+    )
     return JSON.parse(CssAuditor.stripFences(text))
   }
 
   async export(prompt) {
-    const text = await this.client.sendPrompt(prompt, this.config.maxTokens.export)
+    const text = await this.client.sendPrompt(
+      prompt,
+      this.config.maxTokens.export
+    )
     return CssAuditor.stripFences(text)
   }
 }
 
 export function buildCssAuditorFromSettingsAndFlags(appSettings, flags) {
-
   const llmProviderName = appSettings.llmProviderName
   const llmProviderConfig = llmProviderConfigs[llmProviderName]
-  if (!llmProviderConfig) throw new Error(`Unsupported LLM provider: ${llmProviderName}`)
+  if (!llmProviderConfig)
+    throw new Error(`Unsupported LLM provider: ${llmProviderName}`)
 
-  const apiKey = typeof flags?.['api-key'] === 'string' ? flags['api-key'] : (appSettings.apiKey ?? llmProviderConfig.apiKey)
+  const apiKey =
+    typeof flags?.['api-key'] === 'string'
+      ? flags['api-key']
+      : (appSettings.apiKey ?? llmProviderConfig.apiKey)
   let client = undefined
   if (llmProviderName == 'anthropic')
-    client = new AnthropicLlmClient({ apiKey, modelName: llmProviderConfig.model })
+    client = new AnthropicLlmClient({
+      apiKey,
+      modelName: llmProviderConfig.model,
+    })
 
   return new CssAuditor(client, llmProviderConfig.cssAuditor)
 }

--- a/lib/css-utils.mjs
+++ b/lib/css-utils.mjs
@@ -1,7 +1,7 @@
 export function preprocessCss(raw) {
   return String(raw)
-    .replace(/\/\*[\s\S]*?\*\//g, ' ')  // block comments
-    .replace(/\/\/[^\n]*/g, ' ')         // line comments (SCSS/LESS)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ') // block comments
+    .replace(/\/\/[^\n]*/g, ' ') // line comments (SCSS/LESS)
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/lib/llm_providers/anthropic/client.mjs
+++ b/lib/llm_providers/anthropic/client.mjs
@@ -13,8 +13,6 @@ export class AnthropicLlmClient extends LlmClient {
   }
 
   async sendPrompt(prompt, maxToken) {
-    
-
     const content = typeof prompt === 'string' ? prompt : prompt.content
     const system = typeof prompt === 'string' ? undefined : prompt.system
 

--- a/lib/llm_providers/anthropic/config.mjs
+++ b/lib/llm_providers/anthropic/config.mjs
@@ -1,13 +1,11 @@
-
-
 export const anthropicConfig = {
   model: 'claude-sonnet-4-20250514',
   apiKey: process.env.ANTHROPIC_API_KEY ?? undefined,
   cssAuditor: {
     maxTokens: {
-        audit: 3000,
-        parse: 4000,
-        export: 6000,
+      audit: 3000,
+      parse: 4000,
+      export: 6000,
     },
-  }
+  },
 }

--- a/lib/llm_providers/config.mjs
+++ b/lib/llm_providers/config.mjs
@@ -1,5 +1,5 @@
-import { anthropicConfig } from "./anthropic/config.mjs";
+import { anthropicConfig } from './anthropic/config.mjs'
 
 export const llmProviderConfigs = {
-    anthropic: anthropicConfig
+  anthropic: anthropicConfig,
 }

--- a/lib/playground-cache.ts
+++ b/lib/playground-cache.ts
@@ -6,8 +6,13 @@ const AUDIT_PREFIX = 'mint-audit-cache-'
 const RESOLVE_PREFIX = 'mint-resolve-cache-'
 
 export async function hashContent(content: string): Promise<string> {
-  const buf = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(content))
-  return Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('')
+  const buf = await globalThis.crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(content)
+  )
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
 }
 
 export async function readAuditCache(css: string): Promise<AuditReport | null> {
@@ -21,16 +26,29 @@ export async function readAuditCache(css: string): Promise<AuditReport | null> {
   }
 }
 
-export async function writeAuditCache(css: string, audit: AuditReport): Promise<void> {
+export async function writeAuditCache(
+  css: string,
+  audit: AuditReport
+): Promise<void> {
   try {
     const hash = await hashContent(preprocessCss(css))
-    localStorage.setItem(`${AUDIT_PREFIX}${hash}`, JSON.stringify({ audit, savedAt: new Date().toISOString() }))
-  } catch { /* storage full or disabled */ }
+    localStorage.setItem(
+      `${AUDIT_PREFIX}${hash}`,
+      JSON.stringify({ audit, savedAt: new Date().toISOString() })
+    )
+  } catch {
+    /* storage full or disabled */
+  }
 }
 
-export async function readResolveCache(css: string, decisions: UserDecisions): Promise<DSTokens | null> {
+export async function readResolveCache(
+  css: string,
+  decisions: UserDecisions
+): Promise<DSTokens | null> {
   try {
-    const hash = await hashContent(preprocessCss(css) + '|' + JSON.stringify(decisions))
+    const hash = await hashContent(
+      preprocessCss(css) + '|' + JSON.stringify(decisions)
+    )
     const raw = localStorage.getItem(`${RESOLVE_PREFIX}${hash}`)
     if (!raw) return null
     return (JSON.parse(raw) as { tokens: DSTokens }).tokens ?? null
@@ -39,11 +57,22 @@ export async function readResolveCache(css: string, decisions: UserDecisions): P
   }
 }
 
-export async function writeResolveCache(css: string, decisions: UserDecisions, tokens: DSTokens): Promise<void> {
+export async function writeResolveCache(
+  css: string,
+  decisions: UserDecisions,
+  tokens: DSTokens
+): Promise<void> {
   try {
-    const hash = await hashContent(preprocessCss(css) + '|' + JSON.stringify(decisions))
-    localStorage.setItem(`${RESOLVE_PREFIX}${hash}`, JSON.stringify({ tokens, savedAt: new Date().toISOString() }))
-  } catch { /* storage full or disabled */ }
+    const hash = await hashContent(
+      preprocessCss(css) + '|' + JSON.stringify(decisions)
+    )
+    localStorage.setItem(
+      `${RESOLVE_PREFIX}${hash}`,
+      JSON.stringify({ tokens, savedAt: new Date().toISOString() })
+    )
+  } catch {
+    /* storage full or disabled */
+  }
 }
 
 export function clearPlaygroundCache(): void {
@@ -55,6 +84,8 @@ export function clearPlaygroundCache(): void {
         toRemove.push(k)
       }
     }
-    toRemove.forEach(k => localStorage.removeItem(k))
-  } catch { /* ignore */ }
+    toRemove.forEach((k) => localStorage.removeItem(k))
+  } catch {
+    /* ignore */
+  }
 }

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -165,7 +165,9 @@ Return ONLY valid JSON matching this exact DSTokens structure. No markdown fence
 }
 
 const EXPORT_PROMPTS = {
-  'css-variables': (shared) => `Generate a complete CSS file with custom properties for these design tokens.${shared}
+  'css-variables': (
+    shared
+  ) => `Generate a complete CSS file with custom properties for these design tokens.${shared}
 
 Requirements:
 - :root { } block with ALL tokens as CSS variables (--color-primary, --color-primary-50, etc.)
@@ -174,7 +176,9 @@ Requirements:
 - Include @import for Google Fonts if fontFamilies are defined
 - Add a /* Usage */ comment at the top with quick examples`,
 
-  'scss-variables': (shared) => `Generate a complete SCSS file with variables and mixins for these design tokens.${shared}
+  'scss-variables': (
+    shared
+  ) => `Generate a complete SCSS file with variables and mixins for these design tokens.${shared}
 
 Requirements:
 - All tokens as $variable-name: value (e.g. $color-primary: #...)
@@ -184,7 +188,9 @@ Requirements:
 - Functions: color($name, $step: 500) to access color maps
 - @forward and @use compatible structure`,
 
-  'js-tokens': (shared) => `Generate a complete TypeScript tokens file for these design tokens.${shared}
+  'js-tokens': (
+    shared
+  ) => `Generate a complete TypeScript tokens file for these design tokens.${shared}
 
 Requirements:
 - Typed interfaces for each token category
@@ -194,7 +200,9 @@ Requirements:
 - Export named types for use in other files
 - Compatible with both ESM and CJS via dual exports comment`,
 
-  'tailwind-config': (shared) => `Generate a complete tailwind.config.js for these design tokens.${shared}
+  'tailwind-config': (
+    shared
+  ) => `Generate a complete tailwind.config.js for these design tokens.${shared}
 
 Requirements:
 - Full module.exports with theme.extend
@@ -206,7 +214,9 @@ Requirements:
 - darkMode: 'class'
 - Add a @type {import('tailwindcss').Config} JSDoc`,
 
-  'styled-components': (shared) => `Generate a complete Styled Components theme file in TypeScript for these design tokens.${shared}
+  'styled-components': (
+    shared
+  ) => `Generate a complete Styled Components theme file in TypeScript for these design tokens.${shared}
 
 Requirements:
 - DefaultTheme interface declaration (module augmentation)
@@ -215,7 +225,9 @@ Requirements:
 - ThemeProvider usage example in a comment
 - Export: { lightTheme, darkTheme, DefaultTheme }`,
 
-  'emotion': (shared) => `Generate a complete Emotion theme file in TypeScript for these design tokens.${shared}
+  emotion: (
+    shared
+  ) => `Generate a complete Emotion theme file in TypeScript for these design tokens.${shared}
 
 Requirements:
 - Theme interface with all token categories
@@ -225,7 +237,9 @@ Requirements:
 - Global styles snippet using the theme
 - Export: { lightTheme, darkTheme, Theme }`,
 
-  'css-modules': (shared) => `Generate a complete CSS Modules file for these design tokens.${shared}
+  'css-modules': (
+    shared
+  ) => `Generate a complete CSS Modules file for these design tokens.${shared}
 
 Requirements:
 - @value declarations for all token values at the top
@@ -237,7 +251,9 @@ Requirements:
   .text-primary, .text-secondary, .text-muted
 - Each class must only use @value references, not hardcoded values`,
 
-  'react-component': (shared) => `Generate production-ready React TypeScript components using these design tokens.${shared}
+  'react-component': (
+    shared
+  ) => `Generate production-ready React TypeScript components using these design tokens.${shared}
 
 Generate these 4 components in a single file:
 
@@ -261,7 +277,9 @@ Requirements:
 - Full TypeScript interfaces with JSDoc
 - Named exports for each component`,
 
-  'vue-component': (shared) => `Generate production-ready Vue 3 components using these design tokens.${shared}
+  'vue-component': (
+    shared
+  ) => `Generate production-ready Vue 3 components using these design tokens.${shared}
 
 Generate Button, Card, Badge, and Input components in a single file using Vue's defineComponent per component pattern.
 
@@ -274,7 +292,9 @@ Requirements:
 - Export all 4 components
 - Add a "How to register" comment at the top`,
 
-  'svelte-component': (shared) => `Generate production-ready Svelte components using these design tokens.${shared}
+  'svelte-component': (
+    shared
+  ) => `Generate production-ready Svelte components using these design tokens.${shared}
 
 Generate Button, Card, Badge, and Input as separate component blocks in a single file (separated by // --- ComponentName --- comments so the user can split them).
 
@@ -285,7 +305,9 @@ Requirements:
 - Slot usage where appropriate
 - Add a usage example in a comment per component`,
 
-  'astro-component': (shared) => `Generate production-ready Astro components using these design tokens.${shared}
+  'astro-component': (
+    shared
+  ) => `Generate production-ready Astro components using these design tokens.${shared}
 
 Generate Button, Card, Badge, and Input as separate .astro component blocks in a single file (separated by // --- ComponentName.astro --- comments so the user can split them into individual files).
 
@@ -301,7 +323,9 @@ Requirements:
 - Add a <!-- Usage example --> comment per component showing how to import and use it
 - Make the components compatible with both SSR and static Astro projects`,
 
-  'angular-component': (shared) => `Generate production-ready Angular standalone components using these design tokens.${shared}
+  'angular-component': (
+    shared
+  ) => `Generate production-ready Angular standalone components using these design tokens.${shared}
 
 Generate these 4 standalone components in a single file:
 
@@ -336,7 +360,9 @@ Requirements:
 - Add a "// Usage" comment at the top showing how to import and add to standalone imports
 - Named exports for each component`,
 
-  'angular-legacy-component': (shared) => `Generate production-ready Angular components using the classic @NgModule pattern with these design tokens.${shared}
+  'angular-legacy-component': (
+    shared
+  ) => `Generate production-ready Angular components using the classic @NgModule pattern with these design tokens.${shared}
 
 Generate these 4 classic components plus a MintDesignSystemModule in a single file:
 
@@ -383,47 +409,58 @@ export function buildExportPrompt(tokens, target) {
 // File-naming metadata for CLI output. UI metadata (label, description,
 // category) lives in lib/types.ts so the playground can group nicely.
 export const EXPORT_OUTPUT = {
-  'css-variables':     { filename: 'variables',        ext: 'css' },
-  'scss-variables':    { filename: '_tokens',          ext: 'scss' },
-  'js-tokens':         { filename: 'tokens',           ext: 'ts' },
-  'tailwind-config':   { filename: 'tailwind.config',  ext: 'js' },
-  'styled-components': { filename: 'theme',            ext: 'ts' },
-  'emotion':           { filename: 'theme',            ext: 'ts' },
-  'css-modules':       { filename: 'tokens',           ext: 'module.css' },
-  'react-component':   { filename: 'components',       ext: 'tsx' },
-  'vue-component':     { filename: 'components',       ext: 'vue' },
-  'svelte-component':  { filename: 'components',       ext: 'svelte' },
-  'astro-component':   { filename: 'components',       ext: 'astro' },
-  'angular-component': { filename: 'components',       ext: 'ts' },
-  'angular-legacy-component':    { filename: 'components.module', ext: 'ts' },
+  'css-variables': { filename: 'variables', ext: 'css' },
+  'scss-variables': { filename: '_tokens', ext: 'scss' },
+  'js-tokens': { filename: 'tokens', ext: 'ts' },
+  'tailwind-config': { filename: 'tailwind.config', ext: 'js' },
+  'styled-components': { filename: 'theme', ext: 'ts' },
+  emotion: { filename: 'theme', ext: 'ts' },
+  'css-modules': { filename: 'tokens', ext: 'module.css' },
+  'react-component': { filename: 'components', ext: 'tsx' },
+  'vue-component': { filename: 'components', ext: 'vue' },
+  'svelte-component': { filename: 'components', ext: 'svelte' },
+  'astro-component': { filename: 'components', ext: 'astro' },
+  'angular-component': { filename: 'components', ext: 'ts' },
+  'angular-legacy-component': { filename: 'components.module', ext: 'ts' },
 }
 
 // Short aliases the CLI accepts for --target.
 export const TARGET_ALIASES = {
-  css:                'css-variables',
-  scss:               'scss-variables',
-  sass:               'scss-variables',
-  js:                 'js-tokens',
-  ts:                 'js-tokens',
-  tokens:             'js-tokens',
-  tailwind:           'tailwind-config',
-  'styled':           'styled-components',
-  'css-modules':      'css-modules',
-  modules:            'css-modules',
-  emotion:            'emotion',
-  react:              'react-component',
-  vue:                'vue-component',
-  svelte:             'svelte-component',
-  astro:              'astro-component',
-  angular:            'angular-component',
-  'angular-legacy':   'angular-legacy-component',
+  css: 'css-variables',
+  scss: 'scss-variables',
+  sass: 'scss-variables',
+  js: 'js-tokens',
+  ts: 'js-tokens',
+  tokens: 'js-tokens',
+  tailwind: 'tailwind-config',
+  styled: 'styled-components',
+  'css-modules': 'css-modules',
+  modules: 'css-modules',
+  emotion: 'emotion',
+  react: 'react-component',
+  vue: 'vue-component',
+  svelte: 'svelte-component',
+  astro: 'astro-component',
+  angular: 'angular-component',
+  'angular-legacy': 'angular-legacy-component',
 }
 
 // Curated short list shown in --help and validation errors. Keeps the public
 // surface friendly; full alias map above remains accepted by resolveTarget.
 export const ADVERTISED_TARGETS = [
-  'tailwind', 'react', 'vue', 'svelte', 'astro',
-  'css', 'scss', 'ts', 'css-modules', 'styled', 'emotion', 'angular', 'angular-legacy',
+  'tailwind',
+  'react',
+  'vue',
+  'svelte',
+  'astro',
+  'css',
+  'scss',
+  'ts',
+  'css-modules',
+  'styled',
+  'emotion',
+  'angular',
+  'angular-legacy',
 ]
 
 export function resolveTarget(input) {
@@ -432,5 +469,3 @@ export function resolveTarget(input) {
   if (EXPORT_OUTPUT[lc]) return lc
   return TARGET_ALIASES[lc] || null
 }
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "husky": "^9.1.0",
         "lint-staged": "^15.5.0",
         "next": "^15.1.0",
+        "prettier": "^3.8.4",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "release-it": "^20.0.1",
@@ -9076,6 +9077,22 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "test:coverage": "vitest run --coverage",
     "test:record": "RECORD_FIXTURES=1 vitest run",
     "lint": "next lint",
+    "format:check": "prettier --check .",
+    "format:write": "prettier --write .",
     "typecheck": "tsc --noEmit",
     "prepare": "husky",
     "release": "release-it",
@@ -60,6 +62,7 @@
     "husky": "^9.1.0",
     "lint-staged": "^15.5.0",
     "next": "^15.1.0",
+    "prettier": "^3.8.4",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "release-it": "^20.0.1",
@@ -67,6 +70,10 @@
     "vitest": "^3.1.0"
   },
   "lint-staged": {
-    "*.{js,mjs,cjs,ts,tsx}": "next lint --file"
+    "*.{js,mjs,cjs,ts,tsx}": [
+      "next lint --file",
+      "prettier --check"
+    ],
+    "*.{json,css,md}": "prettier --check"
   }
 }


### PR DESCRIPTION
## Summary

- Set up Prettier with Vercel-aligned config (semi: false, singleQuote: true, etc.)
- Formatted all source files and added `format:check` to pre-commit hooks and CI pipeline
- Updated CI workflow to run `format:check` before lint

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [x] Dependency update

## How to test

1. Run `npm run format:check` and verify it exits cleanly
2. Introduce a style deviation (e.g., replace a single quote with a double quote in a .ts file) and confirm `format:check` catches it
3. Run `npm run format:write` and re-run `format:check` to confirm it passes
4. Review CI workflow, now it includes a new `format:check` step

## Checklist

- [x] `npx tsc --noEmit` passes with no errors
- [x] Tested with real CSS input through the full audit → tokens → export flow
- [x] UI is responsive on mobile (tested at 375px width)
- [x] No new Spanish strings introduced — all user-facing text is English
- [x] No hardcoded colors or values that should be CSS variables

Closes #21 