### PR TITLE
feat: DTCG v1 validation for tokens.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- `mint-ds validate` — DTCG v1 validation for `tokens.json`: structural checks plus
+  semantic checks (broken/circular references, naming consistency, reference type
+  mismatches), `--json` output, `--no-semantic` flag, and CI templates under `templates/dtcg/`.
+
 ## [0.1.0] - 2026-05-19
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -274,6 +274,21 @@ These commands set the key only for the current shell session. To persist it, ad
 | `mint-ds cache --clear`          | Delete the local `mint-ds.cache.json` cache file                                                                           |
 | `mint-ds --help`                 | Show full usage                                                                                                            |
 
+### Validate options
+
+| Flag            | Description                                                |
+| --------------- | ---------------------------------------------------------- |
+| `--spec <name>` | Spec to validate against (default: `dtcg`)                 |
+| `--json`        | Emit machine-readable JSON to stdout                       |
+| `--no-semantic` | Skip semantic checks (refs, cycles, naming, type mismatch) |
+
+`validate` runs two layers of checks:
+
+- **Structural** — every node must be a valid DTCG token (with `$value`) or a group; `$type` is required and validated against the value.
+- **Semantic** — broken references, circular references, naming-convention drift, and reference type mismatches.
+
+**Exit codes:** `0` valid · `1` warnings only · `2` errors. Structural violations and broken/circular references are errors (exit `2`); naming drift and type mismatches are warnings (exit `1`). Ready-made CI templates (GitHub Action + pre-commit hook) live in [`templates/dtcg/`](templates/dtcg/).
+
 ### Audit options
 
 | Flag              | Description                                                               |

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ These commands set the key only for the current shell session. To persist it, ad
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `mint-ds audit <dir>`            | Walk `<dir>` for `.css`, `.scss`, `.sass`, `.less`, `.html` files, audit them with Claude, and write `mint-ds.tokens.json` |
 | `mint-ds export --target <name>` | Read `mint-ds.tokens.json` and generate the chosen format                                                                  |
+| `mint-ds validate <file>`        | Validate `tokens.json` against DTCG v1 — structure, references, cycles, naming consistency                                 |
 | `mint-ds cache --clear`          | Delete the local `mint-ds.cache.json` cache file                                                                           |
 | `mint-ds --help`                 | Show full usage                                                                                                            |
 

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -17,6 +17,7 @@ import {
   resolveTarget,
 } from '../lib/prompts.mjs'
 import { getCssAuditor } from '../lib/css-auditor.mjs'
+import { validateFile } from '../lib/dtcg-validator.mjs'
 
 const require = createRequire(import.meta.url)
 const { version: VERSION } = require('../package.json')
@@ -84,6 +85,7 @@ ${styles.bold('USAGE')}
 ${styles.bold('COMMANDS')}
   audit <dir>                  Analyze CSS/SCSS files in <dir> and write ${DEFAULT_TOKENS_FILE}
   export --target <name>       Generate exports from ${DEFAULT_TOKENS_FILE}
+  validate <file> [options]    Validate tokens.json against a spec (e.g. dtcg)
   cache --clear                Delete the local ${CACHE_FILE}
 
 ${styles.bold('AUDIT OPTIONS')}
@@ -99,6 +101,11 @@ ${styles.bold('EXPORT OPTIONS')}
   --out <file>                 Override the generated filename
   --stdout                     Print to stdout instead of writing a file
 
+${styles.bold('VALIDATE OPTIONS')}
+  --spec <name>                Spec to validate against (default: dtcg). Values: dtcg
+  --json                       Output results as JSON
+  --quiet                      Suppress non-error output
+
 ${styles.bold('AUTH (any command)')}
   --api-key <value>            Anthropic API key (overrides ANTHROPIC_API_KEY env var)
 
@@ -111,6 +118,8 @@ ${styles.bold('EXAMPLES')}
   npx mint-ds export --target tailwind
   npx mint-ds export --target react --out ui/Components.tsx
   npx mint-ds export --target css --stdout > variables.css
