### PR TITLE
feat: add CSS layout linting rules for a11y and modern practices

### DIFF
--- a/BUILD-PLAN-issue-5.md
+++ b/BUILD-PLAN-issue-5.md
@@ -1,0 +1,12 @@
+# BUILD #5 — CSS layout linting rules for a11y and modern practices
+
+Card: https://github.com/nujovich/mint-radar/issues/5
+
+Based on pain points from Patrick Brosset's analysis and State of CSS 2025 data.
+
+## Milestones
+
+- [ ] Milestone 1 — Layout ordering accessibility rules: detect flex/grid order that breaks DOM order, and visual reordering without tabindex fallback
+- [ ] Milestone 2 — Modern CSS best practice rules: detect grid misuse (single-column grids), legacy centering techniques, min-width:0 hacks, and fragile nested selectors
+- [ ] Milestone 3 — Modern feature adoption suggestions: detect opportunities to use @layer and @container queries
+- [ ] Milestone 4 — Overflow and wrap safety rules: detect missing overflow handling in grid/flex containers and flex containers without flex-wrap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to this project will be documented in this file.
 - `mint-ds validate` — DTCG v1 validation for `tokens.json`: structural checks plus
   semantic checks (broken/circular references, naming consistency, reference type
   mismatches), `--json` output, `--no-semantic` flag, and CI templates under `templates/dtcg/`.
+- CSS layout linting rules added to the Claude audit:
+  - **Layout accessibility** — flag grid/flex `order` that breaks DOM order and visual reordering without a `tabindex` fallback
+  - **Modern best practices** — flag single-column grids, legacy centering, the flex `min-width: 0` hack, and fragile nested selectors
+  - **Feature adoption** — suggest `@layer` cascade organization and `@container` queries where width-scoped `@media` queries are used
+  - **Overflow & wrap safety** — flag flex containers missing `flex-wrap` and sized grid/flex containers without overflow handling
+- Chaos score now factors in layout-accessibility (+1 when ≥ 3 issues) and overflow-safety (+1 when ≥ 4 issues) counts
+- New `AuditReport` fields: `layoutA11yIssues`, `modernPracticeIssues`, `adoptionSuggestions`, `overflowSafetyIssues`
 
 ## [0.1.0] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,28 @@ Both share the same prompts and Claude pipeline.
 CSS / SCSS / HTML  →  Claude Audit  →  Review & curate  →  Clean tokens  →  Export
 ```
 
-1. **Audit** — Claude analyzes your CSS, groups near-duplicate colors into clusters, detects fonts, flags spacing values that don't fit a 4px grid, and identifies duplicate transition/animation declarations.
+1. **Audit** — Claude analyzes your CSS, groups near-duplicate colors into clusters, detects fonts, flags spacing values that don't fit a 4px grid, identifies duplicate transition/animation declarations, and lints layout patterns for accessibility and modern-CSS pitfalls (see [CSS layout linting](#css-layout-linting)).
 2. **Curate** — Review each cluster. Pick the canonical color, rename tokens, include or exclude entries, and select which fonts to keep. (CLI applies sensible defaults: include every cluster, keep non-system fonts, use the suggested 4px scale.)
 3. **Export** — Generate production-ready output in any format.
+
+## CSS layout linting
+
+Beyond color, font, and spacing tokens, the audit also lints your CSS for layout accessibility issues and modern-CSS pitfalls. These findings are returned in the raw `AuditReport` (write it to disk with `--report`); the accessibility and overflow checks also feed the chaos score.
+
+| Category                   | Rule                                | Severity   | What it flags                                                                                                                   |
+| -------------------------- | ----------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Layout accessibility**   | `order` breaks DOM order            | warning    | A grid/flex child reordered with `order` so the visual order no longer matches the DOM — breaks keyboard navigation and SR flow |
+|                            | reordering without tabindex         | warning    | An element visually reordered via `order` with no matching `tabindex` adjustment, so keyboard users navigate in DOM order       |
+| **Modern best practices**  | `grid-when-flexbox-wrap-would-work` | suggestion | Single-column grid that a `flex` + `flex-wrap` layout would handle more simply                                                  |
+|                            | `legacy-centering`                  | suggestion | `margin: 0 auto` + fixed width, or absolute-position + `transform` centering, where modern `flex`/`grid` centering is cleaner   |
+|                            | `flex-min-width-zero-hack`          | suggestion | `min-width: 0` on a flex item — the classic overflow workaround that often hides a layout misunderstanding                      |
+|                            | `fragile-nested-selectors`          | suggestion | Selectors coupled to a brittle DOM shape (deep `>` / `+` chains) that a small HTML refactor would break                         |
+| **Feature adoption**       | `use-css-layers`                    | info       | Large stylesheets (20+ rules) with no `@layer` organization                                                                     |
+|                            | `use-container-queries`             | info       | Component-scoped width `@media` queries that a `@container` query would express better                                          |
+| **Overflow & wrap safety** | `flex-wrap-missing`                 | warning    | Flex container without `flex-wrap` — items can't wrap and may overflow on narrow viewports                                      |
+|                            | `missing-overflow-wrap`             | suggestion | Sized grid/flex container (fixed width/height) with no `overflow` handling, so content can be clipped                           |
+
+The chaos score gains **+1** when there are 3 or more layout-accessibility issues and **+1** when there are 4 or more overflow-safety issues. Adoption suggestions are informational only and never affect the score.
 
 ## Example — Frankenstein
 

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -18,6 +18,7 @@ import {
 } from '../lib/prompts.mjs'
 import { getCssAuditor } from '../lib/css-auditor.mjs'
 import { validateFile } from '../lib/dtcg-validator.mjs'
+import { formatLintSummary } from '../lib/audit-summary.mjs'
 
 const require = createRequire(import.meta.url)
 const { version: VERSION } = require('../package.json')
@@ -341,6 +342,8 @@ async function cmdAudit(argv) {
         `  ${audit.colorClusters?.length ?? 0} clusters · ${audit.fonts?.length ?? 0} fonts · ${audit.spacing?.found?.length ?? 0} spacing values · ${audit.motion?.durations?.found?.length ?? 0} motion durations`
       )
     )
+    const lintSummary = formatLintSummary(audit)
+    if (lintSummary) log(styles.dim(`  ${lintSummary}`))
     log('')
   }
   log(styles.green('✓') + ` Tokens written to ${styles.bold(outFile)}`)

--- a/components/AuditView.tsx
+++ b/components/AuditView.tsx
@@ -2,10 +2,18 @@
 
 import { useState } from 'react'
 import type { AuditReport, ColorDecision, UserDecisions } from '@/lib/types'
+import { collectLintGroups } from '@/lib/audit-summary.mjs'
 
 interface Props {
   audit: AuditReport
   onResolve: (decisions: UserDecisions) => void
+}
+
+interface LintIssue {
+  selector?: string
+  rule?: string
+  severity: string
+  reason: string
 }
 
 function nearestScaleValue(
@@ -44,6 +52,7 @@ export default function AuditView({ audit, onResolve }: Props) {
   const lineHeights = audit.lineHeights?.suggestedScale ?? {}
   const motionDurations = audit.motion?.durations?.suggestedScale ?? {}
   const motionEasings = audit.motion?.easings?.suggestedScale ?? {}
+  const lintGroups = collectLintGroups(audit)
 
   const chaosColor =
     audit.chaosScore <= 3
@@ -792,6 +801,87 @@ export default function AuditView({ audit, onResolve }: Props) {
         </div>
       </section>
 
+      {/* Layout linting */}
+      {lintGroups.length > 0 && (
+        <section>
+          <SectionLabel>
+            Layout linting —{' '}
+            {lintGroups.reduce((n, g) => n + g.issues.length, 0)} issue
+            {lintGroups.reduce((n, g) => n + g.issues.length, 0) === 1
+              ? ''
+              : 's'}
+          </SectionLabel>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {lintGroups.map((group) => (
+              <div key={group.key}>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: 'var(--text-faint)',
+                    marginBottom: 8,
+                  }}
+                >
+                  {group.label} ({group.issues.length})
+                </div>
+                <div
+                  style={{ display: 'flex', flexDirection: 'column', gap: 6 }}
+                >
+                  {group.issues.map((issue: LintIssue, i: number) => (
+                    <div
+                      key={`${group.key}-${i}`}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'baseline',
+                        gap: 8,
+                        padding: '8px 12px',
+                        borderRadius: 8,
+                        background: 'var(--surface)',
+                        border: '1px solid var(--border)',
+                      }}
+                    >
+                      <span
+                        style={{
+                          flexShrink: 0,
+                          fontSize: 10,
+                          fontWeight: 600,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.04em',
+                          color: severityColor(issue.severity),
+                        }}
+                      >
+                        {issue.severity}
+                      </span>
+                      <div style={{ minWidth: 0 }}>
+                        <code
+                          style={{
+                            fontSize: 11,
+                            fontFamily: 'var(--mono)',
+                            color: 'var(--text)',
+                          }}
+                        >
+                          {issue.selector || issue.rule || '—'}
+                        </code>
+                        <div
+                          style={{
+                            fontSize: 11,
+                            color: 'var(--text-muted)',
+                            lineHeight: 1.55,
+                            marginTop: 2,
+                          }}
+                        >
+                          {issue.reason}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* CTA */}
       <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 8 }}>
         <button
@@ -827,6 +917,12 @@ export default function AuditView({ audit, onResolve }: Props) {
       </div>
     </div>
   )
+}
+
+function severityColor(severity: string): string {
+  if (severity === 'warning') return '#fbbf24'
+  if (severity === 'suggestion') return '#818cf8'
+  return 'var(--text-faint)'
 }
 
 function SectionLabel({ children }: { children: React.ReactNode }) {

--- a/lib/__tests__/audit-summary.test.mjs
+++ b/lib/__tests__/audit-summary.test.mjs
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { formatLintSummary } from '../audit-summary.mjs'
+
+describe('formatLintSummary', () => {
+  it('returns empty string when no linting fields are present', () => {
+    const audit = { brand: 'x', chaosScore: 3 }
+    expect(formatLintSummary(audit)).toBe('')
+  })
+
+  it('returns empty string when all linting arrays are empty', () => {
+    const audit = {
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+      overflowSafetyIssues: [],
+    }
+    expect(formatLintSummary(audit)).toBe('')
+  })
+
+  it('includes the layout a11y count when issues are present', () => {
+    const audit = { layoutA11yIssues: [{}, {}] }
+    expect(formatLintSummary(audit)).toBe('2 layout a11y')
+  })
+
+  it('omits zero-count categories and joins the rest with a middot', () => {
+    const audit = {
+      layoutA11yIssues: [{}],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [{}, {}, {}],
+      overflowSafetyIssues: [{}, {}],
+    }
+    expect(formatLintSummary(audit)).toBe(
+      '1 layout a11y · 3 adoption · 2 overflow'
+    )
+  })
+
+  it('labels all four categories in a stable order', () => {
+    const audit = {
+      layoutA11yIssues: [{}],
+      modernPracticeIssues: [{}],
+      adoptionSuggestions: [{}],
+      overflowSafetyIssues: [{}],
+    }
+    expect(formatLintSummary(audit)).toBe(
+      '1 layout a11y · 1 modern-practice · 1 adoption · 1 overflow'
+    )
+  })
+})

--- a/lib/__tests__/audit-summary.test.mjs
+++ b/lib/__tests__/audit-summary.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatLintSummary } from '../audit-summary.mjs'
+import { formatLintSummary, collectLintGroups } from '../audit-summary.mjs'
 
 describe('formatLintSummary', () => {
   it('returns empty string when no linting fields are present', () => {
@@ -44,5 +44,55 @@ describe('formatLintSummary', () => {
     expect(formatLintSummary(audit)).toBe(
       '1 layout a11y · 1 modern-practice · 1 adoption · 1 overflow'
     )
+  })
+})
+
+describe('collectLintGroups', () => {
+  it('returns an empty array when no linting fields are present', () => {
+    expect(collectLintGroups({ brand: 'x' })).toEqual([])
+  })
+
+  it('returns an empty array when every category is empty', () => {
+    const audit = {
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+      overflowSafetyIssues: [],
+    }
+    expect(collectLintGroups(audit)).toEqual([])
+  })
+
+  it('returns a labeled group carrying the raw issues for a category', () => {
+    const issue = {
+      selector: '.nav-item',
+      property: 'order',
+      value: '-1',
+      reason: 'Visual order differs from DOM order',
+      severity: 'warning',
+    }
+    const groups = collectLintGroups({ layoutA11yIssues: [issue] })
+    expect(groups).toEqual([
+      {
+        key: 'layoutA11yIssues',
+        label: 'Layout accessibility',
+        issues: [issue],
+      },
+    ])
+  })
+
+  it('includes only non-empty categories, in a stable order', () => {
+    const audit = {
+      overflowSafetyIssues: [
+        { selector: '.nav', reason: 'r', severity: 'warning' },
+      ],
+      layoutA11yIssues: [{ selector: '.a', reason: 'r', severity: 'warning' }],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [{ selector: '', reason: 'r', severity: 'info' }],
+    }
+    expect(collectLintGroups(audit).map((g) => g.key)).toEqual([
+      'layoutA11yIssues',
+      'adoptionSuggestions',
+      'overflowSafetyIssues',
+    ])
   })
 })

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { CssAuditor } from '../css-auditor.mjs'
+import { buildAuditPrompt } from '../prompts.mjs'
 
 describe('CssAuditor', () => {
   it('audit returns parsed JSON object', async () => {
@@ -93,5 +94,103 @@ describe('CssAuditor.stripFences', () => {
 
   it('strips ```json fenced block', () => {
     expect(CssAuditor.stripFences('```json\n{"a":1}\n```')).toBe('{"a":1}')
