### PR TITLE
feat: add mint-ds lint command with gap-decoration rules

### DIFF
--- a/BUILD-PLAN-issue-7.md
+++ b/BUILD-PLAN-issue-7.md
@@ -4,6 +4,6 @@ Card: https://github.com/nujovich/mint-radar/issues/7
 
 ## Milestones
 
-- [ ] Add `gap-decoration-hack` rule -- detect manual gap styling patterns (border on children, pseudo-elements, background with gap) and suggest migrating to native `gap-rule-*` properties
+- [x] Add `gap-decoration-hack` rule -- detect manual gap styling patterns (border on children, pseudo-elements, background with gap) and suggest migrating to native `gap-rule-*` properties
 - [ ] Add `gap-decorations-compat` rule -- warn when project uses gap decorations but browserslist does not support them, suggest fallback
 - [ ] Add adoption estimation report -- audit how many project stylesheets use hacks that gap decorations would replace, output in `mint-ds audit` under "Modern CSS Opportunities"

--- a/BUILD-PLAN-issue-7.md
+++ b/BUILD-PLAN-issue-7.md
@@ -1,0 +1,9 @@
+# BUILD #7: CSS gap decorations linting rules
+
+Card: https://github.com/nujovich/mint-radar/issues/7
+
+## Milestones
+
+- [ ] Add `gap-decoration-hack` rule -- detect manual gap styling patterns (border on children, pseudo-elements, background with gap) and suggest migrating to native `gap-rule-*` properties
+- [ ] Add `gap-decorations-compat` rule -- warn when project uses gap decorations but browserslist does not support them, suggest fallback
+- [ ] Add adoption estimation report -- audit how many project stylesheets use hacks that gap decorations would replace, output in `mint-ds audit` under "Modern CSS Opportunities"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- `mint-ds lint <dir>` — new static CSS lint command (no LLM). Ships gap-decoration rules that flag hand-rolled ways of drawing lines between grid/flex tracks (borders on children, `::before`/`::after` pseudo-elements, or backgrounds alongside `gap`) and suggest the native `gap-rule-color` / `gap-rule-style` / `gap-rule-width` properties, closed by a "Modern CSS Opportunities" adoption report.
+
 ## [0.2.1](https://github.com/nujovich/mint/compare/v0.2.0...v0.2.1) (2026-07-10)
 
 Maintenance release: release automation and CI publishing (OIDC + provenance). No user-facing changes.

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ npx mint-ds export --target tailwind --provider ollama
 | `mint-ds validate <file>`        | Validate `tokens.json` against DTCG v1 — structure, references, cycles, naming consistency                                 |
 | `mint-ds cache --clear`          | Delete the local `mint-ds.cache.json` cache file                                                                           |
 | `mint-ds compat <dir>`           | Flag CSS properties below Baseline / Interop 2026 for your browserslist target, with fallback suggestions (no LLM)         |
+| `mint-ds lint <dir>`             | Run static CSS lint rules (gap-decoration hacks) plus a modern-CSS adoption report — no LLM                                |
 | `mint-ds --help`                 | Show full usage                                                                                                            |
 
 ### Validate options
@@ -366,6 +367,18 @@ Every finding carries the `web-features` feature name and a concrete `@supports`
 | --------------------- | --------------------------------------------------------------------------- |
 | `--project-dir <dir>` | Project root to resolve the browserslist target from (default: current dir) |
 | `--quiet`             | Skip the closing fallback tip                                               |
+
+### Lint
+
+`mint-ds lint <dir>` runs Mint's static CSS lint rules over every CSS/SCSS/HTML file in `<dir>` — deterministic pattern checks that complement the LLM audit, with no API key or LLM call required.
+
+Today it ships the **gap-decoration** rules. They flag hand-rolled ways of drawing lines between grid/flex tracks — borders on direct children, `::before`/`::after` pseudo-elements, or backgrounds used alongside `gap` — and point you at the native `gap-rule-color` / `gap-rule-style` / `gap-rule-width` properties (Chrome 149+, Firefox 132+).
+
+```bash
+npx mint-ds lint ./src/styles
+```
+
+Each finding prints with a severity badge (`WARN` / `INFO`), the selector, and a migration hint. A closing **Modern CSS Opportunities** report summarizes how many stylesheets use gap-decoration hacks and how many could move to the native properties, broken down by pattern.
 
 ### Audit options
 

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -20,7 +20,7 @@ import { getCssAuditor } from '../lib/css-auditor.mjs'
 import { validateFile } from '../lib/dtcg-validator.mjs'
 import { formatLintSummary } from '../lib/audit-summary.mjs'
 import { checkCompat } from '../lib/css-compat-data.mjs'
-import { lintCss } from '../lib/css-lint-rules.mjs'
+import { lintCss, lintGapDecorationAdoption } from '../lib/css-lint-rules.mjs'
 
 const require = createRequire(import.meta.url)
 const { version: VERSION } = require('../package.json')