+  npx mint-ds validate tokens.json --spec dtcg
+  npx mint-ds validate tokens.json --spec dtcg --json
 `)
 }
 
@@ -383,6 +392,40 @@ async function cmdExport(argv) {
   )
 }
 
+async function cmdValidate(argv) {
+  const { flags, rest } = parseFlags(argv)
+  const file = rest[0]
+  if (!file)
+    die(
+      'Usage: mint-ds validate <tokens.json> [--spec dtcg] [--json] [--quiet]'
+    )
+
+  const spec = String(flags.spec || 'dtcg').toLowerCase()
+  if (spec !== 'dtcg') {
+    die(`Unknown spec "${spec}". Supported: dtcg`)
+  }
+
+  const asJson = Boolean(flags.json)
+  const quiet = Boolean(flags.quiet)
+
+  log(
+    styles.cyan('→') +
+      ` Validating ${styles.bold(file)} against ${styles.bold(spec.toUpperCase())} v1…`
+  )
+
+  const result = await validateFile(file)
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify(result.toJSON(), null, 2) + '\n')
+  } else if (!quiet) {
+    const output = result.print(true, false)
+    log(output)
+  }
+
+  // Exit with appropriate code: 0 = ok, 1 = warnings, 2 = errors
+  process.exit(result.exitCode)
+}
+
 async function main() {
   const argv = process.argv.slice(2)
   if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help') {
@@ -398,6 +441,7 @@ async function main() {
   try {
     if (cmd === 'audit') await cmdAudit(rest)
     else if (cmd === 'export') await cmdExport(rest)
+    else if (cmd === 'validate') await cmdValidate(rest)
     else if (cmd === 'cache') await cmdCache(rest)
     else {
       printHelp()

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -105,6 +105,7 @@ ${styles.bold('VALIDATE OPTIONS')}
   --spec <name>                Spec to validate against (default: dtcg). Values: dtcg
   --json                       Output results as JSON
   --quiet                      Suppress non-error output
+  --no-semantic                Skip semantic checks (refs, cycles, naming, type mismatch)
 
 ${styles.bold('AUTH (any command)')}
   --api-key <value>            Anthropic API key (overrides ANTHROPIC_API_KEY env var)
@@ -413,7 +414,9 @@ async function cmdValidate(argv) {
       ` Validating ${styles.bold(file)} against ${styles.bold(spec.toUpperCase())} v1…`
   )
 
-  const result = await validateFile(file)
+  const result = await validateFile(file, {
+    semantic: flags['no-semantic'] !== true,
+  })
 
   if (asJson) {
     process.stdout.write(JSON.stringify(result.toJSON(), null, 2) + '\n')

--- a/examples/frankenstein/mint-ds.tokens.dtcg.broken.json
+++ b/examples/frankenstein/mint-ds.tokens.dtcg.broken.json
@@ -1,0 +1,135 @@
+{
+  "color": {
+    "$type": "color",
+    "primary": {
+      "50": { "$value": "#e3f2fd" },
+      "100": { "$value": "#bbdefb" },
+      "200": { "$value": "#90caf9" },
+      "300": { "$value": "#64b5f6" },
+      "400": { "$value": "#42a5f5" },
+      "500": { "$value": "#1976d2" },
+      "600": { "$value": "#1565c0" },
+      "700": { "$value": "#0d47a1" },
+      "800": { "$value": "#0a3f8f" },
+      "900": { "$value": "#08357d" }
+    },
+    "error": {
+      "50": { "$value": "#ffebee" },
+      "100": { "$value": "#ffcdd2" },
+      "200": { "$value": "#ef9a9a" },
+      "300": { "$value": "#e57373" },
+      "400": { "$value": "#ef5350" },
+      "500": { "$value": "#e53935" },
+      "600": { "$value": "#d32f2f" },
+      "700": { "$value": "#c62828" },
+      "800": { "$value": "#b71c1c" },
+      "900": { "$value": "#a01818" }
+    },
+    "background": {
+      "50": { "$value": "#fefefe" },
+      "100": { "$value": "#fdfdfd" },
+      "200": { "$value": "#fafafa" },
+      "300": { "$value": "#f7f7f7" },
+      "400": { "$value": "#f6f6f6" },
+      "500": { "$value": "#f5f5f5" },
+      "600": { "$value": "#e8e8e8" },
+      "700": { "$value": "#d4d4d4" },
+      "800": { "$value": "#c0c0c0" },
+      "900": { "$value": "#a8a8a8" }
+    },
+    "text": {
+      "50": { "$value": "#f5f5f5" },
+      "100": { "$value": "#e0e0e0" },
+      "200": { "$value": "#bdbdbd" },
+      "300": { "$value": "#9e9e9e" },
+      "400": { "$value": "#757575" },
+      "500": { "$value": "#212121" },
+      "600": { "$value": "#1e1e1e" },
+      "700": { "$value": "#1a1a1a" },
+      "800": { "$value": "#171717" },
+      "900": { "$value": "#141414" }
+    },
+    "border": {
+      "50": { "$value": "#f9f9f9" },
+      "100": { "$value": "#f4f4f4" },
+      "200": { "$value": "#eeeeee" },
+      "300": { "$value": "#e7e7e7" },
+      "400": { "$value": "#e2e2e2" },
+      "500": { "$value": "#dddddd" },
+      "600": { "$value": "#c7c7c7" },
+      "700": { "$value": "#a8a8a8" },
+      "800": { "$value": "#8a8a8a" },
+      "900": { "$value": "#6c6c6c" }
+    },
+    "surface": {
+      "50": { "$value": "#ffffff" },
+      "100": { "$value": "#ffffff" },
+      "200": { "$value": "#ffffff" },
+      "300": { "$value": "#ffffff" },
+      "400": { "$value": "#ffffff" },
+      "500": { "$value": "#ffffff" },
+      "600": { "$value": "#e6e6e6" },
+      "700": { "$value": "#cccccc" },
+      "800": { "$value": "#b3b3b3" },
+      "900": { "$value": "#999999" }
+    },
+    "muted": {
+      "50": { "$value": "#f2f2f2" },
+      "100": { "$value": "#e0e0e0" },
+      "200": { "$value": "#cccccc" },
+      "300": { "$value": "#b3b3b3" },
+      "400": { "$value": "#8c8c8c" },
+      "500": { "$value": "#666666" },
+      "600": { "$value": "#5c5c5c" },
+      "700": { "$value": "#4d4d4d" },
+      "800": { "$value": "#404040" },
+      "900": { "$value": "#333333" }
+    },
+
+    "link": { "$value": "{color.does-not-exist}" },
+
+    "alpha": { "$value": "{color.beta}" },
+    "beta": { "$value": "{color.alpha}" },
+
+    "brandPrimary": { "$value": "#1976d2" }
+  },
+  "spacing": {
+    "$type": "dimension",
+    "1": { "$value": { "value": 4, "unit": "px" } },
+    "2": { "$value": { "value": 8, "unit": "px" } },
+    "3": { "$value": { "value": 12, "unit": "px" } },
+    "5": { "$value": { "value": 20, "unit": "px" } },
+    "6": { "$value": { "value": 24, "unit": "px" } },
+    "weird": { "$value": "{color.primary.500}" }
+  },
+  "border-radius": {
+    "$type": "dimension",
+    "sm": { "$value": { "value": 4, "unit": "px" } },
+    "md": { "$value": { "value": 8, "unit": "px" } }
+  },
+  "shadow": {
+    "$type": "shadow",
+    "sm": {
+      "$value": [
+        {
+          "color": "#0000001a",
+          "offsetX": { "value": 0, "unit": "px" },
+          "offsetY": { "value": 2, "unit": "px" },
+          "blur": { "value": 4, "unit": "px" },
+          "spread": { "value": 0, "unit": "px" }
+        }
+      ]
+    }
+  },
+  "typography": {
+    "font-family": {
+      "$type": "fontFamily",
+      "body": { "$value": "Helvetica Neue" }
+    },
+    "font-weight": {
+      "$type": "fontWeight",
+      "bold": { "$value": 700 },
+      "extra-bold": { "$value": 800 }
+    }
+  }
+}

--- a/examples/frankenstein/mint-ds.tokens.dtcg.json
+++ b/examples/frankenstein/mint-ds.tokens.dtcg.json
@@ -1,0 +1,127 @@
+{
+  "color": {
+    "$type": "color",
+    "primary": {
+      "50": { "$value": "#e3f2fd" },
+      "100": { "$value": "#bbdefb" },
+      "200": { "$value": "#90caf9" },
+      "300": { "$value": "#64b5f6" },
+      "400": { "$value": "#42a5f5" },
+      "500": { "$value": "#1976d2" },
+      "600": { "$value": "#1565c0" },
+      "700": { "$value": "#0d47a1" },
+      "800": { "$value": "#0a3f8f" },
+      "900": { "$value": "#08357d" }
+    },
+    "error": {
+      "50": { "$value": "#ffebee" },
+      "100": { "$value": "#ffcdd2" },
+      "200": { "$value": "#ef9a9a" },
+      "300": { "$value": "#e57373" },
+      "400": { "$value": "#ef5350" },
+      "500": { "$value": "#e53935" },
+      "600": { "$value": "#d32f2f" },
+      "700": { "$value": "#c62828" },
+      "800": { "$value": "#b71c1c" },
+      "900": { "$value": "#a01818" }
+    },
+    "background": {
+      "50": { "$value": "#fefefe" },
+      "100": { "$value": "#fdfdfd" },
+      "200": { "$value": "#fafafa" },
+      "300": { "$value": "#f7f7f7" },
+      "400": { "$value": "#f6f6f6" },
+      "500": { "$value": "#f5f5f5" },
+      "600": { "$value": "#e8e8e8" },
+      "700": { "$value": "#d4d4d4" },
+      "800": { "$value": "#c0c0c0" },
+      "900": { "$value": "#a8a8a8" }
+    },
+    "text": {
+      "50": { "$value": "#f5f5f5" },
+      "100": { "$value": "#e0e0e0" },
+      "200": { "$value": "#bdbdbd" },
+      "300": { "$value": "#9e9e9e" },
+      "400": { "$value": "#757575" },
+      "500": { "$value": "#212121" },
+      "600": { "$value": "#1e1e1e" },
+      "700": { "$value": "#1a1a1a" },
+      "800": { "$value": "#171717" },
+      "900": { "$value": "#141414" }
+    },
+    "border": {
+      "50": { "$value": "#f9f9f9" },
+      "100": { "$value": "#f4f4f4" },
+      "200": { "$value": "#eeeeee" },
+      "300": { "$value": "#e7e7e7" },
+      "400": { "$value": "#e2e2e2" },
+      "500": { "$value": "#dddddd" },
+      "600": { "$value": "#c7c7c7" },
+      "700": { "$value": "#a8a8a8" },
+      "800": { "$value": "#8a8a8a" },
+      "900": { "$value": "#6c6c6c" }
+    },
+    "surface": {
+      "50": { "$value": "#ffffff" },
+      "100": { "$value": "#ffffff" },
+      "200": { "$value": "#ffffff" },
+      "300": { "$value": "#ffffff" },
+      "400": { "$value": "#ffffff" },
+      "500": { "$value": "#ffffff" },
+      "600": { "$value": "#e6e6e6" },
+      "700": { "$value": "#cccccc" },
+      "800": { "$value": "#b3b3b3" },
+      "900": { "$value": "#999999" }
+    },
+    "muted": {
+      "50": { "$value": "#f2f2f2" },
+      "100": { "$value": "#e0e0e0" },
+      "200": { "$value": "#cccccc" },
+      "300": { "$value": "#b3b3b3" },
+      "400": { "$value": "#8c8c8c" },
+      "500": { "$value": "#666666" },
+      "600": { "$value": "#5c5c5c" },
+      "700": { "$value": "#4d4d4d" },
+      "800": { "$value": "#404040" },
+      "900": { "$value": "#333333" }
+    }
+  },
+  "spacing": {
+    "$type": "dimension",
+    "1": { "$value": { "value": 4, "unit": "px" } },
+    "2": { "$value": { "value": 8, "unit": "px" } },
+    "3": { "$value": { "value": 12, "unit": "px" } },
+    "5": { "$value": { "value": 20, "unit": "px" } },
+    "6": { "$value": { "value": 24, "unit": "px" } }
+  },
+  "border-radius": {
+    "$type": "dimension",
+    "sm": { "$value": { "value": 4, "unit": "px" } },
+    "md": { "$value": { "value": 8, "unit": "px" } }
+  },
+  "shadow": {
+    "$type": "shadow",
+    "sm": {
+      "$value": [
+        {
+          "color": "#0000001a",
+          "offsetX": { "value": 0, "unit": "px" },
+          "offsetY": { "value": 2, "unit": "px" },
+          "blur": { "value": 4, "unit": "px" },
+          "spread": { "value": 0, "unit": "px" }
+        }
+      ]
+    }
+  },
+  "typography": {
+    "font-family": {
+      "$type": "fontFamily",
+      "body": { "$value": "Helvetica Neue" }
+    },
+    "font-weight": {
+      "$type": "fontWeight",
+      "bold": { "$value": 700 },
+      "extra-bold": { "$value": 800 }
+    }
+  }
+}

--- a/lib/__tests__/dtcg-validator.test.mjs
+++ b/lib/__tests__/dtcg-validator.test.mjs
@@ -447,6 +447,130 @@ describe('DTCG Validator', () => {
     })
   })
 
+  describe('semantic coherence (milestone 2)', () => {
+    it('reports broken references', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: { $value: '#1976d2' },
+          alias: { $value: '{color.nope}' },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.errors.some((e) => e.code === 'BROKEN_REFERENCE')).toBe(
+        true
+      )
+    })
+
+    it('accepts valid references between tokens', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: { $value: '#1976d2' },
+          alias: { $value: '{color.primary}' },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.errors.some((e) => e.code === 'BROKEN_REFERENCE')).toBe(
+        false
+      )
+    })
+
+    it('detects circular references', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          a: { $value: '{color.b}' },
+          b: { $value: '{color.a}' },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.errors.some((e) => e.code === 'CIRCULAR_REFERENCE')).toBe(
+        true
+      )
+    })
+
+    it('flags type mismatch on referenced tokens', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: { $value: '#1976d2' },
+        },
+        spacing: {
+          $type: 'dimension',
+          weird: { $value: '{color.primary}' },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.warnings.some((w) => w.code === 'TYPE_MISMATCH')).toBe(true)
+    })
+
+    it('extracts references from composite (object) values', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          base: { $value: '#000' },
+        },
+        border: {
+          $type: 'border',
+          thin: {
+            $value: {
+              width: { value: 1, unit: 'px' },
+              style: 'solid',
+              color: '{color.missing}',
+            },
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.errors.some((e) => e.code === 'BROKEN_REFERENCE')).toBe(
+        true
+      )
+    })
+
+    it('warns when naming conventions are mixed', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          'primary-light': { $value: '#aaa' },
+          'primary-dark': { $value: '#000' },
+          primaryAccent: { $value: '#fff' },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.warnings.some((w) => w.code === 'NAMING_CONVENTION')).toBe(
+        true
+      )
+    })
+
+    it('does not warn when naming is consistent', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          'primary-light': { $value: '#aaa' },
+          'primary-dark': { $value: '#000' },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.warnings.some((w) => w.code === 'NAMING_CONVENTION')).toBe(
+        false
+      )
+    })
+
+    it('can disable semantic checks via option', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          alias: { $value: '{color.nope}' },
+        },
+      }
+      const result = validateDTCG(tokens, { semantic: false })
+      expect(result.errors.some((e) => e.code === 'BROKEN_REFERENCE')).toBe(
+        false
+      )
+    })
+  })
+
   describe('ValidationResult', () => {
     it('tracks errors, warnings, infos separately', () => {
       const result = new ValidationResult()

--- a/lib/__tests__/dtcg-validator.test.mjs
+++ b/lib/__tests__/dtcg-validator.test.mjs
@@ -445,6 +445,27 @@ describe('DTCG Validator', () => {
       expect(result.hasErrors).toBe(true)
       expect(result.errors[0].code).toBe('INVALID_ROOT')
     })
+
+    it('treats a non-token/non-group top-level child as an error', () => {
+      const tokens = { brand: 'frankenstein' }
+      const result = validateDTCG(tokens)
+      expect(result.errors.some((e) => e.code === 'INVALID_TOP_LEVEL')).toBe(
+        true
+      )
+      expect(result.exitCode).toBe(2)
+    })
+
+    it('treats a non-token/non-group nested child as an error', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: { name: 'primary', value: '#1976d2' },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.errors.some((e) => e.code === 'INVALID_CHILD')).toBe(true)
+      expect(result.exitCode).toBe(2)
+    })
   })
 
   describe('semantic coherence (milestone 2)', () => {

--- a/lib/__tests__/dtcg-validator.test.mjs
+++ b/lib/__tests__/dtcg-validator.test.mjs
@@ -1,0 +1,484 @@
+import { describe, it, expect } from 'vitest'
+import { validateDTCG, ValidationResult, Severity } from '../dtcg-validator.mjs'
+
+describe('DTCG Validator', () => {
+  describe('validateDTCG', () => {
+    it('accepts a valid DTCG tokens file', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: {
+            $value: '#1976d2',
+            $type: 'color',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(false)
+      expect(result.exitCode).toBe(0)
+    })
+
+    it('rejects token missing $value', () => {
+      const tokens = {
+        color: {
+          primary: {
+            $type: 'color',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'MISSING_VALUE')).toBe(true)
+    })
+
+    it('rejects token missing $type with no inherited type', () => {
+      const tokens = {
+        color: {
+          primary: {
+            $value: '#1976d2',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'MISSING_TYPE')).toBe(true)
+    })
+
+    it('accepts token with inherited type from parent group', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: {
+            $value: '#1976d2',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(false)
+    })
+
+    it('validates color value format', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: {
+            $value: 'not-a-color',
+            $type: 'color',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasWarnings).toBe(true)
+      expect(result.warnings.some((w) => w.code === 'COLOR_FORMAT')).toBe(true)
+    })
+
+    it('validates dimension value structure', () => {
+      const tokens = {
+        spacing: {
+          $type: 'dimension',
+          small: {
+            $value: { value: 'not-a-number', unit: 'px' },
+            $type: 'dimension',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_DIMENSION')).toBe(
+        true
+      )
+    })
+
+    it('accepts valid dimension value', () => {
+      const tokens = {
+        spacing: {
+          $type: 'dimension',
+          small: {
+            $value: { value: 4, unit: 'px' },
+            $type: 'dimension',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(false)
+    })
+
+    it('accepts color object format', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: {
+            $value: {
+              colorSpace: 'srgb',
+              components: [1, 0, 0],
+              hex: '#ff0000',
+            },
+            $type: 'color',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(false)
+    })
+
+    it('rejects invalid color object', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: {
+            $value: { colorSpace: 'srgb' },
+            $type: 'color',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_COLOR_OBJECT')).toBe(
+        true
+      )
+    })
+
+    it('accepts duration format', () => {
+      const tokens = {
+        duration: {
+          $type: 'duration',
+          fast: {
+            $value: '150ms',
+            $type: 'duration',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(false)
+    })
+
+    it('rejects invalid duration format', () => {
+      const tokens = {
+        duration: {
+          $type: 'duration',
+          fast: {
+            $value: '150',
+            $type: 'duration',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_DURATION')).toBe(
+        true
+      )
+    })
+
+    it('accepts fontFamily as string or array', () => {
+      const tokens = {
+        typography: {
+          $type: 'fontFamilies',
+          body: {
+            $value: 'Inter',
+            $type: 'fontFamily',
+          },
+          heading: {
+            $value: ['Roboto', 'sans-serif'],
+            $type: 'fontFamily',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(false)
+    })
+
+    it('accepts references (curly brace syntax) without value validation', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: {
+            $value: '#1976d2',
+            $type: 'color',
+          },
+        },
+        semantic: {
+          text: {
+            $value: '{color.primary}',
+            $type: 'color',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(false)
+      expect(result.hasWarnings).toBe(false)
+    })
+
+    it('validates $description is string', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: {
+            $value: '#1976d2',
+            $type: 'color',
+            $description: 123,
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_DESCRIPTION')).toBe(
+        true
+      )
+    })
+
+    it('validates $deprecated format', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: {
+            $value: '#1976d2',
+            $type: 'color',
+            $deprecated: 123,
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_DEPRECATED')).toBe(
+        true
+      )
+    })
+
+    it('accepts valid $deprecated values', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          old: {
+            $value: '#1976d2',
+            $type: 'color',
+            $deprecated: true,
+          },
+          oldWithReason: {
+            $value: '#1976d2',
+            $type: 'color',
+            $deprecated: 'Use primary instead',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(false)
+    })
+
+    it('validates $extensions is object', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: {
+            $value: '#1976d2',
+            $type: 'color',
+            $extensions: 'not-an-object',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_EXTENSIONS')).toBe(
+        true
+      )
+    })
+
+    it('warns on unknown token properties', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          primary: {
+            $value: '#1976d2',
+            $type: 'color',
+            customProp: 'value',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasWarnings).toBe(true)
+      expect(result.warnings.some((w) => w.code === 'UNKNOWN_PROPERTY')).toBe(
+        true
+      )
+    })
+
+    it('validates group $type is string', () => {
+      const tokens = {
+        color: {
+          $type: 123,
+          primary: {
+            $value: '#1976d2',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_GROUP_TYPE')).toBe(
+        true
+      )
+    })
+
+    it('warns on non-standard group type', () => {
+      const tokens = {
+        customGroup: {
+          $type: 'customType',
+          primary: {
+            $value: '#1976d2',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasWarnings).toBe(true)
+      expect(
+        result.warnings.some((w) => w.code === 'NON_STANDARD_GROUP_TYPE')
+      ).toBe(true)
+    })
+
+    it('rejects invalid $extends', () => {
+      const tokens = {
+        base: {
+          $type: 'color',
+          primary: {
+            $value: '#1976d2',
+          },
+        },
+        derived: {
+          $extends: 123,
+          secondary: {
+            $value: '#9c27b0',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_EXTENDS')).toBe(true)
+    })
+
+    it('rejects circular $extends', () => {
+      const tokens = {
+        a: {
+          $extends: '{a}',
+          primary: {
+            $value: '#1976d2',
+            $type: 'color',
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'CIRCULAR_EXTENDS')).toBe(
+        true
+      )
+    })
+
+    it('validates token name rules', () => {
+      const tokens = {
+        'color.primary': {
+          // contains '.'
+          $value: '#1976d2',
+          $type: 'color',
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_TOKEN_NAME')).toBe(
+        true
+      )
+    })
+
+    it('rejects token name starting with $', () => {
+      const tokens = {
+        $color: {
+          $value: '#1976d2',
+          $type: 'color',
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_TOKEN_NAME')).toBe(
+        true
+      )
+    })
+
+    it('handles nested groups', () => {
+      const tokens = {
+        color: {
+          $type: 'color',
+          brand: {
+            $type: 'color',
+            primary: {
+              $value: '#1976d2',
+            },
+            secondary: {
+              $value: '#9c27b0',
+            },
+          },
+        },
+      }
+      const result = validateDTCG(tokens)
+      expect(result.hasErrors).toBe(false)
+    })
+
+    it('returns correct exit codes', () => {
+      const valid = {
+        color: { $type: 'color', primary: { $value: '#1976d2' } },
+      }
+      const warningsOnly = {
+        color: {
+          $type: 'color',
+          primary: { $value: 'not-a-color', $type: 'color' },
+        },
+      }
+      const errors = { color: { primary: { $value: '#1976d2' } } }
+
+      expect(validateDTCG(valid).exitCode).toBe(0)
+      expect(validateDTCG(warningsOnly).exitCode).toBe(1)
+      expect(validateDTCG(errors).exitCode).toBe(2)
+    })
+
+    it('rejects invalid root', () => {
+      const result = validateDTCG(null)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors[0].code).toBe('INVALID_ROOT')
+    })
+
+    it('rejects array as root', () => {
+      const result = validateDTCG([])
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors[0].code).toBe('INVALID_ROOT')
+    })
+  })
+
+  describe('ValidationResult', () => {
+    it('tracks errors, warnings, infos separately', () => {
+      const result = new ValidationResult()
+      result.addError('path1', 'error1', 'CODE1')
+      result.addWarning('path2', 'warning1', 'CODE2')
+      result.addInfo('path3', 'info1', 'CODE3')
+
+      expect(result.errors.length).toBe(1)
+      expect(result.warnings.length).toBe(1)
+      expect(result.infos.length).toBe(1)
+    })
+
+    it('toJSON serializes correctly', () => {
+      const result = new ValidationResult()
+      result.addError('path1', 'error1', 'CODE1')
+      const json = result.toJSON()
+      expect(json.valid).toBe(false)
+      expect(json.errors.length).toBe(1)
+      expect(json.errors[0]).toEqual({
+        path: 'path1',
+        message: 'error1',
+        code: 'CODE1',
+      })
+    })
+
+    it('print formats output correctly', () => {
+      const result = new ValidationResult()
+      result.addError('color.primary', 'Missing $type', 'MISSING_TYPE')
+      result.addWarning('color.primary', 'Weird color', 'COLOR_FORMAT')
+      const output = result.print()
+      expect(output).toContain('✗ color.primary: Missing $type [MISSING_TYPE]')
+      expect(output).toContain('⚠ color.primary: Weird color [COLOR_FORMAT]')
+    })
+  })
+})

--- a/lib/dtcg-validator.mjs
+++ b/lib/dtcg-validator.mjs
@@ -635,7 +635,7 @@ function validateGroup(
         )
       }
     } else {
-      result.addWarning(
+      result.addError(
         childPath,
         `Child is neither a token (has $value) nor a group (object without $value)`,
         'INVALID_CHILD'
@@ -852,7 +852,7 @@ export function validateDTCG(tokens, options = {}) {
         validateGroup(value, key, path, null, result)
       }
     } else {
-      result.addWarning(
+      result.addError(
         path,
         `Top-level child is neither a token nor a group`,
         'INVALID_TOP_LEVEL'

--- a/lib/dtcg-validator.mjs
+++ b/lib/dtcg-validator.mjs
@@ -1,0 +1,719 @@
+/**
+ * DTCG v1 Validator — validates tokens.json against W3C Design Tokens Community Group Format Module v1.
+ * Spec: https://www.designtokens.org/TR/2025.10/format/
+ */
+
+// DTCG token types (from spec)
+export const DTCG_TYPES = [
+  'color',
+  'dimension',
+  'fontFamily',
+  'fontWeight',
+  'duration',
+  'cubicBezier',
+  'number',
+  'border',
+  'shadow',
+  'gradient',
+  'transition',
+  'fontFamilies',
+  'fontSizes',
+  'fontWeights',
+  'lineHeights',
+  'spacing',
+  'borderRadius',
+  'opacity',
+  'zIndex',
+  'typography',
+  'asset',
+]
+
+// Reserved property prefixes
+const RESERVED_PROPS = [
+  '$value',
+  '$type',
+  '$description',
+  '$deprecated',
+  '$extensions',
+  '$root',
+  '$extends',
+]
+
+// Reserved token name rules
+const TOKEN_NAME_FORBIDDEN = ['{', '}', '.']
+
+/**
+ * Validation result types
+ */
+export const Severity = {
+  ERROR: 'error',
+  WARNING: 'warning',
+  INFO: 'info',
+}
+
+export class ValidationIssue {
+  constructor(path, message, severity = Severity.ERROR, code = null) {
+    this.path = path
+    this.message = message
+    this.severity = severity
+    this.code = code
+  }
+
+  toString() {
+    const prefix =
+      this.severity === Severity.ERROR
+        ? '✗'
+        : this.severity === Severity.WARNING
+          ? '⚠'
+          : 'ℹ'
+    const codeStr = this.code ? ` [${this.code}]` : ''
+    return `${prefix} ${this.path}: ${this.message}${codeStr}`
+  }
+}
+
+export class ValidationResult {
+  constructor() {
+    this.issues = []
+  }
+
+  addError(path, message, code = null) {
+    this.issues.push(new ValidationIssue(path, message, Severity.ERROR, code))
+  }
+
+  addWarning(path, message, code = null) {
+    this.issues.push(new ValidationIssue(path, message, Severity.WARNING, code))
+  }
+
+  addInfo(path, message, code = null) {
+    this.issues.push(new ValidationIssue(path, message, Severity.INFO, code))
+  }
+
+  get errors() {
+    return this.issues.filter((i) => i.severity === Severity.ERROR)
+  }
+
+  get warnings() {
+    return this.issues.filter((i) => i.severity === Severity.WARNING)
+  }
+
+  get infos() {
+    return this.issues.filter((i) => i.severity === Severity.INFO)
+  }
+
+  get hasErrors() {
+    return this.errors.length > 0
+  }
+
+  get hasWarnings() {
+    return this.warnings.length > 0
+  }
+
+  get exitCode() {
+    if (this.hasErrors) return 2
+    if (this.hasWarnings) return 1
+    return 0
+  }
+
+  toJSON() {
+    return {
+      valid: !this.hasErrors,
+      errors: this.errors.map((i) => ({
+        path: i.path,
+        message: i.message,
+        code: i.code,
+      })),
+      warnings: this.warnings.map((i) => ({
+        path: i.path,
+        message: i.message,
+        code: i.code,
+      })),
+      infos: this.infos.map((i) => ({
+        path: i.path,
+        message: i.message,
+        code: i.code,
+      })),
+    }
+  }
+
+  print(includeWarnings = true, includeInfos = false) {
+    const lines = []
+    for (const issue of this.issues) {
+      if (
+        issue.severity === Severity.ERROR ||
+        (includeWarnings && issue.severity === Severity.WARNING) ||
+        (includeInfos && issue.severity === Severity.INFO)
+      ) {
+        lines.push(issue.toString())
+      }
+    }
+    if (lines.length === 0) {
+      lines.push('✓ Valid DTCG v1 tokens file')
+    }
+    return lines.join('\n')
+  }
+}
+
+/**
+ * Check if a token name is valid per DTCG spec
+ */
+function isValidTokenName(name, path) {
+  const issues = []
+  if (name.startsWith('$')) {
+    issues.push(
+      new ValidationIssue(
+        path,
+        `Token name must not start with '$'`,
+        Severity.ERROR,
+        'INVALID_TOKEN_NAME'
+      )
+    )
+  }
+  for (const forbidden of TOKEN_NAME_FORBIDDEN) {
+    if (name.includes(forbidden)) {
+      issues.push(
+        new ValidationIssue(
+          path,
+          `Token name must not contain '${forbidden}'`,
+          Severity.ERROR,
+          'INVALID_TOKEN_NAME'
+        )
+      )
+      break
+    }
+  }
+  return issues
+}
+
+/**
+ * Check if a value is a DTCG reference (curly brace syntax)
+ */
+function isReference(value) {
+  return typeof value === 'string' && /^\{.+\}$/.test(value)
+}
+
+/**
+ * Validate a token value against its declared type
+ */
+function validateTokenValue(type, value, path, result) {
+  if (!type) return // Type validation happens elsewhere
+
+  // Skip value validation for references - they're validated in semantic phase (Milestone 2)
+  if (isReference(value)) {
+    return
+  }
+
+  switch (type) {
+    case 'color': {
+      // Color value can be string (hex, rgb, etc.) or object with colorSpace/components
+      if (typeof value === 'string') {
+        // Basic hex/rgb check
+        if (
+          !/^#([0-9a-fA-F]{3,8}|[0-9a-fA-F]{6})$/.test(value) &&
+          !/^rgb\(/.test(value) &&
+          !/^hsl\(/.test(value) &&
+          !/^(transparent|currentColor|inherit|initial|unset)$/i.test(value)
+        ) {
+          result.addWarning(
+            path,
+            `Color value '${value}' may not be a valid CSS color`,
+            'COLOR_FORMAT'
+          )
+        }
+      } else if (typeof value === 'object' && value !== null) {
+        // Object format: { colorSpace, components, hex?, alpha? }
+        if (!value.colorSpace || !Array.isArray(value.components)) {
+          result.addError(
+            path,
+            `Color object must have 'colorSpace' and 'components' array`,
+            'INVALID_COLOR_OBJECT'
+          )
+        }
+      } else {
+        result.addError(
+          path,
+          `Color token $value must be a string or object`,
+          'INVALID_COLOR_VALUE'
+        )
+      }
+      break
+    }
+    case 'dimension': {
+      // Dimension: { value: number, unit: string }
+      if (
+        typeof value !== 'object' ||
+        value === null ||
+        typeof value.value !== 'number' ||
+        typeof value.unit !== 'string'
+      ) {
+        result.addError(
+          path,
+          `Dimension token $value must be an object with 'value' (number) and 'unit' (string)`,
+          'INVALID_DIMENSION'
+        )
+      }
+      break
+    }
+    case 'fontFamily':
+    case 'fontFamilies': {
+      // String or array of strings
+      if (typeof value !== 'string' && !Array.isArray(value)) {
+        result.addError(
+          path,
+          `Font family token $value must be a string or array of strings`,
+          'INVALID_FONT_FAMILY'
+        )
+      }
+      break
+    }
+    case 'fontWeight':
+    case 'fontWeights': {
+      // Number or string (e.g., 'bold', 'normal', 400, 700)
+      if (typeof value !== 'number' && typeof value !== 'string') {
+        result.addError(
+          path,
+          `Font weight token $value must be a number or string`,
+          'INVALID_FONT_WEIGHT'
+        )
+      }
+      break
+    }
+    case 'duration': {
+      // String with time unit (e.g., '200ms', '1s')
+      if (typeof value !== 'string' || !/^\d+(\.\d+)?(ms|s)$/.test(value)) {
+        result.addError(
+          path,
+          `Duration token $value must be a string like '200ms' or '1s'`,
+          'INVALID_DURATION'
+        )
+      }
+      break
+    }
+    case 'cubicBezier': {
+      // Array of 4 numbers
+      if (
+        !Array.isArray(value) ||
+        value.length !== 4 ||
+        !value.every((v) => typeof v === 'number')
+      ) {
+        result.addError(
+          path,
+          `Cubic bezier token $value must be an array of 4 numbers`,
+          'INVALID_CUBIC_BEZIER'
+        )
+      }
+      break
+    }
+    case 'number': {
+      if (typeof value !== 'number') {
+        result.addError(
+          path,
+          `Number token $value must be a number`,
+          'INVALID_NUMBER'
+        )
+      }
+      break
+    }
+    case 'border': {
+      // Object with width, style, color
+      if (typeof value !== 'object' || value === null) {
+        result.addError(
+          path,
+          `Border token $value must be an object`,
+          'INVALID_BORDER'
+        )
+      }
+      break
+    }
+    case 'shadow': {
+      // Array of shadow objects
+      if (!Array.isArray(value)) {
+        result.addError(
+          path,
+          `Shadow token $value must be an array`,
+          'INVALID_SHADOW'
+        )
+      }
+      break
+    }
+    case 'gradient': {
+      // Gradient object
+      if (typeof value !== 'object' || value === null) {
+        result.addError(
+          path,
+          `Gradient token $value must be an object`,
+          'INVALID_GRADIENT'
+        )
+      }
+      break
+    }
+    case 'transition': {
+      // Transition object
+      if (typeof value !== 'object' || value === null) {
+        result.addError(
+          path,
+          `Transition token $value must be an object`,
+          'INVALID_TRANSITION'
+        )
+      }
+      break
+    }
+    case 'fontSizes':
+    case 'lineHeights':
+    case 'spacing':
+    case 'borderRadius':
+    case 'opacity':
+    case 'zIndex':
+    case 'typography':
+    case 'asset': {
+      // These are composite types or generic - basic object check
+      if (typeof value !== 'object' || value === null) {
+        result.addWarning(
+          path,
+          `Token of type '${type}' should have an object value`,
+          'INVALID_COMPOSITE_VALUE'
+        )
+      }
+      break
+    }
+    default: {
+      // Unknown type - warn but don't error
+      result.addWarning(
+        path,
+        `Unknown token type '${type}' - skipping value validation`,
+        'UNKNOWN_TYPE'
+      )
+      break
+    }
+  }
+}
+
+/**
+ * Determine if an object is a group (no $value) or a token (has $value)
+ * A token MUST have $value. If it has $type but no $value AND has no children, it's an invalid token.
+ * But groups CAN have $type for inheritance.
+ */
+function isToken(obj) {
+  return obj && typeof obj === 'object' && '$value' in obj
+}
+
+function isGroup(obj) {
+  return obj && typeof obj === 'object' && !('$value' in obj)
+}
+
+function isInvalidToken(obj) {
+  // An object with $type but no $value and no children (only reserved props) is an invalid token
+  // We check this at call sites by looking at whether it has non-reserved children
+  return false // We handle this inline now
+}
+
+/**
+ * Validate a single token
+ */
+function validateToken(token, name, path, inheritedType, result) {
+  // Check token name
+  for (const issue of isValidTokenName(name, path)) {
+    result.issues.push(issue)
+  }
+
+  // $value is REQUIRED
+  if (!('$value' in token)) {
+    result.addError(
+      path,
+      `Token missing required '$value' property`,
+      'MISSING_VALUE'
+    )
+    return
+  }
+
+  // Resolve type: explicit $type > inherited group $type > error
+  const explicitType = token.$type
+  const resolvedType = explicitType || inheritedType
+
+  if (!resolvedType) {
+    result.addError(
+      path,
+      `Token has no '$type' and no inherited type from parent groups`,
+      'MISSING_TYPE'
+    )
+    return
+  }
+
+  // Validate $type is known (warn if unknown)
+  if (!DTCG_TYPES.includes(resolvedType)) {
+    result.addWarning(
+      path,
+      `Token type '${resolvedType}' is not a standard DTCG type`,
+      'NON_STANDARD_TYPE'
+    )
+  }
+
+  // Validate $value against type
+  validateTokenValue(resolvedType, token.$value, path, result)
+
+  // $description - optional string
+  if (
+    token.$description !== undefined &&
+    typeof token.$description !== 'string'
+  ) {
+    result.addError(
+      path,
+      `'$description' must be a string`,
+      'INVALID_DESCRIPTION'
+    )
+  }
+
+  // $deprecated - optional: true | string | false
+  if (token.$deprecated !== undefined) {
+    if (
+      token.$deprecated !== true &&
+      token.$deprecated !== false &&
+      typeof token.$deprecated !== 'string'
+    ) {
+      result.addError(
+        path,
+        `'$deprecated' must be true, false, or a string reason`,
+        'INVALID_DEPRECATED'
+      )
+    }
+  }
+
+  // $extensions - optional object
+  if (token.$extensions !== undefined) {
+    if (
+      typeof token.$extensions !== 'object' ||
+      token.$extensions === null ||
+      Array.isArray(token.$extensions)
+    ) {
+      result.addError(
+        path,
+        `'$extensions' must be an object`,
+        'INVALID_EXTENSIONS'
+      )
+    }
+  }
+
+  // Check for unknown properties (not reserved)
+  for (const key of Object.keys(token)) {
+    if (!RESERVED_PROPS.includes(key)) {
+      result.addWarning(
+        path,
+        `Unknown token property '${key}' (not a reserved DTCG property)`,
+        'UNKNOWN_PROPERTY'
+      )
+    }
+  }
+}
+
+/**
+ * Validate a group recursively
+ */
+function validateGroup(
+  group,
+  name,
+  path,
+  parentType,
+  result,
+  visitedGroups = new Set()
+) {
+  // Check group name
+  for (const issue of isValidTokenName(name, path)) {
+    result.issues.push(issue)
+  }
+
+  // Track visited groups for circular $extends detection
+  const groupId = path
+  if (visitedGroups.has(groupId)) {
+    result.addError(path, `Circular group reference detected`, 'CIRCULAR_GROUP')
+    return
+  }
+  visitedGroups.add(groupId)
+
+  // Resolve this group's type for inheritance
+  let groupType = parentType
+  if (group.$type !== undefined) {
+    if (typeof group.$type !== 'string') {
+      result.addError(path, `'$type' must be a string`, 'INVALID_GROUP_TYPE')
+    } else {
+      groupType = group.$type
+      if (!DTCG_TYPES.includes(groupType)) {
+        result.addWarning(
+          path,
+          `Group type '${groupType}' is not a standard DTCG type`,
+          'NON_STANDARD_GROUP_TYPE'
+        )
+      }
+    }
+  }
+
+  // $extends - check for circular references (basic check)
+  if (group.$extends !== undefined) {
+    if (typeof group.$extends !== 'string') {
+      result.addError(
+        path,
+        `'$extends' must be a string reference`,
+        'INVALID_EXTENDS'
+      )
+    } else if (group.$extends.includes(path)) {
+      result.addError(
+        path,
+        `'$extends' creates a circular reference`,
+        'CIRCULAR_EXTENDS'
+      )
+    }
+  }
+
+  // $description
+  if (
+    group.$description !== undefined &&
+    typeof group.$description !== 'string'
+  ) {
+    result.addError(
+      path,
+      `'$description' must be a string`,
+      'INVALID_DESCRIPTION'
+    )
+  }
+
+  // $deprecated
+  if (group.$deprecated !== undefined) {
+    if (
+      group.$deprecated !== true &&
+      group.$deprecated !== false &&
+      typeof group.$deprecated !== 'string'
+    ) {
+      result.addError(
+        path,
+        `'$deprecated' must be true, false, or a string reason`,
+        'INVALID_DEPRECATED'
+      )
+    }
+  }
+
+  // $extensions
+  if (group.$extensions !== undefined) {
+    if (
+      typeof group.$extensions !== 'object' ||
+      group.$extensions === null ||
+      Array.isArray(group.$extensions)
+    ) {
+      result.addError(
+        path,
+        `'$extensions' must be an object`,
+        'INVALID_EXTENSIONS'
+      )
+    }
+  }
+
+  // Recurse into children
+  for (const [key, value] of Object.entries(group)) {
+    if (RESERVED_PROPS.includes(key)) continue
+
+    const childPath = path ? `${path}.${key}` : key
+
+    if (isToken(value)) {
+      validateToken(value, key, childPath, groupType, result)
+    } else if (isGroup(value)) {
+      // Check if this "group" has any non-reserved children
+      const hasChildren = Object.keys(value).some(
+        (k) => !RESERVED_PROPS.includes(k)
+      )
+      if (!hasChildren && value.$type !== undefined) {
+        // No children but has $type - invalid token (missing $value)
+        result.addError(
+          childPath,
+          `Token missing required '$value' property`,
+          'MISSING_VALUE'
+        )
+      } else {
+        validateGroup(
+          value,
+          key,
+          childPath,
+          groupType,
+          result,
+          new Set(visitedGroups)
+        )
+      }
+    } else {
+      result.addWarning(
+        childPath,
+        `Child is neither a token (has $value) nor a group (object without $value)`,
+        'INVALID_CHILD'
+      )
+    }
+  }
+
+  visitedGroups.delete(groupId)
+}
+
+/**
+ * Main validation entry point
+ * @param {object} tokens - Parsed tokens.json object
+ * @param {object} options - Validation options
+ * @returns {ValidationResult}
+ */
+export function validateDTCG(tokens, options = {}) {
+  const result = new ValidationResult()
+
+  if (!tokens || typeof tokens !== 'object' || Array.isArray(tokens)) {
+    result.addError('root', 'Root must be an object', 'INVALID_ROOT')
+    return result
+  }
+
+  // Validate top-level children
+  for (const [key, value] of Object.entries(tokens)) {
+    const path = key
+    if (isToken(value)) {
+      validateToken(value, key, path, null, result)
+    } else if (isGroup(value)) {
+      // Check if this "group" has any non-reserved children
+      const hasChildren = Object.keys(value).some(
+        (k) => !RESERVED_PROPS.includes(k)
+      )
+      if (!hasChildren && value.$type !== undefined) {
+        // No children but has $type - invalid token (missing $value)
+        result.addError(
+          path,
+          `Token missing required '$value' property`,
+          'MISSING_VALUE'
+        )
+      } else {
+        validateGroup(value, key, path, null, result)
+      }
+    } else {
+      result.addWarning(
+        path,
+        `Top-level child is neither a token nor a group`,
+        'INVALID_TOP_LEVEL'
+      )
+    }
+  }
+
+  return result
+}
+
+/**
+ * Load and validate a tokens.json file
+ */
+export async function validateFile(filePath, options = {}) {
+  const { promises: fs } = await import('node:fs')
+  const content = await fs.readFile(filePath, 'utf8')
+  let tokens
+  try {
+    tokens = JSON.parse(content)
+  } catch (err) {
+    const result = new ValidationResult()
+    result.addError(filePath, `Invalid JSON: ${err.message}`, 'INVALID_JSON')
+    return result
+  }
+  return validateDTCG(tokens, options)
+}
+
+const DTCGValidator = {
+  validateDTCG,
+  validateFile,
+  ValidationResult,
+  ValidationIssue,
+  Severity,
+}
+export default DTCGValidator

--- a/lib/dtcg-validator.mjs
+++ b/lib/dtcg-validator.mjs
@@ -647,6 +647,176 @@ function validateGroup(
 }
 
 /**
+ * Walk the token tree and collect every token's resolved type, raw value, and
+ * the list of references it points to. Used by semantic checks (Milestone 2).
+ */
+function collectTokens(tokens) {
+  const map = new Map()
+  const walk = (node, path, inheritedType) => {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) return
+    const groupType =
+      typeof node.$type === 'string' ? node.$type : inheritedType
+    if ('$value' in node) {
+      const type = typeof node.$type === 'string' ? node.$type : inheritedType
+      map.set(path, {
+        path,
+        type: type || null,
+        value: node.$value,
+        refs: extractRefs(node.$value),
+      })
+      return
+    }
+    for (const [key, child] of Object.entries(node)) {
+      if (RESERVED_PROPS.includes(key)) continue
+      const childPath = path ? `${path}.${key}` : key
+      walk(child, childPath, groupType)
+    }
+  }
+  walk(tokens, '', null)
+  return map
+}
+
+/**
+ * Pull `{some.token.path}` references out of any value (string / object / array).
+ */
+function extractRefs(value) {
+  const refs = []
+  const visit = (v) => {
+    if (typeof v === 'string') {
+      const matches = v.match(/\{[^{}]+\}/g)
+      if (matches) {
+        for (const m of matches) refs.push(m.slice(1, -1))
+      }
+    } else if (Array.isArray(v)) {
+      v.forEach(visit)
+    } else if (v && typeof v === 'object') {
+      Object.values(v).forEach(visit)
+    }
+  }
+  visit(value)
+  return refs
+}
+
+/**
+ * Classify a name as kebab-case, camelCase, snake_case, PascalCase, or 'mixed/other'.
+ */
+function classifyName(name) {
+  if (/^[a-z][a-z0-9]*(-[a-z0-9]+)+$/.test(name)) return 'kebab-case'
+  if (/^[a-z][a-z0-9]*(_[a-z0-9]+)+$/.test(name)) return 'snake_case'
+  if (/^[a-z][a-z0-9]*([A-Z][a-z0-9]*)+$/.test(name)) return 'camelCase'
+  if (/^[A-Z][a-z0-9]*([A-Z][a-z0-9]*)*$/.test(name)) return 'PascalCase'
+  return null // single-word or non-classifiable - excluded from convention check
+}
+
+function collectNames(tokens) {
+  const names = []
+  const walk = (node, path) => {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) return
+    for (const [key, child] of Object.entries(node)) {
+      if (RESERVED_PROPS.includes(key)) continue
+      const childPath = path ? `${path}.${key}` : key
+      names.push({ name: key, path: childPath })
+      if (child && typeof child === 'object' && !('$value' in child)) {
+        walk(child, childPath)
+      }
+    }
+  }
+  walk(tokens, '')
+  return names
+}
+
+/**
+ * Semantic checks (Milestone 2):
+ *  - broken references
+ *  - circular dependencies
+ *  - type mismatch on referenced tokens
+ *  - naming convention consistency
+ */
+function validateSemantic(tokens, result) {
+  const map = collectTokens(tokens)
+
+  // 1. Broken references + type mismatch
+  for (const token of map.values()) {
+    for (const ref of token.refs) {
+      const target = map.get(ref)
+      if (!target) {
+        result.addError(
+          token.path,
+          `Reference '{${ref}}' points to a token that does not exist`,
+          'BROKEN_REFERENCE'
+        )
+        continue
+      }
+      if (token.type && target.type && token.type !== target.type) {
+        result.addWarning(
+          token.path,
+          `References '{${ref}}' of type '${target.type}', but this token is type '${token.type}'`,
+          'TYPE_MISMATCH'
+        )
+      }
+    }
+  }
+
+  // 2. Circular dependency detection (DFS)
+  const visited = new Set()
+  const onStack = new Set()
+  const detect = (path, trail) => {
+    if (onStack.has(path)) {
+      const cycleStart = trail.indexOf(path)
+      const cycle = trail.slice(cycleStart).concat(path).join(' → ')
+      result.addError(
+        path,
+        `Circular reference: ${cycle}`,
+        'CIRCULAR_REFERENCE'
+      )
+      return
+    }
+    if (visited.has(path)) return
+    const node = map.get(path)
+    if (!node) return
+    onStack.add(path)
+    trail.push(path)
+    for (const ref of node.refs) {
+      if (map.has(ref)) detect(ref, trail)
+    }
+    trail.pop()
+    onStack.delete(path)
+    visited.add(path)
+  }
+  for (const path of map.keys()) detect(path, [])
+
+  // 3. Naming convention consistency
+  const names = collectNames(tokens)
+  const buckets = new Map()
+  for (const { name, path } of names) {
+    const style = classifyName(name)
+    if (!style) continue
+    if (!buckets.has(style)) buckets.set(style, [])
+    buckets.get(style).push({ name, path })
+  }
+  if (buckets.size > 1) {
+    let dominant = null
+    let max = 0
+    for (const [style, items] of buckets) {
+      if (items.length > max) {
+        max = items.length
+        dominant = style
+      }
+    }
+    for (const [style, items] of buckets) {
+      if (style === dominant) continue
+      for (const { name, path } of items) {
+        result.addWarning(
+          path,
+          `Name '${name}' is ${style}, but dominant convention is ${dominant}`,
+          'NAMING_CONVENTION'
+        )
+      }
+    }
+  }
+}
+
+/**
  * Main validation entry point
  * @param {object} tokens - Parsed tokens.json object
  * @param {object} options - Validation options
@@ -654,6 +824,7 @@ function validateGroup(
  */
 export function validateDTCG(tokens, options = {}) {
   const result = new ValidationResult()
+  const { semantic = true } = options
 
   if (!tokens || typeof tokens !== 'object' || Array.isArray(tokens)) {
     result.addError('root', 'Root must be an object', 'INVALID_ROOT')
@@ -687,6 +858,11 @@ export function validateDTCG(tokens, options = {}) {
         'INVALID_TOP_LEVEL'
       )
     }
+  }
+
+  // Skip semantic checks if structural validation hit fatal root errors.
+  if (semantic && !result.issues.some((i) => i.code === 'INVALID_ROOT')) {
+    validateSemantic(tokens, result)
   }
 
   return result

--- a/templates/dtcg/README.md
+++ b/templates/dtcg/README.md
@@ -1,0 +1,36 @@
+# DTCG validation in CI
+
+Two ready-made templates to gate `tokens.json` changes against the W3C Design Tokens
+Community Group (DTCG) Format Module v1 spec.
+
+## GitHub Actions
+
+Copy `github-action.yml` into `.github/workflows/dtcg-validate.yml`. The job
+runs on every PR that touches a `tokens.json` file and fails the check if the
+file is structurally invalid or has broken token references.
+
+## Pre-commit hook
+
+`pre-commit.sh` blocks a commit when the staged `tokens.json` does not pass
+validation. Install it directly:
+
+```bash
+cp templates/dtcg/pre-commit.sh .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+Or wire it through [husky](https://typicode.github.io/husky):
+
+```bash
+npx husky add .husky/pre-commit "sh templates/dtcg/pre-commit.sh"
+```
+
+## Exit codes
+
+The `mint-ds validate` command exits with:
+
+- `0` — no errors and no warnings
+- `1` — warnings only
+- `2` — at least one error
+
+Pass `--json` for machine-readable output suitable for downstream tools.

--- a/templates/dtcg/github-action.yml
+++ b/templates/dtcg/github-action.yml
@@ -1,0 +1,22 @@
+name: Validate design tokens (DTCG)
+
+on:
+  pull_request:
+    paths:
+      - '**/tokens.json'
+      - '**/*.tokens.json'
+      - 'mint-ds.tokens.json'
+  push:
+    branches: [main]
+
+jobs:
+  dtcg-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Validate tokens against DTCG v1
+        run: npx mint-ds validate mint-ds.tokens.json --spec dtcg --json

--- a/templates/dtcg/pre-commit.sh
+++ b/templates/dtcg/pre-commit.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+# DTCG validation pre-commit hook.
+# Install: copy to .git/hooks/pre-commit and `chmod +x .git/hooks/pre-commit`.
+# Or wire it through husky:  npx husky add .husky/pre-commit "sh templates/dtcg/pre-commit.sh"
+
+set -e
+
+TOKENS_FILE="${MINT_TOKENS_FILE:-mint-ds.tokens.json}"
+
+if ! git diff --cached --name-only | grep -qE "(^|/)(.*\.)?tokens\.json$"; then
+  exit 0
+fi
+
+if [ ! -f "$TOKENS_FILE" ]; then
+  echo "✗ DTCG pre-commit: $TOKENS_FILE not found (set MINT_TOKENS_FILE to override)"
+  exit 1
+fi
+
+echo "→ Validating $TOKENS_FILE against DTCG v1…"
+npx mint-ds validate "$TOKENS_FILE" --spec dtcg


### PR DESCRIPTION
## Feature
Validate `tokens.json` files against the W3C Design Tokens Community Group (DTCG) Format Module v1 specification.

## Related Card
https://github.com/nujovich/mint-radar/issues/3

## Milestones
- [x] Milestone 1 — DTCG parser and structural validation
  - Read DTCG Format Module v1 spec (W3C Community Group)
  - Implement parser for tokens.json that validates structure: groups, required $type, $value per type
  - Rules: missing $type, mistyped $value for type, invalid nesting
  - New command: `mint-ds validate tokens.json --spec dtcg`

- [x] Milestone 2 — Semantic coherence
  - Detect broken references (token → nonexistent token)
  - Detect circular dependencies (A → B → A)
  - Naming conventions (kebab-case vs camelCase consistency)
  - Type mismatch cross-reference (spacing token used as color)

- [x] Milestone 3 — CI integration
  - Pre-commit hook for automatic validation
  - GitHub Actions config template
  - Exit codes for CI (0 = ok, 1 = warnings, 2 = errors)
  - Output format: terminal (default), JSON (--json)

- [ ] Milestone 4 — Extras (optional)
  - Validate $extensions (Figma, Tokens Studio metadata)
  - Compare two snapshots: `mint-ds diff tokens-v1.json tokens-v2.json`
  - Relation to card #34 (mint-ds diff)