+  })
+})
+
+describe('buildAuditPrompt layout a11y', () => {
+  it('includes STEP 9 for layout accessibility detection', () => {
+    const css = '.flex-parent { display: flex; } .flex-child { order: 1; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('STEP 9')
+    expect(prompt.content).toContain('LAYOUT ACCESSIBILITY')
+  })
+
+  it('instructs LLM to detect order breaking DOM order', () => {
+    const css = '.nav { display: grid; } .nav-item { order: -1; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('ORDER BREAKING DOM ORDER')
+    expect(prompt.content).toContain('order')
+  })
+
+  it('instructs LLM to check for missing tabindex fallback', () => {
+    const css = '.flex { display: flex; } .flex-item { order: 2; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('REORDERING WITHOUT TABINDEX FALLBACK')
+    expect(prompt.content).toContain('tabindex')
+  })
+
+  it('includes layoutA11yIssues in the output example', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('layoutA11yIssues')
+    expect(prompt.content).toContain('nav-logo')
+  })
+
+  it('includes layout a11y in chaos score calculation', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('layoutA11yIssues.length')
+  })
+})
+
+describe('CssAuditor layout a11y integration', () => {
+  it('audit parses response with layoutA11yIssues', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 5,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [
+        {
+          selector: '.nav-item',
+          property: 'order',
+          value: '-1',
+          reason: 'Visual order differs from DOM order',
+          severity: 'warning',
+        },
+      ],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.layoutA11yIssues).toEqual([
+      {
+        selector: '.nav-item',
+        property: 'order',
+        value: '-1',
+        reason: 'Visual order differs from DOM order',
+        severity: 'warning',
+      },
+    ])
+  })
+
+  it('audit handles empty layoutA11yIssues array', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.layoutA11yIssues).toEqual([])
   })
 })

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -211,7 +211,8 @@ describe('buildAuditPrompt modern practices', () => {
   })
 
   it('instructs LLM to detect legacy centering techniques', () => {
-    const css = '.modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }'
+    const css =
+      '.modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }'
     const prompt = buildAuditPrompt(css)
     expect(prompt.content).toContain('LEGACY CENTERING')
     expect(prompt.content).toContain('legacy-centering')
@@ -299,5 +300,124 @@ describe('CssAuditor modernPracticeIssues integration', () => {
 
     const result = await auditor.audit({ content: 'test', system: 'sys' })
     expect(result.modernPracticeIssues).toEqual([])
+  })
+})
+
+describe('buildAuditPrompt adoption suggestions', () => {
+  it('includes STEP 10 for modern feature adoption detection', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('STEP 10')
+    expect(prompt.content).toContain('MODERN FEATURE ADOPTION')
+  })
+
+  it('instructs LLM to suggest CSS layers for large projects', () => {
+    const css =
+      '.a {} .b {} .c {} .d {} .e {} .f {} .g {} .h {} .i {} .j {} .k {} .l {} .m {} .n {} .o {} .p {} .q {} .r {} .s {} .t {} .u {}'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('USE CSS LAYERS')
+    expect(prompt.content).toContain('use-css-layers')
+  })
+
+  it('instructs LLM to suggest container queries', () => {
+    const css = '@media (min-width: 768px) { .card { width: 50%; } }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('USE CONTAINER QUERIES')
+    expect(prompt.content).toContain('use-container-queries')
+  })
+
+  it('includes adoptionSuggestions in the output example', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('adoptionSuggestions')
+    expect(prompt.content).toContain('use-css-layers')
+    expect(prompt.content).toContain('product-card')
+  })
+})
+
+describe('CssAuditor adoptionSuggestions integration', () => {
+  it('audit parses response with adoptionSuggestions', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 4,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [
+        {
+          selector: '',
+          rule: 'use-css-layers',
+          severity: 'info',
+          reason: 'Project has 30 selector rules without @layer organization',
+        },
+      ],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.adoptionSuggestions).toEqual([
+      {
+        selector: '',
+        rule: 'use-css-layers',
+        severity: 'info',
+        reason: 'Project has 30 selector rules without @layer organization',
+      },
+    ])
+  })
+
+  it('audit handles empty adoptionSuggestions array', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.adoptionSuggestions).toEqual([])
+  })
+
+  it('audit handles missing adoptionSuggestions gracefully', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.adoptionSuggestions).toBeUndefined()
   })
 })

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -305,3 +305,101 @@ describe('buildCssAuditorFromSettingsAndFlags', () => {
     )
   })
 })
+
+describe('buildAuditPrompt layout a11y', () => {
+  it('includes STEP 8 for layout accessibility detection', () => {
+    const css = '.flex-parent { display: flex; } .flex-child { order: 1; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('STEP 8')
+    expect(prompt.content).toContain('LAYOUT ACCESSIBILITY')
+  })
+
+  it('instructs LLM to detect order breaking DOM order', () => {
+    const css = '.nav { display: grid; } .nav-item { order: -1; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('ORDER BREAKING DOM ORDER')
+    expect(prompt.content).toContain('order')
+  })
+
+  it('instructs LLM to check for missing tabindex fallback', () => {
+    const css = '.flex { display: flex; } .flex-item { order: 2; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('REORDERING WITHOUT TABINDEX FALLBACK')
+    expect(prompt.content).toContain('tabindex')
+  })
+
+  it('includes layoutA11yIssues in the output example', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('layoutA11yIssues')
+    expect(prompt.content).toContain('nav-logo')
+  })
+
+  it('includes layout a11y in chaos score calculation', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('layoutA11yIssues.length')
+  })
+})
+
+describe('CssAuditor layout a11y integration', () => {
+  it('audit parses response with layoutA11yIssues', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 5,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [
+        {
+          selector: '.nav-item',
+          property: 'order',
+          value: '-1',
+          reason: 'Visual order differs from DOM order',
+          severity: 'warning',
+        },
+      ],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.layoutA11yIssues).toEqual([
+      {
+        selector: '.nav-item',
+        property: 'order',
+        value: '-1',
+        reason: 'Visual order differs from DOM order',
+        severity: 'warning',
+      },
+    ])
+  })
+
+  it('audit handles empty layoutA11yIssues array', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.layoutA11yIssues).toEqual([])
+  })
+})

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -421,3 +421,131 @@ describe('CssAuditor adoptionSuggestions integration', () => {
     expect(result.adoptionSuggestions).toBeUndefined()
   })
 })