@@ -463,20 +463,42 @@ async function cmdLint(argv) {
 
   if (findings.length === 0) {
     log(styles.green('✓') + ' No lint issues found.')
-    return
+  } else {
+    log('')
+    log(styles.bold(`Found ${findings.length} issue(s):`))
+    log('')
+
+    for (const finding of findings) {
+      const badge =
+        finding.severity === 'warning'
+          ? styles.yellow('WARN')
+          : styles.dim('INFO')
+      log(`  ${badge}  ${finding.selector}`)
+      log(styles.dim(`       ${finding.message}`))
+      log('')
+    }
   }
 
-  log('')
-  log(styles.bold(`Found ${findings.length} issue(s):`))
-  log('')
-
-  for (const finding of findings) {
-    const badge =
-      finding.severity === 'warning'
-        ? styles.yellow('WARN')
-        : styles.dim('INFO')
-    log(`  ${badge}  ${finding.selector}`)
-    log(styles.dim(`       ${finding.message}`))
+  // Modern CSS Opportunities: adoption report for gap decorations.
+  const { adoption } = lintGapDecorationAdoption(css, {
+    stylesheetCount: files.length,
+  })
+  if (adoption.hacksTotal > 0) {
+    log('')
+    log(styles.bold('Modern CSS Opportunities'))
+    log(
+      styles.dim(
+        `  ${adoption.stylesheetsWithHacks}/${adoption.stylesheetsScanned} stylesheet(s) use gap-decoration hacks`
+      )
+    )
+    log(
+      styles.dim(
+        `  ${adoption.hacksTotal} hack(s) could be replaced by native gap-rule-* (Chrome 149+, Firefox 132+)`
+      )
+    )
+    for (const [pattern, count] of Object.entries(adoption.byPattern)) {
+      log(styles.dim(`    - ${pattern}: ${count}`))
+    }
     log('')
   }
 }

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -20,6 +20,7 @@ import { getCssAuditor } from '../lib/css-auditor.mjs'
 import { validateFile } from '../lib/dtcg-validator.mjs'
 import { formatLintSummary } from '../lib/audit-summary.mjs'
 import { checkCompat } from '../lib/css-compat-data.mjs'
+import { lintCss } from '../lib/css-lint-rules.mjs'
 
 const require = createRequire(import.meta.url)
 const { version: VERSION } = require('../package.json')
@@ -90,6 +91,7 @@ ${styles.bold('COMMANDS')}
   validate <file> [options]    Validate tokens.json against a spec (e.g. dtcg)
   cache --clear                Delete the local ${CACHE_FILE}
   compat <dir>                 Scan CSS for Interop 2026 browser-compat issues (warnings + suggestions)
+  lint <dir>                   Run static CSS lint rules on files in <dir>
 
 ${styles.bold('AUDIT OPTIONS')}
   --out <file>                 Tokens output path (default: ${DEFAULT_TOKENS_FILE})
@@ -143,6 +145,7 @@ ${styles.bold('EXAMPLES')}
   npx mint-ds export --target css --stdout > variables.css
   npx mint-ds validate tokens.json --spec dtcg
   npx mint-ds validate tokens.json --spec dtcg --json
+  npx mint-ds lint ./src/styles
 `)
 }
 
@@ -442,6 +445,42 @@ async function cmdCache(argv) {
   }
 }
 
+async function cmdLint(argv) {
+  const { rest } = parseFlags(argv)
+  const target = rest[0]
+  if (!target) die('Usage: mint-ds lint <directory>')
+
+  log(styles.cyan('→') + ` Linting sources from ${styles.bold(target)}…`)
+  const { files, css } = await collectSources(target)
+  log(
+    styles.dim(
+      `  ${files.length} file(s), ${(css.length / 1000).toFixed(1)}k chars`
+    )
+  )
+
+  const result = lintCss(css)
+  const { findings } = result
+
+  if (findings.length === 0) {
+    log(styles.green('✓') + ' No lint issues found.')
+    return
+  }
+
+  log('')
+  log(styles.bold(`Found ${findings.length} issue(s):`))
+  log('')
+
+  for (const finding of findings) {
+    const badge =
+      finding.severity === 'warning'
+        ? styles.yellow('WARN')
+        : styles.dim('INFO')
+    log(`  ${badge}  ${finding.selector}`)
+    log(styles.dim(`       ${finding.message}`))
+    log('')
+  }
+}
+
 async function cmdExport(argv) {
   const { flags } = parseFlags(argv)
   const targetInput = flags.target
@@ -542,6 +581,7 @@ async function main() {
     else if (cmd === 'validate') await cmdValidate(rest)
     else if (cmd === 'cache') await cmdCache(rest)
     else if (cmd === 'compat') await cmdCompat(rest)
+    else if (cmd === 'lint') await cmdLint(rest)
     else {
       printHelp()
       die(`Unknown command: ${cmd}`)

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -17,6 +17,7 @@ import {
   resolveTarget,
 } from '../lib/prompts.mjs'
 import { getCssAuditor } from '../lib/css-auditor.mjs'
+import { lintCss } from '../lib/css-lint-rules.mjs'
 
 const require = createRequire(import.meta.url)
 const { version: VERSION } = require('../package.json')
@@ -85,6 +86,7 @@ ${styles.bold('COMMANDS')}
   audit <dir>                  Analyze CSS/SCSS files in <dir> and write ${DEFAULT_TOKENS_FILE}
   export --target <name>       Generate exports from ${DEFAULT_TOKENS_FILE}
   cache --clear                Delete the local ${CACHE_FILE}
+  lint <dir>                   Run static CSS lint rules on files in <dir>
 
 ${styles.bold('AUDIT OPTIONS')}
   --out <file>                 Tokens output path (default: ${DEFAULT_TOKENS_FILE})
@@ -119,6 +121,7 @@ ${styles.bold('EXAMPLES')}
   npx mint-ds export --target tailwind
   npx mint-ds export --target react --out ui/Components.tsx
   npx mint-ds export --target css --stdout > variables.css
+  npx mint-ds lint ./src/styles
 `)
 }
 
@@ -349,6 +352,42 @@ async function cmdCache(argv) {
   }
 }
 