+
+describe('buildAuditPrompt overflow wrap safety', () => {
+  it('includes STEP 11 for overflow and wrap safety', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('STEP 11')
+    expect(prompt.content).toContain('OVERFLOW AND WRAP SAFETY')
+  })
+
+  it('instructs LLM to detect flex containers without flex-wrap', () => {
+    const css = '.nav { display: flex; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('FLEX-WRAP MISSING')
+    expect(prompt.content).toContain('flex-wrap-missing')
+    expect(prompt.content).toContain('nowrap')
+  })
+
+  it('instructs LLM to detect sized containers without overflow handling', () => {
+    const css = '.grid { display: grid; height: 400px; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('MISSING OVERFLOW HANDLING')
+    expect(prompt.content).toContain('missing-overflow-wrap')
+  })
+
+  it('includes overflowSafetyIssues in the output example', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('overflowSafetyIssues')
+    expect(prompt.content).toContain('flex-wrap-missing')
+    expect(prompt.content).toContain('.nav-list')
+  })
+
+  it('includes overflow safety in chaos score formula', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('overflowSafetyIssues.length >= 4')
+  })
+})
+
+describe('CssAuditor overflowSafetyIssues integration', () => {
+  it('audit parses response with overflowSafetyIssues', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 5,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+      overflowSafetyIssues: [
+        {
+          selector: '.nav-list',
+          rule: 'flex-wrap-missing',
+          severity: 'warning',
+          reason: 'Flex container without flex-wrap',
+        },
+      ],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.overflowSafetyIssues).toEqual([
+      {
+        selector: '.nav-list',
+        rule: 'flex-wrap-missing',
+        severity: 'warning',
+        reason: 'Flex container without flex-wrap',
+      },
+    ])
+  })
+
+  it('audit handles empty overflowSafetyIssues array', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+      overflowSafetyIssues: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.overflowSafetyIssues).toEqual([])
+  })
+
+  it('audit handles missing overflowSafetyIssues gracefully', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.overflowSafetyIssues).toBeUndefined()
+  })
+})

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -630,3 +630,131 @@ describe('CssAuditor adoptionSuggestions integration', () => {
     expect(result.adoptionSuggestions).toBeUndefined()
   })
 })
+
+describe('buildAuditPrompt overflow wrap safety', () => {
+  it('includes STEP 11 for overflow and wrap safety', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('STEP 11')
+    expect(prompt.content).toContain('OVERFLOW AND WRAP SAFETY')
+  })
+
+  it('instructs LLM to detect flex containers without flex-wrap', () => {
+    const css = '.nav { display: flex; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('FLEX-WRAP MISSING')
+    expect(prompt.content).toContain('flex-wrap-missing')
+    expect(prompt.content).toContain('nowrap')
+  })
+
+  it('instructs LLM to detect sized containers without overflow handling', () => {
+    const css = '.grid { display: grid; height: 400px; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('MISSING OVERFLOW HANDLING')
+    expect(prompt.content).toContain('missing-overflow-wrap')
+  })
+
+  it('includes overflowSafetyIssues in the output example', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('overflowSafetyIssues')
+    expect(prompt.content).toContain('flex-wrap-missing')
+    expect(prompt.content).toContain('.nav-list')
+  })
+
+  it('includes overflow safety in chaos score formula', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('overflowSafetyIssues.length >= 4')
+  })
+})
+
+describe('CssAuditor overflowSafetyIssues integration', () => {
+  it('audit parses response with overflowSafetyIssues', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 5,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+      overflowSafetyIssues: [
+        {
+          selector: '.nav-list',
+          rule: 'flex-wrap-missing',
+          severity: 'warning',
+          reason: 'Flex container without flex-wrap',
+        },
+      ],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.overflowSafetyIssues).toEqual([
+      {
+        selector: '.nav-list',
+        rule: 'flex-wrap-missing',
+        severity: 'warning',
+        reason: 'Flex container without flex-wrap',
+      },
+    ])
+  })
+
+  it('audit handles empty overflowSafetyIssues array', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+      overflowSafetyIssues: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.overflowSafetyIssues).toEqual([])
+  })
+
+  it('audit handles missing overflowSafetyIssues gracefully', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.overflowSafetyIssues).toBeUndefined()
+  })
+})

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -194,3 +194,110 @@ describe('CssAuditor layout a11y integration', () => {
     expect(result.layoutA11yIssues).toEqual([])
   })
 })
+
+describe('buildAuditPrompt modern practices', () => {
+  it('includes STEP 9 for modern CSS best practices detection', () => {
+    const css = '.grid { display: grid; grid-template-columns: 1fr; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('STEP 9')
+    expect(prompt.content).toContain('MODERN CSS BEST PRACTICES')
+  })
+
+  it('instructs LLM to detect single-column grids', () => {
+    const css = '.container { display: grid; grid-template-columns: 1fr; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('SINGLE-COLUMN GRID')
+    expect(prompt.content).toContain('grid-when-flexbox-wrap-would-work')
+  })
+
+  it('instructs LLM to detect legacy centering techniques', () => {
+    const css = '.modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('LEGACY CENTERING')
+    expect(prompt.content).toContain('legacy-centering')
+  })
+
+  it('instructs LLM to detect flex min-width zero hack', () => {
+    const css = '.parent { display: flex; } .child { min-width: 0; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('FLEX MIN-WIDTH ZERO HACK')
+    expect(prompt.content).toContain('flex-min-width-zero-hack')
+  })
+
+  it('instructs LLM to detect fragile nested selectors', () => {
+    const css = '.card > .header > .title { font-size: 16px; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('FRAGILE NESTED SELECTORS')
+    expect(prompt.content).toContain('fragile-nested-selectors')
+  })
+
+  it('includes modernPracticeIssues in the output example', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('modernPracticeIssues')
+    expect(prompt.content).toContain('card-grid')
+    expect(prompt.content).toContain('fragile-nested-selectors')
+  })
+})
+
+describe('CssAuditor modernPracticeIssues integration', () => {
+  it('audit parses response with modernPracticeIssues', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 4,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [
+        {
+          selector: '.card-grid',
+          rule: 'grid-when-flexbox-wrap-would-work',
+          severity: 'suggestion',
+          reason: 'Single-column grid layout',
+        },
+      ],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.modernPracticeIssues).toEqual([
+      {
+        selector: '.card-grid',
+        rule: 'grid-when-flexbox-wrap-would-work',
+        severity: 'suggestion',
+        reason: 'Single-column grid layout',
+      },
+    ])
+  })
+
+  it('audit handles empty modernPracticeIssues array', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.modernPracticeIssues).toEqual([])
+  })
+})

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -420,7 +420,8 @@ describe('buildAuditPrompt modern practices', () => {
   })
 
   it('instructs LLM to detect legacy centering techniques', () => {
-    const css = '.modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }'
+    const css =
+      '.modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }'
     const prompt = buildAuditPrompt(css)
     expect(prompt.content).toContain('LEGACY CENTERING')
     expect(prompt.content).toContain('legacy-centering')
@@ -508,5 +509,124 @@ describe('CssAuditor modernPracticeIssues integration', () => {
 
     const result = await auditor.audit({ content: 'test', system: 'sys' })
     expect(result.modernPracticeIssues).toEqual([])
+  })
+})
+
+describe('buildAuditPrompt adoption suggestions', () => {
+  it('includes STEP 10 for modern feature adoption detection', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('STEP 10')
+    expect(prompt.content).toContain('MODERN FEATURE ADOPTION')
+  })
+
+  it('instructs LLM to suggest CSS layers for large projects', () => {
+    const css =
+      '.a {} .b {} .c {} .d {} .e {} .f {} .g {} .h {} .i {} .j {} .k {} .l {} .m {} .n {} .o {} .p {} .q {} .r {} .s {} .t {} .u {}'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('USE CSS LAYERS')
+    expect(prompt.content).toContain('use-css-layers')
+  })
+
+  it('instructs LLM to suggest container queries', () => {
+    const css = '@media (min-width: 768px) { .card { width: 50%; } }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('USE CONTAINER QUERIES')
+    expect(prompt.content).toContain('use-container-queries')
+  })
+
+  it('includes adoptionSuggestions in the output example', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('adoptionSuggestions')
+    expect(prompt.content).toContain('use-css-layers')
+    expect(prompt.content).toContain('product-card')
+  })
+})
+
+describe('CssAuditor adoptionSuggestions integration', () => {
+  it('audit parses response with adoptionSuggestions', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 4,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [
+        {
+          selector: '',
+          rule: 'use-css-layers',
+          severity: 'info',
+          reason: 'Project has 30 selector rules without @layer organization',
+        },
+      ],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.adoptionSuggestions).toEqual([
+      {
+        selector: '',
+        rule: 'use-css-layers',
+        severity: 'info',
+        reason: 'Project has 30 selector rules without @layer organization',
+      },
+    ])
+  })
+
+  it('audit handles empty adoptionSuggestions array', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.adoptionSuggestions).toEqual([])
+  })
+
+  it('audit handles missing adoptionSuggestions gracefully', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.adoptionSuggestions).toBeUndefined()
   })
 })

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -403,3 +403,110 @@ describe('CssAuditor layout a11y integration', () => {
     expect(result.layoutA11yIssues).toEqual([])
   })
 })
+
+describe('buildAuditPrompt modern practices', () => {
+  it('includes STEP 9 for modern CSS best practices detection', () => {
+    const css = '.grid { display: grid; grid-template-columns: 1fr; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('STEP 9')
+    expect(prompt.content).toContain('MODERN CSS BEST PRACTICES')
+  })
+
+  it('instructs LLM to detect single-column grids', () => {
+    const css = '.container { display: grid; grid-template-columns: 1fr; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('SINGLE-COLUMN GRID')
+    expect(prompt.content).toContain('grid-when-flexbox-wrap-would-work')
+  })
+
+  it('instructs LLM to detect legacy centering techniques', () => {
+    const css = '.modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('LEGACY CENTERING')
+    expect(prompt.content).toContain('legacy-centering')
+  })
+
+  it('instructs LLM to detect flex min-width zero hack', () => {
+    const css = '.parent { display: flex; } .child { min-width: 0; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('FLEX MIN-WIDTH ZERO HACK')
+    expect(prompt.content).toContain('flex-min-width-zero-hack')
+  })
+
+  it('instructs LLM to detect fragile nested selectors', () => {
+    const css = '.card > .header > .title { font-size: 16px; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('FRAGILE NESTED SELECTORS')
+    expect(prompt.content).toContain('fragile-nested-selectors')
+  })
+
+  it('includes modernPracticeIssues in the output example', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('modernPracticeIssues')
+    expect(prompt.content).toContain('card-grid')
+    expect(prompt.content).toContain('fragile-nested-selectors')
+  })
+})
+
+describe('CssAuditor modernPracticeIssues integration', () => {
+  it('audit parses response with modernPracticeIssues', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 4,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [
+        {
+          selector: '.card-grid',
+          rule: 'grid-when-flexbox-wrap-would-work',
+          severity: 'suggestion',
+          reason: 'Single-column grid layout',
+        },
+      ],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.modernPracticeIssues).toEqual([
+      {
+        selector: '.card-grid',
+        rule: 'grid-when-flexbox-wrap-would-work',
+        severity: 'suggestion',
+        reason: 'Single-column grid layout',
+      },
+    ])
+  })
+
+  it('audit handles empty modernPracticeIssues array', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.modernPracticeIssues).toEqual([])
+  })
+})

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -196,10 +196,10 @@ describe('CssAuditor layout a11y integration', () => {
 })
 
 describe('buildAuditPrompt modern practices', () => {
-  it('includes STEP 9 for modern CSS best practices detection', () => {
+  it('includes STEP 10 for modern CSS best practices detection', () => {
     const css = '.grid { display: grid; grid-template-columns: 1fr; }'
     const prompt = buildAuditPrompt(css)
-    expect(prompt.content).toContain('STEP 9')
+    expect(prompt.content).toContain('STEP 10')
     expect(prompt.content).toContain('MODERN CSS BEST PRACTICES')
   })
 
@@ -304,10 +304,10 @@ describe('CssAuditor modernPracticeIssues integration', () => {
 })
 
 describe('buildAuditPrompt adoption suggestions', () => {
-  it('includes STEP 10 for modern feature adoption detection', () => {
+  it('includes STEP 11 for modern feature adoption detection', () => {
     const css = 'body { color: red; }'
     const prompt = buildAuditPrompt(css)
-    expect(prompt.content).toContain('STEP 10')
+    expect(prompt.content).toContain('STEP 11')
     expect(prompt.content).toContain('MODERN FEATURE ADOPTION')
   })
 
@@ -423,10 +423,10 @@ describe('CssAuditor adoptionSuggestions integration', () => {
 })
 
 describe('buildAuditPrompt overflow wrap safety', () => {
-  it('includes STEP 11 for overflow and wrap safety', () => {
+  it('includes STEP 12 for overflow and wrap safety', () => {
     const css = 'body { color: red; }'
     const prompt = buildAuditPrompt(css)
-    expect(prompt.content).toContain('STEP 11')
+    expect(prompt.content).toContain('STEP 12')
     expect(prompt.content).toContain('OVERFLOW AND WRAP SAFETY')
   })
 

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -116,7 +116,7 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('</example>')
   })
 
-  it('includes all seven analysis steps', () => {
+  it('includes all eleven analysis steps', () => {
     const content = buildAuditPrompt(css).content
     expect(content).toContain('STEP 1')
     expect(content).toContain('STEP 2')
@@ -125,6 +125,10 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('STEP 5')
     expect(content).toContain('STEP 6')
     expect(content).toContain('STEP 7')
+    expect(content).toContain('STEP 8')
+    expect(content).toContain('STEP 9')
+    expect(content).toContain('STEP 10')
+    expect(content).toContain('STEP 11')
   })
 
   it('covers all required JSON output fields in the example', () => {

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -116,7 +116,7 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('</example>')
   })
 
-  it('includes all seven analysis steps', () => {
+  it('includes all twelve analysis steps', () => {
     const content = buildAuditPrompt(css).content
     expect(content).toContain('STEP 1')
     expect(content).toContain('STEP 2')
@@ -126,6 +126,10 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('STEP 6')
     expect(content).toContain('STEP 7')
     expect(content).toContain('STEP 8')
+    expect(content).toContain('STEP 9')
+    expect(content).toContain('STEP 10')
+    expect(content).toContain('STEP 11')
+    expect(content).toContain('STEP 12')
   })
 
   it('covers all required JSON output fields in the example', () => {

--- a/lib/audit-summary.mjs
+++ b/lib/audit-summary.mjs
@@ -1,11 +1,27 @@
 // Shared, dependency-free helpers for summarizing an AuditReport.
-// Imported by the CLI (bin/mint-ds.mjs); keep it build-step free.
+// Imported by the CLI (bin/mint-ds.mjs) and the web AuditView; keep it build-step free.
 
 const LINT_CATEGORIES = [
-  { key: 'layoutA11yIssues', label: 'layout a11y' },
-  { key: 'modernPracticeIssues', label: 'modern-practice' },
-  { key: 'adoptionSuggestions', label: 'adoption' },
-  { key: 'overflowSafetyIssues', label: 'overflow' },
+  {
+    key: 'layoutA11yIssues',
+    shortLabel: 'layout a11y',
+    label: 'Layout accessibility',
+  },
+  {
+    key: 'modernPracticeIssues',
+    shortLabel: 'modern-practice',
+    label: 'Modern best practices',
+  },
+  {
+    key: 'adoptionSuggestions',
+    shortLabel: 'adoption',
+    label: 'Feature adoption',
+  },
+  {
+    key: 'overflowSafetyIssues',
+    shortLabel: 'overflow',
+    label: 'Overflow & wrap safety',
+  },
 ]
 
 /**
@@ -14,10 +30,24 @@ const LINT_CATEGORIES = [
  */
 export function formatLintSummary(audit) {
   if (!audit) return ''
-  return LINT_CATEGORIES.map(({ key, label }) => {
+  return LINT_CATEGORIES.map(({ key, shortLabel }) => {
     const count = audit[key]?.length ?? 0
-    return count > 0 ? `${count} ${label}` : null
+    return count > 0 ? `${count} ${shortLabel}` : null
   })
     .filter(Boolean)
     .join(' · ')
+}
+
+/**
+ * Group the CSS layout-linting findings for display. Returns one entry per
+ * non-empty category ({ key, label, issues }) in a stable order; [] when none.
+ */
+export function collectLintGroups(audit) {
+  if (!audit) return []
+  const groups = []
+  for (const { key, label } of LINT_CATEGORIES) {
+    const issues = audit[key] ?? []
+    if (issues.length > 0) groups.push({ key, label, issues })
+  }
+  return groups
 }

--- a/lib/audit-summary.mjs
+++ b/lib/audit-summary.mjs
@@ -1,0 +1,23 @@
+// Shared, dependency-free helpers for summarizing an AuditReport.
+// Imported by the CLI (bin/mint-ds.mjs); keep it build-step free.
+
+const LINT_CATEGORIES = [
+  { key: 'layoutA11yIssues', label: 'layout a11y' },
+  { key: 'modernPracticeIssues', label: 'modern-practice' },
+  { key: 'adoptionSuggestions', label: 'adoption' },
+  { key: 'overflowSafetyIssues', label: 'overflow' },
+]
+
+/**
+ * Build a one-line summary of the CSS layout-linting findings in an audit.
+ * Only non-empty categories are included; returns '' when there are none.
+ */
+export function formatLintSummary(audit) {
+  if (!audit) return ''
+  return LINT_CATEGORIES.map(({ key, label }) => {
+    const count = audit[key]?.length ?? 0
+    return count > 0 ? `${count} ${label}` : null
+  })
+    .filter(Boolean)
+    .join(' · ')
+}

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -95,6 +95,7 @@ Compute a deterministic integer from 1–10. Start at 1, then add:
 - +1 if count of non-system fonts > 1 (stacks with the above)
 - +1 if lineHeights.unitlessMix is true
 - +1 if motion.duplicateDeclarations > 5
+- +1 if layoutA11yIssues.length >= 3
 Cap the final result at 10.
 
 STEP 7 — SUMMARY
@@ -102,6 +103,27 @@ Write 1–2 sentences naming the top quality issues. Be specific: cite actual co
 
 STEP 8 — BRAND
 Infer a project name from CSS comments, HTML title elements, BEM block prefixes, CSS variable namespaces (e.g. --myapp-*), or @layer names. Return "" if nothing identifiable is found.
+
+STEP 9 — LAYOUT ACCESSIBILITY
+Scan the CSS for layout accessibility issues related to grid and flexbox reordering. Focus on two patterns:
+
+9a. ORDER BREAKING DOM ORDER
+Look for rules where a selector has \`order\` AND its parent (or ancestor) has \`display: grid\` or \`display: flex\`. When an element has \`order\` set to a value other than 0, the visual order differs from the DOM order. For each such case, record:
+- "selector": the CSS selector that sets order
+- "property": "order"
+- "value": the order value (e.g. "2", "-1")
+- "reason": "Visual order differs from DOM order — this breaks keyboard navigation and screen reader flow"
+- "severity": "warning"
+
+9b. REORDERING WITHOUT TABINDEX FALLBACK
+When you detect a selector with order (as in 9a), check whether the same source provides a matching tabindex adjustment for the same element. If the CSS sets order but no corresponding tabindex value is found anywhere (in CSS or HTML comments), record:
+- "selector": the CSS selector that sets order
+- "property": "tabindex"
+- "value": "missing"
+- "reason": "Element is visually reordered via CSS \`order\` but has no \`tabindex\` adjustment — keyboard users will navigate in DOM order, not visual order"
+- "severity": "warning"
+
+Only report up to 10 issues total. Combine the two checks: for each order rule found, emit up to two LayoutA11yIssue entries (one for the order itself, one for the missing tabindex). Skip selectors where order is 0 (default).
 </instructions>
 
 <output_format>
@@ -153,7 +175,11 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
       "suggestedScale": { "standard": "cubic-bezier(0.4, 0, 0.2, 1)", "emphasized": "cubic-bezier(0.4, 0, 0.6, 1)" }
     },
     "duplicateDeclarations": 6
-  }
+  },
+  "layoutA11yIssues": [
+    { "selector": ".nav-logo", "property": "order", "value": "-1", "reason": "Visual order differs from DOM order — this breaks keyboard navigation and screen reader flow", "severity": "warning" },
+    { "selector": ".cta-button", "property": "tabindex", "value": "missing", "reason": "Element is visually reordered via CSS \`order\` but has no \`tabindex\` adjustment — keyboard users will navigate in DOM order, not visual order", "severity": "warning" }
+  ]
 }
 </example>
 </output_format>`

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -131,7 +131,25 @@ Look for selectors that couple CSS rules to a brittle DOM structure. These are s
 - "reason": "This selector depends on a specific DOM structure — consider using a single class name or BEM naming to reduce coupling"
 
 Cap at 12 modernPracticeIssues total. Prioritize by severity of the pattern (legacy-centering and fragile selectors first). Skip any selector already flagged in layoutA11yIssues.
-</instructions>
+
+STEP 10 — MODERN FEATURE ADOPTION SUGGESTIONS
+Scan the CSS for opportunities to adopt modern CSS features that are underused in the ecosystem. These are aspirational suggestions (severity info), not warnings. Focus on two patterns:
+
+10a. USE CSS LAYERS
+If the CSS source has more than 20 selector rules and no @layer declarations, record a suggestion to adopt @layer for better cascade organization. Also detect projects that use @layer but only a single layer — they may benefit from splitting into multiple layers (e.g. reset, base, components, utilities). For each case, record:
+- "selector": empty string "" (this is project-wide guidance, not per-selector)
+- "rule": "use-css-layers"
+- "severity": "info"
+- "reason": "Project has N selector rules without @layer organization — consider adopting @layer for better cascade management and specificity control" (replace N with approximate selector count)
+
+10b. USE CONTAINER QUERIES
+Look for @media rules that scope by width and appear to target specific components. A component-level media query is one where the @media rule contains only a single block selector (like a component class) or where multiple similar @media blocks target sibling selectors. When you find @media queries that could be replaced by a @container query on the parent, record:
+- "selector": the class/selector that appears inside the @media block (the component targeted)
+- "rule": "use-container-queries"
+- "severity": "info"
+- "reason": "Component appears to use width-scoped @media queries — consider wrapping the parent in a @container and using @container queries for component-responsive behavior"
+
+Only report up to 6 adoptionSuggestions total. Prioritize CSS layers first (one entry max), then up to 5 container query suggestions. These are informational only — do not include them in the chaos score.</instructions>
 
 <output_format>
 Return ONLY a valid JSON object matching the structure in the example below. No markdown fences, no backticks, no text before or after the JSON.
@@ -174,7 +192,11 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
     { "selector": ".card-grid", "rule": "grid-when-flexbox-wrap-would-work", "severity": "suggestion", "reason": "Single-column grid layout \u2014 consider \`display: flex; flex-wrap: wrap\` for simpler responsive behavior" },
     { "selector": ".modal", "rule": "legacy-centering", "severity": "suggestion", "reason": "Using absolute positioning + transform for centering \u2014 consider \`display: grid; place-items: center\`" },
     { "selector": ".flex-child", "rule": "flex-min-width-zero-hack", "severity": "suggestion", "reason": "\`min-width: 0\` hack on a flex item \u2014 this overrides the default \`min-width: auto\` and may signal a layout misunderstanding" },
-    { "selector": ".card > .header > .title", "rule": "fragile-nested-selectors", "severity": "suggestion", "reason": "This selector depends on a specific DOM structure \u2014 consider using a single class name or BEM naming to reduce coupling" }
+    { "selector": ".card > .header > .title", "rule": "fragile-nested-selectors", "severity": "suggestion", "reason": "This selector depends on a specific DOM structure — consider using a single class name or BEM naming to reduce coupling" }
+  ],
+  "adoptionSuggestions": [
+    { "selector": "", "rule": "use-css-layers", "severity": "info", "reason": "Project has 47 selector rules without @layer organization — consider adopting @layer for better cascade management and specificity control" },
+    { "selector": ".product-card", "rule": "use-container-queries", "severity": "info", "reason": "Component appears to use width-scoped @media queries — consider wrapping the parent in a @container and using @container queries for component-responsive behavior" }
   ]
 }
 </example>

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -96,6 +96,7 @@ Compute a deterministic integer from 1–10. Start at 1, then add:
 - +1 if lineHeights.unitlessMix is true
 - +1 if motion.duplicateDeclarations > 5
 - +1 if layoutA11yIssues.length >= 3
+- +1 if overflowSafetyIssues.length >= 4
 Cap the final result at 10.
 
 STEP 7 — SUMMARY
@@ -175,7 +176,29 @@ Look for @media rules that scope by width and appear to target specific componen
 - "severity": "info"
 - "reason": "Component appears to use width-scoped @media queries — consider wrapping the parent in a @container and using @container queries for component-responsive behavior"
 
-Only report up to 6 adoptionSuggestions total. Prioritize CSS layers first (one entry max), then up to 5 container query suggestions. These are informational only — do not include them in the chaos score.</instructions>
+Only report up to 6 adoptionSuggestions total. Prioritize CSS layers first (one entry max), then up to 5 container query suggestions. These are informational only — do not include them in the chaos score.
+
+STEP 11 — OVERFLOW AND WRAP SAFETY
+Scan the CSS for overflow and wrap safety issues in grid and flexbox containers. Focus on two patterns:
+
+11a. FLEX-WRAP MISSING
+Look for rules where a selector has \`display: flex\` or \`display: inline-flex\` without \`flex-wrap\`. Flex containers default to \`flex-wrap: nowrap\`, which means items will not wrap and can cause horizontal overflow on narrower viewports. For each such case, record:
+- "selector": the CSS selector that declares the flex container
+- "rule": "flex-wrap-missing"
+- "severity": "warning"
+- "reason": "Flex container without \`flex-wrap\` — items will not wrap and may overflow on narrow viewports. Consider adding \`flex-wrap: wrap\`"
+
+11b. MISSING OVERFLOW HANDLING
+Look for grid or flex containers that have explicit width, height, or max-size constraints but no \`overflow\`, \`overflow-x\`, or \`overflow-y\` property set. When a sized container's children can exceed those bounds, content may be clipped or cause scroll issues. Common signals:
+- \`display: grid\` or \`display: flex\` with a fixed \`height\`, \`max-height\`, \`width\`, or \`max-width\`
+- Grid with \`grid-template-rows\` producing more tracks than available space typically fits
+For each such case, record:
+- "selector": the CSS selector for the container
+- "rule": "missing-overflow-wrap"
+- "severity": "suggestion"
+- "reason": a specific message identifying the overflow risk (e.g. "Grid container with fixed height but no overflow handling — content may be clipped if grid items exceed the container" or "Flex container with max-width and no overflow property — ensure overflow is handled explicitly")
+
+Only report up to 8 overflowSafetyIssues total. Prioritize flex-wrap-missing (warnings) first, then missing-overflow-wrap (suggestions).</instructions>
 
 <output_format>
 Return ONLY a valid JSON object matching the structure in the example below. No markdown fences, no backticks, no text before or after the JSON.
@@ -240,6 +263,10 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
   "adoptionSuggestions": [
     { "selector": "", "rule": "use-css-layers", "severity": "info", "reason": "Project has 47 selector rules without @layer organization — consider adopting @layer for better cascade management and specificity control" },
     { "selector": ".product-card", "rule": "use-container-queries", "severity": "info", "reason": "Component appears to use width-scoped @media queries — consider wrapping the parent in a @container and using @container queries for component-responsive behavior" }
+  ],
+  "overflowSafetyIssues": [
+    { "selector": ".nav-list", "rule": "flex-wrap-missing", "severity": "warning", "reason": "Flex container without \`flex-wrap\` — items will not wrap and may overflow on narrow viewports" },
+    { "selector": ".dashboard-grid", "rule": "missing-overflow-wrap", "severity": "suggestion", "reason": "Grid container with fixed height but no overflow handling — content may be clipped if grid items exceed the container" }
   ]
 }
 </example>

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -126,31 +126,31 @@ When you detect a selector with order (as in 9a), check whether the same source 
 
 Only report up to 10 issues total. Combine the two checks: for each order rule found, emit up to two LayoutA11yIssue entries (one for the order itself, one for the missing tabindex). Skip selectors where order is 0 (default).
 
-STEP 9 — MODERN CSS BEST PRACTICES
+STEP 10 — MODERN CSS BEST PRACTICES
 Scan the CSS for code patterns that can be improved with modern CSS features. Focus on four checks:
 
-9a. SINGLE-COLUMN GRID THAT COULD BE FLEXBOX
+10a. SINGLE-COLUMN GRID THAT COULD BE FLEXBOX
 Look for rules where a selector has \`display: grid\` with \`grid-template-columns\` set to a single column (e.g. \`grid-template-columns: 1fr\`, \`grid-template-columns: 100%\`, or \`grid-template-columns: repeat(1, 1fr)\`). A single-column grid offers no layout advantage over flexbox with wrap. For each such case, record:
 - "selector": the CSS selector with the grid rule
 - "rule": "grid-when-flexbox-wrap-would-work"
 - "severity": "suggestion"
 - "reason": "Single-column grid layout — consider \`display: flex; flex-wrap: wrap\` for simpler responsive behavior"
 
-9b. LEGACY CENTERING TECHNIQUES
+10b. LEGACY CENTERING TECHNIQUES
 Look for centering techniques that predate modern grid/flex layout. Detect patterns like: \`margin: 0 auto\` with an explicit \`width\` (centered block), \`position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%)\` (absolute centering), or \`text-align: center\` used for block-level centering with \`display: inline-block\` on children. Do NOT flag \`text-align: center\` on inline text (that is the correct use). For each legacy pattern found, record:
 - "selector": the CSS selector using the legacy technique
 - "rule": "legacy-centering"
 - "severity": "suggestion"
 - "reason": a specific message like "Using margin:auto + fixed width for centering — consider \`display: flex; justify-content: center\`" or "Using absolute positioning + transform for centering — consider \`display: grid; place-items: center\`"
 
-9c. FLEX MIN-WIDTH ZERO HACK
+10c. FLEX MIN-WIDTH ZERO HACK
 Look for rules where a flex item (an element whose parent has \`display: flex\` or \`display: inline-flex\`) has \`min-width: 0\`. This is a well-known workaround to prevent flex items from overflowing, and it often signals a layout misunderstanding. For each case, record:
 - "selector": the CSS selector with min-width: 0 on a flex item
 - "rule": "flex-min-width-zero-hack"
 - "severity": "suggestion"
 - "reason": "\`min-width: 0\` hack on a flex item — this overrides the default \`min-width: auto\` and may signal a layout misunderstanding. Consider setting an explicit preferred size instead"
 
-9d. FRAGILE NESTED SELECTORS
+10d. FRAGILE NESTED SELECTORS
 Look for selectors that couple CSS rules to a brittle DOM structure. These are selectors that use child combinators (\`>\`), adjacent sibling combinators (\`+\`), or deep nesting of descendant selectors (3+ levels) where a small HTML refactor would break the styling. Focus on: more than 2 consecutive child combinators (e.g. \`.card > .header > .title\`), adjacent siblings with fragile ordering assumptions (e.g. \`.header + .content\`), and deeply nested descendants with 3+ space-separated levels targeting generic elements (e.g. \`.sidebar ul li a\`). Do NOT flag single-level child combinators that are structural by nature (e.g. \`.list > .item\` is fine). For each fragile selector, record:
 - "selector": the full CSS selector
 - "rule": "fragile-nested-selectors"
@@ -159,17 +159,17 @@ Look for selectors that couple CSS rules to a brittle DOM structure. These are s
 
 Cap at 12 modernPracticeIssues total. Prioritize by severity of the pattern (legacy-centering and fragile selectors first). Skip any selector already flagged in layoutA11yIssues.
 
-STEP 10 — MODERN FEATURE ADOPTION SUGGESTIONS
+STEP 11 — MODERN FEATURE ADOPTION SUGGESTIONS
 Scan the CSS for opportunities to adopt modern CSS features that are underused in the ecosystem. These are aspirational suggestions (severity info), not warnings. Focus on two patterns:
 
-10a. USE CSS LAYERS
+11a. USE CSS LAYERS
 If the CSS source has more than 20 selector rules and no @layer declarations, record a suggestion to adopt @layer for better cascade organization. Also detect projects that use @layer but only a single layer — they may benefit from splitting into multiple layers (e.g. reset, base, components, utilities). For each case, record:
 - "selector": empty string "" (this is project-wide guidance, not per-selector)
 - "rule": "use-css-layers"
 - "severity": "info"
 - "reason": "Project has N selector rules without @layer organization — consider adopting @layer for better cascade management and specificity control" (replace N with approximate selector count)
 
-10b. USE CONTAINER QUERIES
+11b. USE CONTAINER QUERIES
 Look for @media rules that scope by width and appear to target specific components. A component-level media query is one where the @media rule contains only a single block selector (like a component class) or where multiple similar @media blocks target sibling selectors. When you find @media queries that could be replaced by a @container query on the parent, record:
 - "selector": the class/selector that appears inside the @media block (the component targeted)
 - "rule": "use-container-queries"
@@ -178,17 +178,17 @@ Look for @media rules that scope by width and appear to target specific componen
 
 Only report up to 6 adoptionSuggestions total. Prioritize CSS layers first (one entry max), then up to 5 container query suggestions. These are informational only — do not include them in the chaos score.
 
-STEP 11 — OVERFLOW AND WRAP SAFETY
+STEP 12 — OVERFLOW AND WRAP SAFETY
 Scan the CSS for overflow and wrap safety issues in grid and flexbox containers. Focus on two patterns:
 
-11a. FLEX-WRAP MISSING
+12a. FLEX-WRAP MISSING
 Look for rules where a selector has \`display: flex\` or \`display: inline-flex\` without \`flex-wrap\`. Flex containers default to \`flex-wrap: nowrap\`, which means items will not wrap and can cause horizontal overflow on narrower viewports. For each such case, record:
 - "selector": the CSS selector that declares the flex container
 - "rule": "flex-wrap-missing"
 - "severity": "warning"
 - "reason": "Flex container without \`flex-wrap\` — items will not wrap and may overflow on narrow viewports. Consider adding \`flex-wrap: wrap\`"
 
-11b. MISSING OVERFLOW HANDLING
+12b. MISSING OVERFLOW HANDLING
 Look for grid or flex containers that have explicit width, height, or max-size constraints but no \`overflow\`, \`overflow-x\`, or \`overflow-y\` property set. When a sized container's children can exceed those bounds, content may be clipped or cause scroll issues. Common signals:
 - \`display: grid\` or \`display: flex\` with a fixed \`height\`, \`max-height\`, \`width\`, or \`max-width\`
 - Grid with \`grid-template-rows\` producing more tracks than available space typically fits

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -69,6 +69,7 @@ Compute a deterministic integer from 1–10. Start at 1, then add:
 - +2 if count of non-system fonts (isSystemFont === false) > 3
 - +1 if count of non-system fonts > 1 (stacks with the above)
 - +1 if lineHeights.unitlessMix is true
+- +1 if layoutA11yIssues.length >= 3
 Cap the final result at 10.
 
 STEP 6 — SUMMARY
@@ -76,6 +77,27 @@ Write 1–2 sentences naming the top quality issues. Be specific: cite actual co
 
 STEP 7 — BRAND
 Infer a project name from CSS comments, HTML title elements, BEM block prefixes, CSS variable namespaces (e.g. --myapp-*), or @layer names. Return "" if nothing identifiable is found.
+
+STEP 8 — LAYOUT ACCESSIBILITY
+Scan the CSS for layout accessibility issues related to grid and flexbox reordering. Focus on two patterns:
+
+8a. ORDER BREAKING DOM ORDER
+Look for rules where a selector has \`order\` AND its parent (or ancestor) has \`display: grid\` or \`display: flex\`. When an element has \`order\` set to a value other than 0, the visual order differs from the DOM order. For each such case, record:
+- "selector": the CSS selector that sets order
+- "property": "order"
+- "value": the order value (e.g. "2", "-1")
+- "reason": "Visual order differs from DOM order — this breaks keyboard navigation and screen reader flow"
+- "severity": "warning"
+
+8b. REORDERING WITHOUT TABINDEX FALLBACK
+When you detect a selector with order (as in 8a), check whether the same source provides a matching tabindex adjustment for the same element. If the CSS sets order but no corresponding tabindex value is found anywhere (in CSS or HTML comments), record:
+- "selector": the CSS selector that sets order
+- "property": "tabindex"
+- "value": "missing"
+- "reason": "Element is visually reordered via CSS \`order\` but has no \`tabindex\` adjustment — keyboard users will navigate in DOM order, not visual order"
+- "severity": "warning"
+
+Only report up to 10 issues total. Combine the two checks: for each order rule found, emit up to two LayoutA11yIssue entries (one for the order itself, one for the missing tabindex). Skip selectors where order is 0 (default).
 </instructions>
 
 <output_format>
@@ -110,7 +132,11 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
     "found": [1.2, 1.25, 1.5, 1.75],
     "suggestedScale": { "tight": 1.2, "snug": 1.25, "normal": 1.5, "relaxed": 1.75 },
     "unitlessMix": true
-  }
+  },
+  "layoutA11yIssues": [
+    { "selector": ".nav-logo", "property": "order", "value": "-1", "reason": "Visual order differs from DOM order — this breaks keyboard navigation and screen reader flow", "severity": "warning" },
+    { "selector": ".cta-button", "property": "tabindex", "value": "missing", "reason": "Element is visually reordered via CSS \`order\` but has no \`tabindex\` adjustment — keyboard users will navigate in DOM order, not visual order", "severity": "warning" }
+  ]
 }
 </example>
 </output_format>`

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -98,6 +98,39 @@ When you detect a selector with order (as in 8a), check whether the same source 
 - "severity": "warning"
 
 Only report up to 10 issues total. Combine the two checks: for each order rule found, emit up to two LayoutA11yIssue entries (one for the order itself, one for the missing tabindex). Skip selectors where order is 0 (default).
+
+STEP 9 — MODERN CSS BEST PRACTICES
+Scan the CSS for code patterns that can be improved with modern CSS features. Focus on four checks:
+
+9a. SINGLE-COLUMN GRID THAT COULD BE FLEXBOX
+Look for rules where a selector has \`display: grid\` with \`grid-template-columns\` set to a single column (e.g. \`grid-template-columns: 1fr\`, \`grid-template-columns: 100%\`, or \`grid-template-columns: repeat(1, 1fr)\`). A single-column grid offers no layout advantage over flexbox with wrap. For each such case, record:
+- "selector": the CSS selector with the grid rule
+- "rule": "grid-when-flexbox-wrap-would-work"
+- "severity": "suggestion"
+- "reason": "Single-column grid layout — consider \`display: flex; flex-wrap: wrap\` for simpler responsive behavior"
+
+9b. LEGACY CENTERING TECHNIQUES
+Look for centering techniques that predate modern grid/flex layout. Detect patterns like: \`margin: 0 auto\` with an explicit \`width\` (centered block), \`position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%)\` (absolute centering), or \`text-align: center\` used for block-level centering with \`display: inline-block\` on children. Do NOT flag \`text-align: center\` on inline text (that is the correct use). For each legacy pattern found, record:
+- "selector": the CSS selector using the legacy technique
+- "rule": "legacy-centering"
+- "severity": "suggestion"
+- "reason": a specific message like "Using margin:auto + fixed width for centering — consider \`display: flex; justify-content: center\`" or "Using absolute positioning + transform for centering — consider \`display: grid; place-items: center\`"
+
+9c. FLEX MIN-WIDTH ZERO HACK
+Look for rules where a flex item (an element whose parent has \`display: flex\` or \`display: inline-flex\`) has \`min-width: 0\`. This is a well-known workaround to prevent flex items from overflowing, and it often signals a layout misunderstanding. For each case, record:
+- "selector": the CSS selector with min-width: 0 on a flex item
+- "rule": "flex-min-width-zero-hack"
+- "severity": "suggestion"
+- "reason": "\`min-width: 0\` hack on a flex item — this overrides the default \`min-width: auto\` and may signal a layout misunderstanding. Consider setting an explicit preferred size instead"
+
+9d. FRAGILE NESTED SELECTORS
+Look for selectors that couple CSS rules to a brittle DOM structure. These are selectors that use child combinators (\`>\`), adjacent sibling combinators (\`+\`), or deep nesting of descendant selectors (3+ levels) where a small HTML refactor would break the styling. Focus on: more than 2 consecutive child combinators (e.g. \`.card > .header > .title\`), adjacent siblings with fragile ordering assumptions (e.g. \`.header + .content\`), and deeply nested descendants with 3+ space-separated levels targeting generic elements (e.g. \`.sidebar ul li a\`). Do NOT flag single-level child combinators that are structural by nature (e.g. \`.list > .item\` is fine). For each fragile selector, record:
+- "selector": the full CSS selector
+- "rule": "fragile-nested-selectors"
+- "severity": "suggestion"
+- "reason": "This selector depends on a specific DOM structure — consider using a single class name or BEM naming to reduce coupling"
+
+Cap at 12 modernPracticeIssues total. Prioritize by severity of the pattern (legacy-centering and fragile selectors first). Skip any selector already flagged in layoutA11yIssues.
 </instructions>
 
 <output_format>
@@ -136,6 +169,12 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
   "layoutA11yIssues": [
     { "selector": ".nav-logo", "property": "order", "value": "-1", "reason": "Visual order differs from DOM order — this breaks keyboard navigation and screen reader flow", "severity": "warning" },
     { "selector": ".cta-button", "property": "tabindex", "value": "missing", "reason": "Element is visually reordered via CSS \`order\` but has no \`tabindex\` adjustment — keyboard users will navigate in DOM order, not visual order", "severity": "warning" }
+  ],
+  "modernPracticeIssues": [
+    { "selector": ".card-grid", "rule": "grid-when-flexbox-wrap-would-work", "severity": "suggestion", "reason": "Single-column grid layout \u2014 consider \`display: flex; flex-wrap: wrap\` for simpler responsive behavior" },
+    { "selector": ".modal", "rule": "legacy-centering", "severity": "suggestion", "reason": "Using absolute positioning + transform for centering \u2014 consider \`display: grid; place-items: center\`" },
+    { "selector": ".flex-child", "rule": "flex-min-width-zero-hack", "severity": "suggestion", "reason": "\`min-width: 0\` hack on a flex item \u2014 this overrides the default \`min-width: auto\` and may signal a layout misunderstanding" },
+    { "selector": ".card > .header > .title", "rule": "fragile-nested-selectors", "severity": "suggestion", "reason": "This selector depends on a specific DOM structure \u2014 consider using a single class name or BEM naming to reduce coupling" }
   ]
 }
 </example>

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -157,7 +157,25 @@ Look for selectors that couple CSS rules to a brittle DOM structure. These are s
 - "reason": "This selector depends on a specific DOM structure — consider using a single class name or BEM naming to reduce coupling"
 
 Cap at 12 modernPracticeIssues total. Prioritize by severity of the pattern (legacy-centering and fragile selectors first). Skip any selector already flagged in layoutA11yIssues.
-</instructions>
+
+STEP 10 — MODERN FEATURE ADOPTION SUGGESTIONS
+Scan the CSS for opportunities to adopt modern CSS features that are underused in the ecosystem. These are aspirational suggestions (severity info), not warnings. Focus on two patterns:
+
+10a. USE CSS LAYERS
+If the CSS source has more than 20 selector rules and no @layer declarations, record a suggestion to adopt @layer for better cascade organization. Also detect projects that use @layer but only a single layer — they may benefit from splitting into multiple layers (e.g. reset, base, components, utilities). For each case, record:
+- "selector": empty string "" (this is project-wide guidance, not per-selector)
+- "rule": "use-css-layers"
+- "severity": "info"
+- "reason": "Project has N selector rules without @layer organization — consider adopting @layer for better cascade management and specificity control" (replace N with approximate selector count)
+
+10b. USE CONTAINER QUERIES
+Look for @media rules that scope by width and appear to target specific components. A component-level media query is one where the @media rule contains only a single block selector (like a component class) or where multiple similar @media blocks target sibling selectors. When you find @media queries that could be replaced by a @container query on the parent, record:
+- "selector": the class/selector that appears inside the @media block (the component targeted)
+- "rule": "use-container-queries"
+- "severity": "info"
+- "reason": "Component appears to use width-scoped @media queries — consider wrapping the parent in a @container and using @container queries for component-responsive behavior"
+
+Only report up to 6 adoptionSuggestions total. Prioritize CSS layers first (one entry max), then up to 5 container query suggestions. These are informational only — do not include them in the chaos score.</instructions>
 
 <output_format>
 Return ONLY a valid JSON object matching the structure in the example below. No markdown fences, no backticks, no text before or after the JSON.
@@ -217,7 +235,11 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
     { "selector": ".card-grid", "rule": "grid-when-flexbox-wrap-would-work", "severity": "suggestion", "reason": "Single-column grid layout \u2014 consider \`display: flex; flex-wrap: wrap\` for simpler responsive behavior" },
     { "selector": ".modal", "rule": "legacy-centering", "severity": "suggestion", "reason": "Using absolute positioning + transform for centering \u2014 consider \`display: grid; place-items: center\`" },
     { "selector": ".flex-child", "rule": "flex-min-width-zero-hack", "severity": "suggestion", "reason": "\`min-width: 0\` hack on a flex item \u2014 this overrides the default \`min-width: auto\` and may signal a layout misunderstanding" },
-    { "selector": ".card > .header > .title", "rule": "fragile-nested-selectors", "severity": "suggestion", "reason": "This selector depends on a specific DOM structure \u2014 consider using a single class name or BEM naming to reduce coupling" }
+    { "selector": ".card > .header > .title", "rule": "fragile-nested-selectors", "severity": "suggestion", "reason": "This selector depends on a specific DOM structure — consider using a single class name or BEM naming to reduce coupling" }
+  ],
+  "adoptionSuggestions": [
+    { "selector": "", "rule": "use-css-layers", "severity": "info", "reason": "Project has 47 selector rules without @layer organization — consider adopting @layer for better cascade management and specificity control" },
+    { "selector": ".product-card", "rule": "use-container-queries", "severity": "info", "reason": "Component appears to use width-scoped @media queries — consider wrapping the parent in a @container and using @container queries for component-responsive behavior" }
   ]
 }
 </example>

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -124,6 +124,39 @@ When you detect a selector with order (as in 9a), check whether the same source 
 - "severity": "warning"
 
 Only report up to 10 issues total. Combine the two checks: for each order rule found, emit up to two LayoutA11yIssue entries (one for the order itself, one for the missing tabindex). Skip selectors where order is 0 (default).
+
+STEP 9 — MODERN CSS BEST PRACTICES
+Scan the CSS for code patterns that can be improved with modern CSS features. Focus on four checks:
+
+9a. SINGLE-COLUMN GRID THAT COULD BE FLEXBOX
+Look for rules where a selector has \`display: grid\` with \`grid-template-columns\` set to a single column (e.g. \`grid-template-columns: 1fr\`, \`grid-template-columns: 100%\`, or \`grid-template-columns: repeat(1, 1fr)\`). A single-column grid offers no layout advantage over flexbox with wrap. For each such case, record:
+- "selector": the CSS selector with the grid rule
+- "rule": "grid-when-flexbox-wrap-would-work"
+- "severity": "suggestion"
+- "reason": "Single-column grid layout — consider \`display: flex; flex-wrap: wrap\` for simpler responsive behavior"
+
+9b. LEGACY CENTERING TECHNIQUES
+Look for centering techniques that predate modern grid/flex layout. Detect patterns like: \`margin: 0 auto\` with an explicit \`width\` (centered block), \`position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%)\` (absolute centering), or \`text-align: center\` used for block-level centering with \`display: inline-block\` on children. Do NOT flag \`text-align: center\` on inline text (that is the correct use). For each legacy pattern found, record:
+- "selector": the CSS selector using the legacy technique
+- "rule": "legacy-centering"
+- "severity": "suggestion"
+- "reason": a specific message like "Using margin:auto + fixed width for centering — consider \`display: flex; justify-content: center\`" or "Using absolute positioning + transform for centering — consider \`display: grid; place-items: center\`"
+
+9c. FLEX MIN-WIDTH ZERO HACK
+Look for rules where a flex item (an element whose parent has \`display: flex\` or \`display: inline-flex\`) has \`min-width: 0\`. This is a well-known workaround to prevent flex items from overflowing, and it often signals a layout misunderstanding. For each case, record:
+- "selector": the CSS selector with min-width: 0 on a flex item
+- "rule": "flex-min-width-zero-hack"
+- "severity": "suggestion"
+- "reason": "\`min-width: 0\` hack on a flex item — this overrides the default \`min-width: auto\` and may signal a layout misunderstanding. Consider setting an explicit preferred size instead"
+
+9d. FRAGILE NESTED SELECTORS
+Look for selectors that couple CSS rules to a brittle DOM structure. These are selectors that use child combinators (\`>\`), adjacent sibling combinators (\`+\`), or deep nesting of descendant selectors (3+ levels) where a small HTML refactor would break the styling. Focus on: more than 2 consecutive child combinators (e.g. \`.card > .header > .title\`), adjacent siblings with fragile ordering assumptions (e.g. \`.header + .content\`), and deeply nested descendants with 3+ space-separated levels targeting generic elements (e.g. \`.sidebar ul li a\`). Do NOT flag single-level child combinators that are structural by nature (e.g. \`.list > .item\` is fine). For each fragile selector, record:
+- "selector": the full CSS selector
+- "rule": "fragile-nested-selectors"
+- "severity": "suggestion"
+- "reason": "This selector depends on a specific DOM structure — consider using a single class name or BEM naming to reduce coupling"
+
+Cap at 12 modernPracticeIssues total. Prioritize by severity of the pattern (legacy-centering and fragile selectors first). Skip any selector already flagged in layoutA11yIssues.
 </instructions>
 
 <output_format>
@@ -179,6 +212,12 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
   "layoutA11yIssues": [
     { "selector": ".nav-logo", "property": "order", "value": "-1", "reason": "Visual order differs from DOM order — this breaks keyboard navigation and screen reader flow", "severity": "warning" },
     { "selector": ".cta-button", "property": "tabindex", "value": "missing", "reason": "Element is visually reordered via CSS \`order\` but has no \`tabindex\` adjustment — keyboard users will navigate in DOM order, not visual order", "severity": "warning" }
+  ],
+  "modernPracticeIssues": [
+    { "selector": ".card-grid", "rule": "grid-when-flexbox-wrap-would-work", "severity": "suggestion", "reason": "Single-column grid layout \u2014 consider \`display: flex; flex-wrap: wrap\` for simpler responsive behavior" },
+    { "selector": ".modal", "rule": "legacy-centering", "severity": "suggestion", "reason": "Using absolute positioning + transform for centering \u2014 consider \`display: grid; place-items: center\`" },
+    { "selector": ".flex-child", "rule": "flex-min-width-zero-hack", "severity": "suggestion", "reason": "\`min-width: 0\` hack on a flex item \u2014 this overrides the default \`min-width: auto\` and may signal a layout misunderstanding" },
+    { "selector": ".card > .header > .title", "rule": "fragile-nested-selectors", "severity": "suggestion", "reason": "This selector depends on a specific DOM structure \u2014 consider using a single class name or BEM naming to reduce coupling" }
   ]
 }
 </example>

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -70,6 +70,7 @@ Compute a deterministic integer from 1–10. Start at 1, then add:
 - +1 if count of non-system fonts > 1 (stacks with the above)
 - +1 if lineHeights.unitlessMix is true
 - +1 if layoutA11yIssues.length >= 3
+- +1 if overflowSafetyIssues.length >= 4
 Cap the final result at 10.
 
 STEP 6 — SUMMARY
@@ -149,7 +150,29 @@ Look for @media rules that scope by width and appear to target specific componen
 - "severity": "info"
 - "reason": "Component appears to use width-scoped @media queries — consider wrapping the parent in a @container and using @container queries for component-responsive behavior"
 
-Only report up to 6 adoptionSuggestions total. Prioritize CSS layers first (one entry max), then up to 5 container query suggestions. These are informational only — do not include them in the chaos score.</instructions>
+Only report up to 6 adoptionSuggestions total. Prioritize CSS layers first (one entry max), then up to 5 container query suggestions. These are informational only — do not include them in the chaos score.
+
+STEP 11 — OVERFLOW AND WRAP SAFETY
+Scan the CSS for overflow and wrap safety issues in grid and flexbox containers. Focus on two patterns:
+
+11a. FLEX-WRAP MISSING
+Look for rules where a selector has \`display: flex\` or \`display: inline-flex\` without \`flex-wrap\`. Flex containers default to \`flex-wrap: nowrap\`, which means items will not wrap and can cause horizontal overflow on narrower viewports. For each such case, record:
+- "selector": the CSS selector that declares the flex container
+- "rule": "flex-wrap-missing"
+- "severity": "warning"
+- "reason": "Flex container without \`flex-wrap\` — items will not wrap and may overflow on narrow viewports. Consider adding \`flex-wrap: wrap\`"
+
+11b. MISSING OVERFLOW HANDLING
+Look for grid or flex containers that have explicit width, height, or max-size constraints but no \`overflow\`, \`overflow-x\`, or \`overflow-y\` property set. When a sized container's children can exceed those bounds, content may be clipped or cause scroll issues. Common signals:
+- \`display: grid\` or \`display: flex\` with a fixed \`height\`, \`max-height\`, \`width\`, or \`max-width\`
+- Grid with \`grid-template-rows\` producing more tracks than available space typically fits
+For each such case, record:
+- "selector": the CSS selector for the container
+- "rule": "missing-overflow-wrap"
+- "severity": "suggestion"
+- "reason": a specific message identifying the overflow risk (e.g. "Grid container with fixed height but no overflow handling — content may be clipped if grid items exceed the container" or "Flex container with max-width and no overflow property — ensure overflow is handled explicitly")
+
+Only report up to 8 overflowSafetyIssues total. Prioritize flex-wrap-missing (warnings) first, then missing-overflow-wrap (suggestions).</instructions>
 
 <output_format>
 Return ONLY a valid JSON object matching the structure in the example below. No markdown fences, no backticks, no text before or after the JSON.
@@ -197,6 +220,10 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
   "adoptionSuggestions": [
     { "selector": "", "rule": "use-css-layers", "severity": "info", "reason": "Project has 47 selector rules without @layer organization — consider adopting @layer for better cascade management and specificity control" },
     { "selector": ".product-card", "rule": "use-container-queries", "severity": "info", "reason": "Component appears to use width-scoped @media queries — consider wrapping the parent in a @container and using @container queries for component-responsive behavior" }
+  ],
+  "overflowSafetyIssues": [
+    { "selector": ".nav-list", "rule": "flex-wrap-missing", "severity": "warning", "reason": "Flex container without \`flex-wrap\` — items will not wrap and may overflow on narrow viewports" },
+    { "selector": ".dashboard-grid", "rule": "missing-overflow-wrap", "severity": "suggestion", "reason": "Grid container with fixed height but no overflow handling — content may be clipped if grid items exceed the container" }
   ]
 }
 </example>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -78,6 +78,14 @@ export interface LineHeightAudit {
   unitlessMix: boolean
 }
 
+export interface LayoutA11yIssue {
+  selector: string
+  property: string // 'order' or 'tabindex'
+  value: string
+  reason: string
+  severity: 'warning' // always warning for a11y impact
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -86,6 +94,7 @@ export interface AuditReport {
   fonts: FontEntry[]
   spacing: SpacingAudit
   lineHeights: LineHeightAudit
+  layoutA11yIssues: LayoutA11yIssue[]
 }
 
 export interface ColorDecision {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -130,6 +130,13 @@ export interface AdoptionSuggestion {
   reason: string
 }
 
+export interface OverflowSafetyIssue {
+  selector: string
+  rule: string // 'flex-wrap-missing' | 'missing-overflow-wrap'
+  severity: 'warning' | 'suggestion'
+  reason: string
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -142,6 +149,7 @@ export interface AuditReport {
   layoutA11yIssues?: LayoutA11yIssue[]
   modernPracticeIssues?: ModernPracticeIssue[]
   adoptionSuggestions?: AdoptionSuggestion[]
+  overflowSafetyIssues?: OverflowSafetyIssue[]
 }
 
 export interface ColorDecision {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -108,6 +108,14 @@ export interface MotionAudit {
   duplicateDeclarations: number
 }
 
+export interface LayoutA11yIssue {
+  selector: string
+  property: string // 'order' or 'tabindex'
+  value: string
+  reason: string
+  severity: 'warning' // always warning for a11y impact
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -117,6 +125,7 @@ export interface AuditReport {
   spacing: SpacingAudit
   lineHeights: LineHeightAudit
   motion?: MotionAudit
+  layoutA11yIssues?: LayoutA11yIssue[]
 }
 
 export interface ColorDecision {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -86,6 +86,20 @@ export interface LayoutA11yIssue {
   severity: 'warning' // always warning for a11y impact
 }
 
+export interface ModernPracticeIssue {
+  selector: string
+  rule: string // 'grid-when-flexbox-wrap-would-work' | 'legacy-centering' | 'flex-min-width-zero-hack' | 'fragile-nested-selectors'
+  severity: 'suggestion'
+  reason: string
+}
+
+export interface AdoptionSuggestion {
+  selector: string
+  rule: string // 'use-css-layers' | 'use-container-queries'
+  severity: 'info'
+  reason: string
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -95,6 +109,8 @@ export interface AuditReport {
   spacing: SpacingAudit
   lineHeights: LineHeightAudit
   layoutA11yIssues: LayoutA11yIssue[]
+  modernPracticeIssues: ModernPracticeIssue[]
+  adoptionSuggestions: AdoptionSuggestion[]
 }
 
 export interface ColorDecision {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -116,6 +116,20 @@ export interface LayoutA11yIssue {
   severity: 'warning' // always warning for a11y impact
 }
 
+export interface ModernPracticeIssue {
+  selector: string
+  rule: string // 'grid-when-flexbox-wrap-would-work' | 'legacy-centering' | 'flex-min-width-zero-hack' | 'fragile-nested-selectors'
+  severity: 'suggestion'
+  reason: string
+}
+
+export interface AdoptionSuggestion {
+  selector: string
+  rule: string // 'use-css-layers' | 'use-container-queries'
+  severity: 'info'
+  reason: string
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -126,6 +140,8 @@ export interface AuditReport {
   lineHeights: LineHeightAudit
   motion?: MotionAudit
   layoutA11yIssues?: LayoutA11yIssue[]
+  modernPracticeIssues?: ModernPracticeIssue[]
+  adoptionSuggestions?: AdoptionSuggestion[]
 }
 
 export interface ColorDecision {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -100,6 +100,13 @@ export interface AdoptionSuggestion {
   reason: string
 }
 
+export interface OverflowSafetyIssue {
+  selector: string
+  rule: string // 'flex-wrap-missing' | 'missing-overflow-wrap'
+  severity: 'warning' | 'suggestion'
+  reason: string
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -111,6 +118,7 @@ export interface AuditReport {
   layoutA11yIssues: LayoutA11yIssue[]
   modernPracticeIssues: ModernPracticeIssue[]
   adoptionSuggestions: AdoptionSuggestion[]
+  overflowSafetyIssues: OverflowSafetyIssue[]
 }
 
 export interface ColorDecision {


### PR DESCRIPTION
Card: https://github.com/nujovich/mint-radar/issues/5

## Summary

Extends the Claude CSS audit with a **layout-linting pass** that flags accessibility and modern-CSS issues, on top of the existing color / font / spacing / motion analysis. Findings are returned in the `AuditReport` and surfaced in both the CLI summary and the web AuditView.

## What it detects

| Category | Rules | Severity |
| --- | --- | --- |
| **Layout accessibility** | `order` breaking DOM order; reordering without a `tabindex` fallback | warning |
| **Modern best practices** | single-column grids, legacy centering, flex `min-width: 0` hack, fragile nested selectors | suggestion |
| **Feature adoption** | `@layer` cascade organization, `@container` queries | info |
| **Overflow & wrap safety** | flex containers missing `flex-wrap`; sized grid/flex without overflow handling | warning / suggestion |

## Changes

- **Prompt** (`lib/prompts.mjs`) — new audit steps for the four categories plus their output fields; the chaos score gains +1 for ≥3 layout-accessibility issues and +1 for ≥4 overflow issues (adoption suggestions are informational and never affect the score).
- **Types** (`lib/types.ts`) — new optional `AuditReport` fields (`layoutA11yIssues`, `modernPracticeIssues`, `adoptionSuggestions`, `overflowSafetyIssues`) with matching interfaces.
- **CLI** (`bin/mint-ds.mjs`) — the audit summary prints a per-category issue-count line.
- **Web** (`components/AuditView.tsx`) — a new "Layout linting" section listing each finding with its severity, selector, and rationale.
- **Docs** — README "CSS layout linting" section and a CHANGELOG entry.

## Testing

- Unit tests for the prompt content, audit parsing, and the shared summary helpers (`lib/audit-summary.mjs`).
- Local checks green: lint, typecheck, unit tests, and `next build`.