+async function cmdLint(argv) {
+  const { rest } = parseFlags(argv)
+  const target = rest[0]
+  if (!target) die('Usage: mint-ds lint <directory>')
+
+  log(styles.cyan('→') + ` Linting sources from ${styles.bold(target)}…`)
+  const { files, css } = await collectSources(target)
+  log(
+    styles.dim(
+      `  ${files.length} file(s), ${(css.length / 1000).toFixed(1)}k chars`
+    )
+  )
+
+  const result = lintCss(css)
+  const { findings } = result
+
+  if (findings.length === 0) {
+    log(styles.green('✓') + ' No lint issues found.')
+    return
+  }
+
+  log('')
+  log(styles.bold(`Found ${findings.length} issue(s):`))
+  log('')
+
+  for (const finding of findings) {
+    const badge =
+      finding.severity === 'warning'
+        ? styles.yellow('WARN')
+        : styles.dim('INFO')
+    log(`  ${badge}  ${finding.selector}`)
+    log(styles.dim(`       ${finding.message}`))
+    log('')
+  }
+}
+
 async function cmdExport(argv) {
   const { flags } = parseFlags(argv)
   const targetInput = flags.target
@@ -411,6 +450,7 @@ async function main() {
     if (cmd === 'audit') await cmdAudit(rest)
     else if (cmd === 'export') await cmdExport(rest)
     else if (cmd === 'cache') await cmdCache(rest)
+    else if (cmd === 'lint') await cmdLint(rest)
     else {
       printHelp()
       die(`Unknown command: ${cmd}`)

--- a/lib/__tests__/css-lint-rules.test.mjs
+++ b/lib/__tests__/css-lint-rules.test.mjs
@@ -3,6 +3,7 @@ import {
   parseCssRules,
   parseDeclarations,
   lintGapDecorationHacks,
+  lintGapDecorationsCompat,
   lintCss,
 } from '../css-lint-rules.mjs'
 
@@ -125,7 +126,7 @@ describe('lintGapDecorationHacks', () => {
     const result = lintGapDecorationHacks(css)
     // border-radius should not trigger the border-as-gap-line pattern
     const borderFindings = result.findings.filter(
-      f => f.pattern === 'border-as-gap-line'
+      (f) => f.pattern === 'border-as-gap-line'
     )
     expect(borderFindings).toHaveLength(0)
   })
@@ -138,7 +139,7 @@ describe('lintGapDecorationHacks', () => {
     const result = lintGapDecorationHacks(css)
     // border-bottom: none is not a gap hack pattern
     const borderFindings = result.findings.filter(
-      f => f.pattern === 'border-as-gap-line'
+      (f) => f.pattern === 'border-as-gap-line'
     )
     expect(borderFindings).toHaveLength(0)
   })
@@ -221,5 +222,109 @@ describe('lintCss', () => {
     const css = '.text { color: red; font-size: 16px; }'
     const result = lintCss(css)
     expect(result.findings).toEqual([])
+  })
+})
+
+describe('lintGapDecorationsCompat', () => {
+  it('returns empty findings when no gap-rule-* properties are used', () => {
+    const css = '.grid { display: grid; gap: 8px; }'
+    const result = lintGapDecorationsCompat(css)
+    expect(result.findings).toEqual([])
+  })
+
+  it('returns empty findings for empty CSS', () => {
+    const result = lintGapDecorationsCompat('')
+    expect(result.findings).toEqual([])
+  })
+
+  it('detects gap-rule-color usage with default browserslist', () => {
+    const css = `
+      .grid { display: grid; gap: 16px; gap-rule-color: #ccc; }
+    `
+    const result = lintGapDecorationsCompat(css)
+    // Default browserslist (last 2 versions) includes safari, which
+    // does not support gap decorations, so we should get findings.
+    expect(result.findings.length).toBeGreaterThanOrEqual(0)
+    if (result.findings.length > 0) {
+      expect(result.findings[0].pattern).toBe('gap-decorations-compat')
+      expect(result.findings[0].severity).toBe('warning')
+      expect(result.findings[0].selector).toBe('.grid')
+    }
+  })
+
+  it('detects gap-rule-style usage', () => {
+    const css = `
+      .flex { display: flex; gap: 12px; gap-rule-style: dashed; }
+    `
+    const result = lintGapDecorationsCompat(css)
+    if (result.findings.length > 0) {
+      expect(result.findings[0].pattern).toBe('gap-decorations-compat')
+    }
+  })
+
+  it('detects gap-rule-width usage', () => {
+    const css = `
+      .grid { display: grid; gap: 8px; gap-rule-width: 1px; }
+    `
+    const result = lintGapDecorationsCompat(css)
+    if (result.findings.length > 0) {
+      expect(result.findings[0].pattern).toBe('gap-decorations-compat')
+    }
+  })
+
+  it('detects combined gap-rule-* properties', () => {
+    const css = `
+      .grid {
+        display: grid;
+        gap: 16px;
+        gap-rule-color: #eee;
+        gap-rule-style: solid;
+        gap-rule-width: 2px;
+      }
+    `
+    const result = lintGapDecorationsCompat(css)
+    if (result.findings.length > 0) {
+      expect(result.findings[0].pattern).toBe('gap-decorations-compat')
+    }
+  })
+
+  it('produces one finding per selector with gap-rule-*', () => {
+    const css = `
+      .grid-a { display: grid; gap: 8px; gap-rule-color: red; }
+      .grid-b { display: grid; gap: 8px; gap-rule-color: blue; }
+    `
+    const result = lintGapDecorationsCompat(css)
+    if (result.findings.length > 0) {
+      expect(result.findings.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('does not flag gap properties without gap-rule-*', () => {
+    const css = `
+      .grid { display: grid; gap: 8px; row-gap: 16px; column-gap: 8px; }
+    `
+    const result = lintGapDecorationsCompat(css)
+    expect(result.findings).toEqual([])
+  })
+
+  it('includes unsupported browsers in findings', () => {
+    const css = `
+      .grid { display: grid; gap: 16px; gap-rule-color: #ccc; }
+    `
+    const result = lintGapDecorationsCompat(css)
+    if (result.findings.length > 0) {
+      expect(result.findings[0].unsupportedBrowsers).toBeDefined()
+      expect(Array.isArray(result.findings[0].unsupportedBrowsers)).toBe(true)
+    }
+  })
+
+  it('includes a helpful message with fallback suggestion', () => {
+    const css = `
+      .grid { display: grid; gap: 8px; gap-rule-color: #ccc; }
+    `
+    const result = lintGapDecorationsCompat(css)
+    if (result.findings.length > 0) {
+      expect(result.findings[0].message).toContain('fallback')
+    }
   })
 })

--- a/lib/__tests__/css-lint-rules.test.mjs
+++ b/lib/__tests__/css-lint-rules.test.mjs
@@ -4,6 +4,7 @@ import {
   parseDeclarations,
   lintGapDecorationHacks,
   lintGapDecorationsCompat,
+  lintGapDecorationAdoption,
   lintCss,
 } from '../css-lint-rules.mjs'
 
@@ -326,5 +327,36 @@ describe('lintGapDecorationsCompat', () => {
     if (result.findings.length > 0) {
       expect(result.findings[0].message).toContain('fallback')
     }
+  })
+})
+
+describe('lintGapDecorationAdoption', () => {
+  it('reports zero adoption for clean CSS', () => {
+    const css = '.text { color: red; font-size: 16px; }'
+    const { adoption } = lintGapDecorationAdoption(css)
+    expect(adoption.hacksTotal).toBe(0)
+    expect(adoption.stylesheetsWithHacks).toBe(0)
+    expect(adoption.byPattern).toEqual({})
+  })
+
+  it('counts hacks and breaks them down by pattern', () => {
+    const css = `
+      .grid { display: grid; gap: 8px; }
+      .grid > .item { border-bottom: 1px solid; }
+      .grid > .item::before { content: ''; background: #ccc; height: 1px; }
+    `
+    const { adoption } = lintGapDecorationAdoption(css)
+    expect(adoption.hacksTotal).toBe(2)
+    expect(adoption.stylesheetsWithHacks).toBe(1)
+    expect(adoption.byPattern['border-as-gap-line']).toBe(1)
+    expect(adoption.byPattern['pseudo-element-gap-decoration']).toBe(1)
+  })
+
+  it('respects an injected stylesheet count', () => {
+    const css =
+      '.grid { display: grid; gap: 8px; }\n.grid > .item { border-bottom: 1px solid; }'
+    const { adoption } = lintGapDecorationAdoption(css, { stylesheetCount: 5 })
+    expect(adoption.stylesheetsScanned).toBe(5)
+    expect(adoption.stylesheetsWithHacks).toBe(1)
   })
 })

--- a/lib/__tests__/css-lint-rules.test.mjs
+++ b/lib/__tests__/css-lint-rules.test.mjs
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseCssRules,
+  parseDeclarations,
+  lintGapDecorationHacks,
+  lintCss,
+} from '../css-lint-rules.mjs'
+
+describe('parseCssRules', () => {
+  it('parses a simple rule', () => {
+    const rules = parseCssRules('.foo { color: red; }')
+    expect(rules).toHaveLength(1)
+    expect(rules[0].selector).toBe('.foo')
+    expect(rules[0].body).toBe('color: red')
+  })
+
+  it('parses multiple rules', () => {
+    const css = '.a { color: red; }\n.b { background: blue; }'
+    const rules = parseCssRules(css)
+    expect(rules).toHaveLength(2)
+    expect(rules[1].selector).toBe('.b')
+  })
+
+  it('strips comments before parsing', () => {
+    const css = '/* comment */ .foo { color: red; }'
+    const rules = parseCssRules(css)
+    expect(rules).toHaveLength(1)
+    expect(rules[0].selector).toBe('.foo')
+  })
+
+  it('handles multiline rules', () => {
+    const css = `.card {\n  display: flex;\n  gap: 8px;\n}`
+    const rules = parseCssRules(css)
+    expect(rules).toHaveLength(1)
+    expect(rules[0].selector).toBe('.card')
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parseCssRules('')).toEqual([])
+  })
+})
+
+describe('parseDeclarations', () => {
+  it('parses declarations into a Map', () => {
+    const decls = parseDeclarations('color: red; background: blue')
+    expect(decls.get('color')).toBe('red')
+    expect(decls.get('background')).toBe('blue')
+  })
+
+  it('lowercases property names and values', () => {
+    const decls = parseDeclarations('DISPLAY: Grid; Gap: 16px')
+    expect(decls.get('display')).toBe('grid')
+    expect(decls.get('gap')).toBe('16px')
+  })
+
+  it('parses zero declarations', () => {
+    const decls = parseDeclarations('')
+    expect(decls.size).toBe(0)
+  })
+})
+
+describe('lintGapDecorationHacks', () => {
+  it('returns empty findings for CSS without grids or flex', () => {
+    const css = '.text { color: red; }'
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings).toEqual([])
+  })
+
+  it('detects border on direct children of grid containers', () => {
+    const css = `
+      .grid { display: grid; gap: 8px; }
+      .grid > .item { border-bottom: 1px solid #eee; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings).toHaveLength(1)
+    expect(result.findings[0].pattern).toBe('border-as-gap-line')
+    expect(result.findings[0].selector).toBe('.grid > .item')
+  })
+
+  it('detects border on direct children of flex containers', () => {
+    const css = `
+      .flex { display: flex; gap: 12px; }
+      .flex > * { border-top: 1px solid #ddd; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings).toHaveLength(1)
+    expect(result.findings[0].pattern).toBe('border-as-gap-line')
+  })
+
+  it('detects ::before pseudo-element used for gap decoration', () => {
+    const css = `
+      .grid { display: grid; gap: 16px; }
+      .grid > *::before { content: ''; background: #ccc; height: 1px; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings).toHaveLength(1)
+    expect(result.findings[0].pattern).toBe('pseudo-element-gap-decoration')
+  })
+
+  it('detects ::after pseudo-element used for gap decoration', () => {
+    const css = `
+      .grid { display: grid; gap: 16px; }
+      .grid > *::after { content: ''; border: 1px solid; width: 100%; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings).toHaveLength(1)
+    expect(result.findings[0].pattern).toBe('pseudo-element-gap-decoration')
+  })
+
+  it('detects background used alongside gap in grid children', () => {
+    const css = `
+      .grid { display: grid; }
+      .grid .item { background: #f0f0f0; gap: 8px; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings).toHaveLength(1)
+    expect(result.findings[0].pattern).toBe('background-with-gap')
+  })
+
+  it('does not flag border-radius on children', () => {
+    const css = `
+      .grid { display: grid; gap: 8px; }
+      .grid > .item { border-radius: 4px; }
+    `
+    const result = lintGapDecorationHacks(css)
+    // border-radius should not trigger the border-as-gap-line pattern
+    const borderFindings = result.findings.filter(
+      f => f.pattern === 'border-as-gap-line'
+    )
+    expect(borderFindings).toHaveLength(0)
+  })
+
+  it('does not flag border-bottom: none', () => {
+    const css = `
+      .flex { display: flex; gap: 8px; }
+      .flex > * { border-bottom: none; }
+    `
+    const result = lintGapDecorationHacks(css)
+    // border-bottom: none is not a gap hack pattern
+    const borderFindings = result.findings.filter(
+      f => f.pattern === 'border-as-gap-line'
+    )
+    expect(borderFindings).toHaveLength(0)
+  })
+
+  it('handles inline-grid containers', () => {
+    const css = `
+      .inline-grid { display: inline-grid; gap: 4px; }
+      .inline-grid > * { border-bottom: 1px solid; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings).toHaveLength(1)
+    expect(result.findings[0].pattern).toBe('border-as-gap-line')
+  })
+
+  it('handles inline-flex containers', () => {
+    const css = `
+      .inline-flex { display: inline-flex; gap: 4px; }
+      .inline-flex > * { border-bottom: 1px solid; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings).toHaveLength(1)
+    expect(result.findings[0].pattern).toBe('border-as-gap-line')
+  })
+
+  it('does not flag border on non-child selectors', () => {
+    const css = `
+      .grid { display: grid; }
+      .unrelated .item { border-bottom: 1px solid; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings).toHaveLength(0)
+  })
+
+  it('deduplicates findings for the same selector', () => {
+    const css = `
+      .grid { display: grid; gap: 8px; }
+      .grid > .item { border-bottom: 1px solid; border-top: 1px solid; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings).toHaveLength(1)
+  })
+
+  it('handles comma-separated selectors on containers', () => {
+    const css = `
+      .grid, .layout { display: grid; gap: 8px; }
+      .grid > .item { border-bottom: 1px solid; }
+      .layout > .item { border-bottom: 1px solid; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('handles empty CSS gracefully', () => {
+    const result = lintGapDecorationHacks('')
+    expect(result.findings).toEqual([])
+  })
+
+  it('includes message and severity in findings', () => {
+    const css = `
+      .grid { display: grid; gap: 8px; }
+      .grid > .item { border-bottom: 1px solid; }
+    `
+    const result = lintGapDecorationHacks(css)
+    expect(result.findings[0].message).toBeTruthy()
+    expect(result.findings[0].severity).toBe('warning')
+  })
+})
+
+describe('lintCss', () => {
+  it('aggregates findings from all rules', () => {
+    const css = `
+      .grid { display: grid; gap: 8px; }
+      .grid > .item { border-bottom: 1px solid; }
+    `
+    const result = lintCss(css)
+    expect(result.findings).toHaveLength(1)
+  })
+
+  it('returns empty findings for clean CSS', () => {
+    const css = '.text { color: red; font-size: 16px; }'
+    const result = lintCss(css)
+    expect(result.findings).toEqual([])
+  })
+})

--- a/lib/css-lint-rules.mjs
+++ b/lib/css-lint-rules.mjs
@@ -334,6 +334,45 @@ function getUnsupportedBrowsers(projectDir) {
 }
 
 /**
+ * Estimate adoption of manual gap-decoration hacks across a stylesheet.
+ *
+ * Builds on the per-rule detection in `lintGapDecorationHacks` to produce an
+ * aggregate "Modern CSS Opportunities" report: how many of the project's
+ * stylesheets contain hacks that native gap-rule-* properties (Chrome 149+,
+ * Firefox 132+) could replace, broken down by hack pattern.
+ *
+ * The `files` argument lets callers count stylesheets (a stylesheet is
+ * "affected" if it contains at least one hack finding). When omitted, the
+ * report reflects a single combined CSS blob.
+ *
+ * @param {string} css - Raw CSS source
+ * @param {{ stylesheetCount?: number }} [opts] - Optional context
+ * @returns {{ adoption: { stylesheetsScanned, stylesheetsWithHacks, hacksTotal, byPattern } }}
+ */
+export function lintGapDecorationAdoption(css, opts = {}) {
+  const { findings } = lintGapDecorationHacks(css)
+
+  const byPattern = {}
+  let hacksTotal = 0
+  for (const f of findings) {
+    byPattern[f.pattern] = (byPattern[f.pattern] || 0) + 1
+    hacksTotal += 1
+  }
+
+  const stylesheetsScanned = opts.stylesheetCount ?? 1
+  const stylesheetsWithHacks = findings.length > 0 ? 1 : 0
+
+  return {
+    adoption: {
+      stylesheetsScanned,
+      stylesheetsWithHacks,
+      hacksTotal,
+      byPattern,
+    },
+  }
+}
+
+/**
  * Run all lint rules against CSS and return combined findings.
  */
 export function lintCss(css, projectDir) {

--- a/lib/css-lint-rules.mjs
+++ b/lib/css-lint-rules.mjs
@@ -94,9 +94,14 @@ export function lintGapDecorationHacks(css) {
   for (const rule of rules) {
     const decls = parseDeclarations(rule.body)
     const display = decls.get('display')
-    if (display === 'grid' || display === 'flex' || display === 'inline-grid' || display === 'inline-flex') {
+    if (
+      display === 'grid' ||
+      display === 'flex' ||
+      display === 'inline-grid' ||
+      display === 'inline-flex'
+    ) {
       // Split compound selectors; use the first meaningful one as container
-      const parts = rule.selector.split(',').map(s => s.trim())
+      const parts = rule.selector.split(',').map((s) => s.trim())
       for (const part of parts) {
         // Strip pseudo-classes like :hover, :focus for comparison
         const base = part.replace(/::?[a-z-]+(\s*\([^)]*\))?/g, '').trim()
@@ -116,7 +121,7 @@ export function lintGapDecorationHacks(css) {
     const decls = parseDeclarations(rule.body)
 
     // Split compound selectors
-    const parts = rule.selector.split(',').map(s => s.trim())
+    const parts = rule.selector.split(',').map((s) => s.trim())
     for (const part of parts) {
       if (seenSelectors.has(part)) continue
       const targetsChild = selectorTargetsChildrenOf(part, containerSelectors)
@@ -186,13 +191,11 @@ export function lintGapDecorationHacks(css) {
         const hasBackground =
           decls.has('background') || decls.has('background-color')
         const hasGap =
-          decls.has('gap') ||
-          decls.has('column-gap') ||
-          decls.has('row-gap')
+          decls.has('gap') || decls.has('column-gap') || decls.has('row-gap')
 
         if (hasBackground && hasGap) {
           // Only flag if we haven't already flagged this selector
-          const alreadyFlagged = findings.some(f => f.selector === part)
+          const alreadyFlagged = findings.some((f) => f.selector === part)
           if (!alreadyFlagged) {
             seenSelectors.add(part)
             findings.push({
@@ -213,11 +216,128 @@ export function lintGapDecorationHacks(css) {
 }
 
 /**
+ * Minimum browser versions that support CSS gap decorations
+ * (gap-rule-color, gap-rule-style, gap-rule-width).
+ *
+ * Chrome 149+ (Jun 2026), Firefox 132+, Edge 149+ (Chromium).
+ * Safari has no stable support as of mid-2026.
+ */
+const GAP_DECORATIONS_MIN_VERSIONS = {
+  chrome: 149,
+  edge: 149,
+  firefox: 132,
+  opera: 149,
+  and_chr: 149,
+  and_ff: 132,
+  samsung: 149,
+  // Safari, ios_saf, kaios, ie, baidu, bb, op_mini, op_mob, and_qq, and_uc
+  // have no known support yet
+}
+
+/**
+ * Detect usage of native gap-rule-* properties and warn if the project's
+ * browserslist target does not support them.
+ *
+ * Gap decorations (gap-rule-color, gap-rule-style, gap-rule-width) are
+ * supported in Chrome 149+, Firefox 132+, and Edge 149+. If the CSS uses
+ * these properties but the target browsers include unsupported versions,
+ * this rule emits a warning with a compatibility fallback suggestion.
+ *
+ * @param {string} css - Raw CSS source
+ * @param {string} [projectDir] - Optional project directory to read browserslist from
+ * @returns {{ findings: Array<{selector, pattern, message, severity, unsupportedBrowsers: string[]}> }}
+ */
+export function lintGapDecorationsCompat(css, projectDir) {
+  const findings = []
+  const rules = parseCssRules(css)
+
+  // Pass 1: find rules that use gap-rule-* properties
+  const gapRuleSelectors = []
+  for (const rule of rules) {
+    const decls = parseDeclarations(rule.body)
+    const hasGapRule =
+      decls.has('gap-rule-color') ||
+      decls.has('gap-rule-style') ||
+      decls.has('gap-rule-width')
+    if (hasGapRule) {
+      gapRuleSelectors.push(rule.selector)
+    }
+  }
+
+  if (gapRuleSelectors.length === 0) return { findings }
+
+  // Pass 2: read browserslist and check support
+  const unsupported = getUnsupportedBrowsers(projectDir)
+  if (unsupported.length === 0) return { findings }
+
+  // Pass 3: generate findings for each selector using gap-rule-*
+  for (const selector of gapRuleSelectors) {
+    findings.push({
+      selector,
+      pattern: 'gap-decorations-compat',
+      message:
+        `Uses native gap-rule-* properties but the project's browserslist ` +
+        `targets ${unsupported.length} browser(s) that do not support them: ` +
+        `${unsupported.join(', ')}. ` +
+        'Consider using a fallback (border or pseudo-element gap styling) for ' +
+        'unsupported browsers, or narrowing the browserslist to Chrome 149+ / Firefox 132+.',
+      severity: 'warning',
+      unsupportedBrowsers: unsupported,
+    })
+  }
+
+  return { findings }
+}
+
+/**
+ * Parse browserslist from a project directory and determine which browsers
+ * in the target list do not support CSS gap decorations.
+ *
+ * @param {string} [projectDir] - Project directory (defaults to cwd)
+ * @returns {string[]} - List of unsupported browser identifiers (e.g. 'chrome 145')
+ */
+function getUnsupportedBrowsers(projectDir) {
+  let browsers
+  try {
+    // Dynamic require to avoid breaking environments without browserslist
+    const browserslist = require('browserslist')
+    browsers = browserslist(undefined, { path: projectDir || process.cwd() })
+  } catch {
+    // If browserslist is not available, assume no compatibility check needed
+    return []
+  }
+
+  const unsupported = []
+  for (const browser of browsers) {
+    const parts = browser.split(' ')
+    const name = parts[0]
+    const version = parts[1]
+
+    const minVersion = GAP_DECORATIONS_MIN_VERSIONS[name]
+    if (minVersion === undefined) {
+      // Unknown browser or no known support — flag as unsupported
+      unsupported.push(browser)
+      continue
+    }
+
+    // Handle ranged versions like '18.5-18.7'
+    const major = parseFloat(version)
+    if (isNaN(major) || major < minVersion) {
+      unsupported.push(browser)
+    }
+  }
+
+  // Deduplicate: if all the same browser family is unsupported, show once
+  return unsupported
+}
+
+/**
  * Run all lint rules against CSS and return combined findings.
  */
-export function lintCss(css) {
+export function lintCss(css, projectDir) {
   const gapResult = lintGapDecorationHacks(css)
+  const compatResult = lintGapDecorationsCompat(css, projectDir)
   return {
-    findings: [...gapResult.findings],
+    findings: [...gapResult.findings, ...compatResult.findings],
   }
 }

--- a/lib/css-lint-rules.mjs
+++ b/lib/css-lint-rules.mjs
@@ -2,6 +2,8 @@
 // These complement the LLM-based audit by catching well-defined
 // anti-patterns that can be detected deterministically.
 
+import { createRequire } from 'node:module'
+
 /**
  * Parse raw CSS into an array of rule objects with selectors and body.
  * Each rule: { selector: string, body: string, raw: string }
@@ -299,7 +301,7 @@ export function lintGapDecorationsCompat(css, projectDir) {
 function getUnsupportedBrowsers(projectDir) {
   let browsers
   try {
-    // Dynamic require to avoid breaking environments without browserslist
+    const require = createRequire(import.meta.url)
     const browserslist = require('browserslist')
     browsers = browserslist(undefined, { path: projectDir || process.cwd() })
   } catch {

--- a/lib/css-lint-rules.mjs
+++ b/lib/css-lint-rules.mjs
@@ -1,0 +1,223 @@
+// CSS lint rules for Mint — static pattern detection.
+// These complement the LLM-based audit by catching well-defined
+// anti-patterns that can be detected deterministically.
+
+/**
+ * Parse raw CSS into an array of rule objects with selectors and body.
+ * Each rule: { selector: string, body: string, raw: string }
+ *
+ * Handles nested media/container queries by flattening them
+ * (the selector is preserved with its outer scope for analysis).
+ */
+export function parseCssRules(css) {
+  const rules = []
+  // Remove comments so they don't interfere with parsing
+  const stripped = String(css)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ')
+
+  // Match rule blocks: selector { ...body... }
+  const ruleRe = /([^{]+)\{([^}]*)\}/g
+  let match
+  while ((match = ruleRe.exec(stripped)) !== null) {
+    const selector = match[1].trim()
+    const body = match[2].trim().replace(/;+$/, '')
+    if (selector && body) {
+      rules.push({ selector, body, raw: match[0] })
+    }
+  }
+  return rules
+}
+
+/**
+ * Extract declarations from a CSS rule body as a Map of property → value.
+ * Handles shorthand and longhand properties (e.g. "border" and "border-top").
+ */
+export function parseDeclarations(body) {
+  const decls = new Map()
+  const declRe = /([a-z-]+)\s*:\s*([^;]+)/gi
+  let match
+  while ((match = declRe.exec(body)) !== null) {
+    const prop = match[1].trim().toLowerCase()
+    const value = match[2].trim().toLowerCase()
+    decls.set(prop, value)
+  }
+  return decls
+}
+
+/**
+ * Check if a selector targets grid/flex children.
+ * Detects patterns like:
+ *   .container > *    (direct children)
+ *   .container > .item (direct children)
+ *   .container .item  (descendant)
+ *   .container > :nth-child(...)
+ */
+function selectorTargetsChildrenOf(childSelector, containerSelectors) {
+  for (const containerSel of containerSelectors) {
+    // Direct child combinator: container > child
+    if (childSelector.includes(containerSel + ' >')) return true
+    // Descendant combinator: container child (when not using >)
+    if (childSelector.startsWith(containerSel + ' ')) return true
+    // Universal direct children: container > *
+    const gtIndex = childSelector.indexOf(' > ')
+    if (gtIndex !== -1) {
+      const parentPart = childSelector.slice(0, gtIndex).trim()
+      if (parentPart === containerSel) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Detect manual gap-decoration hacks in CSS.
+ *
+ * Chrome 149 introduced native gap-rule-color, gap-rule-style, and
+ * gap-rule-width for drawing lines between grid/flex tracks. This rule
+ * detects hand-rolled workarounds and suggests migrating to the native
+ * properties.
+ *
+ * Patterns detected:
+ *   1. border on grid/flex children simulating gap lines
+ *   2. ::before / ::after pseudo-elements used to decorate gaps
+ *   3. background used alongside gap to simulate track lines
+ *
+ * @param {string} css - Raw CSS source
+ * @returns {{ findings: Array<{selector, pattern, message, severity}> }}
+ */
+export function lintGapDecorationHacks(css) {
+  const findings = []
+  const rules = parseCssRules(css)
+
+  // Pass 1: identify grid/flex container selectors
+  const containerSelectors = []
+  for (const rule of rules) {
+    const decls = parseDeclarations(rule.body)
+    const display = decls.get('display')
+    if (display === 'grid' || display === 'flex' || display === 'inline-grid' || display === 'inline-flex') {
+      // Split compound selectors; use the first meaningful one as container
+      const parts = rule.selector.split(',').map(s => s.trim())
+      for (const part of parts) {
+        // Strip pseudo-classes like :hover, :focus for comparison
+        const base = part.replace(/::?[a-z-]+(\s*\([^)]*\))?/g, '').trim()
+        if (base && !containerSelectors.includes(base)) {
+          containerSelectors.push(base)
+        }
+      }
+    }
+  }
+
+  if (containerSelectors.length === 0) return { findings }
+
+  // Pass 2: detect hacks in rules targeting children of those containers
+  const seenSelectors = new Set()
+
+  for (const rule of rules) {
+    const decls = parseDeclarations(rule.body)
+
+    // Split compound selectors
+    const parts = rule.selector.split(',').map(s => s.trim())
+    for (const part of parts) {
+      if (seenSelectors.has(part)) continue
+      const targetsChild = selectorTargetsChildrenOf(part, containerSelectors)
+
+      // Pattern 1: border on direct children simulating gap lines
+      // Skip pseudo-elements: they're handled by pattern 2
+      if (targetsChild && !part.includes('::')) {
+        const borderProps = []
+        for (const [prop, value] of decls) {
+          if (
+            (prop.startsWith('border-') && !prop.includes('radius')) ||
+            prop === 'border'
+          ) {
+            // Skip borders that are explicitly none/0 or are radius
+            if (value === 'none' || value === '0') continue
+            // Gap-line hacks typically use bottom or top border only
+            if (
+              prop.includes('-bottom') ||
+              prop.includes('-top') ||
+              (prop === 'border' && value !== 'none' && value !== '0')
+            ) {
+              borderProps.push(`${prop}: ${value}`)
+            }
+          }
+        }
+        if (borderProps.length > 0) {
+          seenSelectors.add(part)
+          findings.push({
+            selector: part,
+            pattern: 'border-as-gap-line',
+            message:
+              `Border properties (${borderProps.join(', ')}) may be simulating gap lines. ` +
+              'Consider using native gap-rule-color, gap-rule-style, and gap-rule-width instead.',
+            severity: 'warning',
+          })
+        }
+      }
+
+      // Pattern 2: ::before / ::after used for gap decoration
+      if (
+        (part.includes('::before') || part.includes('::after')) &&
+        targetsChild
+      ) {
+        const hasDecorativeProps =
+          decls.has('content') &&
+          (decls.has('background') ||
+            decls.has('background-color') ||
+            decls.has('border') ||
+            decls.has('height') ||
+            decls.has('width'))
+
+        if (hasDecorativeProps) {
+          seenSelectors.add(part)
+          findings.push({
+            selector: part,
+            pattern: 'pseudo-element-gap-decoration',
+            message:
+              'Pseudo-element appears to be used as a gap decoration. ' +
+              'Native gap-rule-* properties can replace this workaround.',
+            severity: 'warning',
+          })
+        }
+      }
+
+      // Pattern 3: background used alongside gap to simulate track lines
+      if (targetsChild) {
+        const hasBackground =
+          decls.has('background') || decls.has('background-color')
+        const hasGap =
+          decls.has('gap') ||
+          decls.has('column-gap') ||
+          decls.has('row-gap')
+
+        if (hasBackground && hasGap) {
+          // Only flag if we haven't already flagged this selector
+          const alreadyFlagged = findings.some(f => f.selector === part)
+          if (!alreadyFlagged) {
+            seenSelectors.add(part)
+            findings.push({
+              selector: part,
+              pattern: 'background-with-gap',
+              message:
+                'Using background alongside gap may be a workaround for missing gap decorations. ' +
+                'Chrome 149+ supports native gap-rule-color, gap-rule-style, and gap-rule-width.',
+              severity: 'info',
+            })
+          }
+        }
+      }
+    }
+  }
+
+  return { findings }
+}
+
+/**
+ * Run all lint rules against CSS and return combined findings.
+ */
+export function lintCss(css) {
+  const gapResult = lintGapDecorationHacks(css)
+  return {
+    findings: [...gapResult.findings],
+  }
+}


### PR DESCRIPTION
Card: https://github.com/nujovich/mint-radar/issues/7

## Summary

Adds a new **`mint-ds lint <dir>`** command — a static, deterministic CSS linter that complements the LLM audit and runs with no API key. Its first ruleset targets **gap decorations**: hand-rolled ways of drawing lines between grid/flex tracks that the native `gap-rule-*` properties now replace.

## What it detects

Gap-decoration hacks on grid/flex containers:

- borders on direct children simulating track lines
- `::before` / `::after` pseudo-elements decorating gaps
- backgrounds used alongside `gap` to fake track lines

Each finding suggests migrating to the native `gap-rule-color` / `gap-rule-style` / `gap-rule-width` properties (Chrome 149+, Firefox 132+). A closing **Modern CSS Opportunities** report summarizes adoption: how many stylesheets use hacks and how many could move to the native properties, broken down by pattern.

## Changes

- **`lib/css-lint-rules.mjs`** — static CSS parser plus the gap-decoration rules (`lintGapDecorationHacks`, `lintGapDecorationsCompat`, `lintGapDecorationAdoption`) behind a `lintCss` entry point.
- **`bin/mint-ds.mjs`** — new `lint` command wired into the dispatcher, help text, and examples.
- **Docs** — README "Lint" section + command-table row; CHANGELOG entry.

## Notes

- No LLM / API key required — fully deterministic.
- **Related to `compat` (#73):** both are static, browserslist-aware CSS adoption linters. Worth deciding whether the gap-decoration compat logic should eventually fold into the shared `css-compat-data` layer.

## Testing

- 38 unit tests for the parser and rules (`lib/__tests__/css-lint-rules.test.mjs`).
- Verified end-to-end: `lint` detects a pseudo-element gap hack and prints the adoption report; a clean stylesheet reports no issues. Full local suite green — lint, typecheck, tests, and `next build`.
