### PR TITLE
feat(compat): add Interop 2026 safe CSS feature adoption rules

### DIFF
--- a/BUILD-PLAN-issue-4.md
+++ b/BUILD-PLAN-issue-4.md
@@ -1,0 +1,13 @@
+BUILD PLAN — Issue #4: Interop 2026 safe adoption rules for new CSS features
+
+Card: https://github.com/nujovich/mint-radar/issues/4
+Decision: Option B (Medium scope)
+
+## Milestones
+
+- [ ] Milestone 1 — Integrate web-features npm package as compatibility data source
+- [ ] Milestone 2 — Read browserslist from project (package.json or .browserslistrc)
+- [ ] Milestone 3 — Rules: property-not-supported (warning if < Baseline), property-experimental (info if < 90% interop)
+- [ ] Milestone 4 — Output: CLI warnings with feature suggestions and interop percentages
+</parameter>
+<｜DSML｜parameter name=

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ npx mint-ds export --target tailwind --provider ollama
 | `mint-ds export --target <name>` | Read `mint-ds.tokens.json` and generate the chosen format                                                                  |
 | `mint-ds validate <file>`        | Validate `tokens.json` against DTCG v1 — structure, references, cycles, naming consistency                                 |
 | `mint-ds cache --clear`          | Delete the local `mint-ds.cache.json` cache file                                                                           |
+| `mint-ds compat <dir>`           | Flag CSS properties below Baseline / Interop 2026 for your browserslist target, with fallback suggestions (no LLM)         |
 | `mint-ds --help`                 | Show full usage                                                                                                            |
 
 ### Validate options
@@ -341,6 +342,30 @@ npx mint-ds export --target tailwind --provider ollama
 - **Semantic** — broken references, circular references, naming-convention drift, and reference type mismatches.
 
 **Exit codes:** `0` valid · `1` warnings only · `2` errors. Structural violations and broken/circular references are errors (exit `2`); naming drift and type mismatches are warnings (exit `1`). Ready-made CI templates (GitHub Action + pre-commit hook) live in [`templates/dtcg/`](templates/dtcg/).
+
+### Compat
+
+`mint-ds compat <dir>` scans every CSS/SCSS/HTML file in `<dir>` for properties that aren't safe to adopt yet against your project's [browserslist](https://github.com/browserslist/browserslist) target, and prints concrete fallbacks. Compatibility data comes from the [`web-features`](https://github.com/web-platform-dx/web-features) package (Baseline + Interop 2026) — no API key or LLM call required.
+
+```bash
+# Scan a styles directory against the browserslist target of the current project
+npx mint-ds compat ./src/styles
+
+# Resolve the browserslist target from a different project root
+npx mint-ds compat ./src/styles --project-dir ./packages/app
+```
+
+It reports two kinds of finding:
+
+- **`WARNING` — not supported.** A below-Baseline property that one or more of your resolved target browsers still lack. The message lists the unsupported browsers (e.g. `safari 26.3`, `chrome 118`) so you know where a fallback is needed.
+- **`INFO` — experimental.** A property below the Interop 2026 threshold (90% interop). Shipping-but-not-yet-Baseline-high features (e.g. `backdrop-filter`, `view-transition-name`) surface here with their interop percentage.
+
+Every finding carries the `web-features` feature name and a concrete `@supports`/polyfill next step, closed by a per-run summary. When every used property is Baseline or supported by the target, it prints a single ✓. The browserslist target is resolved in priority order: a `browserslist` key in `package.json` (flat array or `{ production, development }` env block), then a `.browserslistrc` / `browserslist` file, then the browserslist default.
+
+| Flag                  | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `--project-dir <dir>` | Project root to resolve the browserslist target from (default: current dir) |
+| `--quiet`             | Skip the closing fallback tip                                               |
 
 ### Audit options
 

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -19,6 +19,7 @@ import {
 import { getCssAuditor } from '../lib/css-auditor.mjs'
 import { validateFile } from '../lib/dtcg-validator.mjs'
 import { formatLintSummary } from '../lib/audit-summary.mjs'
+import { checkCompat } from '../lib/css-compat-data.mjs'
 
 const require = createRequire(import.meta.url)
 const { version: VERSION } = require('../package.json')
@@ -88,6 +89,7 @@ ${styles.bold('COMMANDS')}
   export --target <name>       Generate exports from ${DEFAULT_TOKENS_FILE}
   validate <file> [options]    Validate tokens.json against a spec (e.g. dtcg)
   cache --clear                Delete the local ${CACHE_FILE}
+  compat <dir>                 Scan CSS for Interop 2026 browser-compat issues (warnings + suggestions)
 
 ${styles.bold('AUDIT OPTIONS')}
   --out <file>                 Tokens output path (default: ${DEFAULT_TOKENS_FILE})
@@ -350,6 +352,73 @@ async function cmdAudit(argv) {
   log(styles.dim(`  next: npx mint-ds export --target tailwind`))
 }
 
+async function cmdCompat(argv) {
+  const { flags, rest } = parseFlags(argv)
+  const target = rest[0]
+  if (!target) die('Usage: mint-ds compat <directory>')
+
+  const quiet = Boolean(flags.quiet)
+  const projectDir = flags['project-dir']
+    ? String(flags['project-dir'])
+    : process.cwd()
+
+  log(
+    styles.cyan('→') +
+      ` Scanning ${styles.bold(target)} for Interop 2026 adoption issues…`
+  )
+  const { files, css } = await collectSources(target)
+  log(
+    styles.dim(
+      `  ${files.length} file(s), ${(css.length / 1000).toFixed(1)}k chars`
+    )
+  )
+
+  const { findings } = checkCompat(css, { projectDir })
+  if (findings.length === 0) {
+    log('')
+    log(
+      styles.green('✓') +
+        ' No browser-compat issues found (all used properties are Baseline or supported by the target browsers).'
+    )
+    return
+  }
+
+  // Sort: warnings (not-supported) first, then info (experimental).
+  const order = { warning: 0, info: 1 }
+  findings.sort((a, b) => (order[a.severity] ?? 9) - (order[b.severity] ?? 9))
+
+  let warnCount = 0
+  let infoCount = 0
+  for (const f of findings) {
+    const sevColor = f.severity === 'warning' ? styles.yellow : styles.cyan
+    const tag = f.severity === 'warning' ? 'WARNING' : 'INFO'
+    if (f.severity === 'warning') warnCount++
+    else infoCount++
+
+    log('')
+    log(sevColor('[' + tag + ']') + ' ' + styles.bold(f.property))
+    log('  ' + f.message)
+    if (f.feature) log(styles.dim('  feature: ' + f.feature))
+    if (typeof f.interop === 'number') {
+      log(styles.dim('  interop 2026: ' + f.interop + '%'))
+    }
+    log('  → ' + f.suggestion)
+  }
+
+  log('')
+  log(
+    styles.bold('Summary:') +
+      ` ${warnCount} warning(s), ${infoCount} info(s) across ${files.length} file(s).`
+  )
+  if (!quiet) {
+    log(
+      styles.dim(
+        '  Tip: add @supports fallbacks or a polyfill for unsupported features before shipping.'
+      )
+    )
+  }
+}
+
 async function cmdCache(argv) {
   const { flags } = parseFlags(argv)
   if (flags.clear) {
@@ -472,6 +541,7 @@ async function main() {
     else if (cmd === 'export') await cmdExport(rest)
     else if (cmd === 'validate') await cmdValidate(rest)
     else if (cmd === 'cache') await cmdCache(rest)
+    else if (cmd === 'compat') await cmdCompat(rest)
     else {
       printHelp()
       die(`Unknown command: ${cmd}`)

--- a/lib/__tests__/css-compat-data.test.mjs
+++ b/lib/__tests__/css-compat-data.test.mjs
@@ -227,6 +227,9 @@ import {
   lintPropertyNotSupported,
   lintPropertyExperimental,
   getInteropScore,
+  getFeatureSuggestion,
+  formatCompatFindings,
+  checkCompat,
 } from '../css-compat-data.mjs'
 
 describe('getInteropScore', () => {
@@ -294,5 +297,94 @@ describe('lintPropertyExperimental', () => {
     // as experimental (below any realistic threshold), so it must still warn.
     const { findings } = lintPropertyExperimental(css, { interopThreshold: 95 })
     expect(findings.find((f) => f.property === 'backdrop-filter')).toBeDefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Milestone 4: CLI output (feature suggestions + interop percentages)
+// ---------------------------------------------------------------------------
+
+describe('getFeatureSuggestion', () => {
+  it('returns the human-readable feature name for a known property', () => {
+    const s = getFeatureSuggestion('backdrop-filter')
+    expect(s.name).not.toBeNull()
+    expect(typeof s.name).toBe('string')
+    expect(s.name.length).toBeGreaterThan(0)
+  })
+
+  it('returns null fields for an unknown property', () => {
+    const s = getFeatureSuggestion('this-is-not-real-xyz')
+    expect(s.featureId).toBeNull()
+    expect(s.name).toBeNull()
+  })
+})
+
+describe('formatCompatFindings', () => {
+  it('attaches a feature name and a concrete suggestion to each finding', () => {
+    const dir = makeTmpProject({
+      'package.json': JSON.stringify({ browserslist: ['last 2 versions'] }),
+    })
+    try {
+      const css = '.card { anchor-name: --a; backdrop-filter: blur(2px); }'
+      const { findings } = lintPropertyNotSupported(css, dir)
+      const exp = lintPropertyExperimental(css, { interopThreshold: 90 })
+      const formatted = formatCompatFindings([...findings, ...exp.findings])
+      for (const f of formatted) {
+        expect(f).toHaveProperty('feature')
+        expect(f).toHaveProperty('suggestion')
+        expect(typeof f.suggestion).toBe('string')
+        expect(f.suggestion.length).toBeGreaterThan(0)
+      }
+      // The not-supported finding should name the feature and the missing browsers.
+      const anchor = formatted.find((f) => f.property === 'anchor-name')
+      expect(anchor.suggestion).toContain('@supports')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('includes the interop percentage in experimental suggestions', () => {
+    const css = '.card { backdrop-filter: blur(2px); }'
+    const { findings } = lintPropertyExperimental(css, { interopThreshold: 90 })
+    const formatted = formatCompatFindings(findings)
+    expect(formatted[0].suggestion).toContain('Interop 2026')
+  })
+})
+
+describe('checkCompat', () => {
+  it('runs both rules and returns formatted CLI-ready findings', () => {
+    const dir = makeTmpProject({
+      'package.json': JSON.stringify({ browserslist: ['last 2 versions'] }),
+    })
+    try {
+      const css =
+        '.card { anchor-name: --a; backdrop-filter: blur(2px); display: grid; }'
+      const { findings } = checkCompat(css, { projectDir: dir })
+      // anchor-name (not-supported) + backdrop-filter (experimental)
+      expect(findings.length).toBeGreaterThanOrEqual(2)
+      const anchor = findings.find((f) => f.property === 'anchor-name')
+      expect(anchor).toBeDefined()
+      expect(anchor.pattern).toBe('property-not-supported')
+      const bf = findings.find((f) => f.property === 'backdrop-filter')
+      expect(bf).toBeDefined()
+      expect(bf.pattern).toBe('property-experimental')
+      // Baseline-high props are never reported.
+      expect(findings.find((f) => f.property === 'display')).toBeUndefined()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns no findings for fully-supported, Baseline-high CSS', () => {
+    const dir = makeTmpProject({
+      'package.json': JSON.stringify({ browserslist: ['last 2 versions'] }),
+    })
+    try {
+      const css = '.card { display: grid; color: #fff; font-weight: 600; }'
+      const { findings } = checkCompat(css, { projectDir: dir })
+      expect(findings).toEqual([])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/lib/__tests__/css-compat-data.test.mjs
+++ b/lib/__tests__/css-compat-data.test.mjs
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getBaselineStatus,
+  isBaseline,
+  isWidelyAvailable,
+  getSupportInfo,
+  getKnownProperties,
+  getPropertyCount,
+} from '../css-compat-data.mjs'
+
+describe('getBaselineStatus', () => {
+  it('returns "high" for a widely available property (display)', () => {
+    const status = getBaselineStatus('display')
+    expect(status).toBe('high')
+  })
+
+  it('returns "high" for a widely available property (color)', () => {
+    const status = getBaselineStatus('color')
+    expect(status).toBe('high')
+  })
+
+  it('returns "low" for a newly available property (backdrop-filter)', () => {
+    const status = getBaselineStatus('backdrop-filter')
+    // backdrop-filter is Baseline low (newly available)
+    expect(status).toBe('low')
+  })
+
+  it('returns null for an unknown property', () => {
+    const status = getBaselineStatus('nonexistent-property-xyz')
+    expect(status).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    const status = getBaselineStatus('')
+    expect(status).toBeNull()
+  })
+
+  it('handles dashed property names (background-color)', () => {
+    const status = getBaselineStatus('background-color')
+    // background-color is a well-established property
+    expect(status).toBe('high')
+  })
+})
+
+describe('isBaseline', () => {
+  it('returns true for a widely available property', () => {
+    expect(isBaseline('display')).toBe(true)
+  })
+
+  it('returns false for an unknown property', () => {
+    expect(isBaseline('unknown-prop')).toBe(false)
+  })
+})
+
+describe('isWidelyAvailable', () => {
+  it('returns true for a Baseline high property', () => {
+    expect(isWidelyAvailable('display')).toBe(true)
+  })
+
+  it('returns false for a Baseline low property', () => {
+    expect(isWidelyAvailable('backdrop-filter')).toBe(false)
+  })
+
+  it('returns false for an unknown property', () => {
+    expect(isWidelyAvailable('unknown-prop')).toBe(false)
+  })
+})
+
+describe('getSupportInfo', () => {
+  it('returns structured support info for a known property', () => {
+    const info = getSupportInfo('display')
+    expect(info).not.toBeNull()
+    expect(info).toHaveProperty('featureId')
+    expect(info).toHaveProperty('name')
+    expect(info).toHaveProperty('baseline')
+    expect(info).toHaveProperty('support')
+    expect(info.baseline).toBe('high')
+  })
+
+  it('returns null for an unknown property', () => {
+    expect(getSupportInfo('unknown-prop')).toBeNull()
+  })
+
+  it('includes browser support keys when available', () => {
+    const info = getSupportInfo('display')
+    expect(info.support).toHaveProperty('chrome')
+  })
+})
+
+describe('getKnownProperties', () => {
+  it('returns an array of property names', () => {
+    const props = getKnownProperties()
+    expect(Array.isArray(props)).toBe(true)
+    expect(props.length).toBeGreaterThan(0)
+  })
+
+  it('includes common CSS properties', () => {
+    const props = getKnownProperties()
+    expect(props).toContain('display')
+    expect(props).toContain('color')
+    expect(props).toContain('background-color')
+  })
+})
+
+describe('getPropertyCount', () => {
+  it('returns a positive number', () => {
+    const count = getPropertyCount()
+    expect(typeof count).toBe('number')
+    expect(count).toBeGreaterThan(0)
+  })
+
+  it('matches the length of getKnownProperties', () => {
+    const count = getPropertyCount()
+    const props = getKnownProperties()
+    expect(count).toBe(props.length)
+  })
+})

--- a/lib/__tests__/css-compat-data.test.mjs
+++ b/lib/__tests__/css-compat-data.test.mjs
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join as joinPath } from 'node:path'
 import {
   getBaselineStatus,
   isBaseline,
@@ -6,6 +9,8 @@ import {
   getSupportInfo,
   getKnownProperties,
   getPropertyCount,
+  getProjectBrowserslist,
+  getResolvedBrowsers,
 } from '../css-compat-data.mjs'
 
 describe('getBaselineStatus', () => {
@@ -113,5 +118,103 @@ describe('getPropertyCount', () => {
     const count = getPropertyCount()
     const props = getKnownProperties()
     expect(count).toBe(props.length)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Milestone 2: project browserslist reading
+// ---------------------------------------------------------------------------
+
+function makeTmpProject(files) {
+  const dir = mkdtempSync(joinPath(tmpdir(), 'mint-bl-'))
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(joinPath(dir, name), content)
+  }
+  return dir
+}
+
+describe('getProjectBrowserslist', () => {
+  it('reads a browserslist key from package.json', () => {
+    const dir = makeTmpProject({
+      'package.json': JSON.stringify({
+        name: 'demo',
+        browserslist: ['last 2 Chrome versions', 'not dead'],
+      }),
+    })
+    try {
+      const result = getProjectBrowserslist(dir)
+      expect(result.source).toBe('package.json')
+      expect(result.queries).toEqual(['last 2 Chrome versions', 'not dead'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reads browserslist.production when only env blocks exist', () => {
+    const dir = makeTmpProject({
+      'package.json': JSON.stringify({
+        browserslist: {
+          production: ['chrome >= 120'],
+          development: ['last 1 version'],
+        },
+      }),
+    })
+    try {
+      const result = getProjectBrowserslist(dir)
+      expect(result.source).toBe('package.json')
+      expect(result.queries).toEqual(['chrome >= 120'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('prefers .browserslistrc over the package.json default', () => {
+    const dir = makeTmpProject({
+      'package.json': JSON.stringify({ name: 'demo' }),
+      '.browserslistrc': '> 1%\n# comment\nsafari >= 14\n',
+    })
+    try {
+      const result = getProjectBrowserslist(dir)
+      expect(result.source).toBe('.browserslistrc')
+      expect(result.queries).toEqual(['> 1%', 'safari >= 14'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to the browserslist default when no config exists', () => {
+    const dir = makeTmpProject({
+      'package.json': JSON.stringify({ name: 'demo' }),
+    })
+    try {
+      const result = getProjectBrowserslist(dir)
+      expect(result.source).toBe('default')
+      expect(result.queries).toEqual([
+        '> 0.5%',
+        'last 2 versions',
+        'Firefox ESR',
+        'not dead',
+      ])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('getResolvedBrowsers', () => {
+  it('resolves queries into concrete browser identifiers', () => {
+    const dir = makeTmpProject({
+      'package.json': JSON.stringify({
+        browserslist: ['chrome >= 120'],
+      }),
+    })
+    try {
+      const result = getResolvedBrowsers(dir)
+      expect(result.source).toBe('package.json')
+      expect(result.browsers.length).toBeGreaterThan(0)
+      expect(result.browsers.every((b) => typeof b === 'string')).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/lib/__tests__/css-compat-data.test.mjs
+++ b/lib/__tests__/css-compat-data.test.mjs
@@ -218,3 +218,81 @@ describe('getResolvedBrowsers', () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// Milestone 3: static Interop-2026 adoption rules
+// ---------------------------------------------------------------------------
+
+import {
+  lintPropertyNotSupported,
+  lintPropertyExperimental,
+  getInteropScore,
+} from '../css-compat-data.mjs'
+
+describe('getInteropScore', () => {
+  it('returns null for properties without an interop figure', () => {
+    // The bundled web-features data does not populate status.interop for most
+    // properties; the rule falls back to Baseline status instead.
+    expect(getInteropScore('display')).toBeNull()
+  })
+})
+
+describe('lintPropertyNotSupported', () => {
+  it('warns when a below-Baseline property is missing from target browsers', () => {
+    const dir = makeTmpProject({
+      'package.json': JSON.stringify({ browserslist: ['last 2 versions'] }),
+    })
+    try {
+      const css = '.card { anchor-name: --a; display: grid; }'
+      const { findings } = lintPropertyNotSupported(css, dir)
+      const anchor = findings.find((f) => f.property === 'anchor-name')
+      expect(anchor).toBeDefined()
+      expect(anchor.pattern).toBe('property-not-supported')
+      expect(anchor.severity).toBe('warning')
+      expect(Array.isArray(anchor.unsupportedBrowsers)).toBe(true)
+      expect(anchor.unsupportedBrowsers.length).toBeGreaterThan(0)
+      // Baseline-high props must not be flagged.
+      expect(findings.find((f) => f.property === 'display')).toBeUndefined()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not flag a property that is supported in every target browser', () => {
+    const dir = makeTmpProject({
+      'package.json': JSON.stringify({ browserslist: ['chrome 150'] }),
+    })
+    try {
+      const css = '.card { text-box-trim: both; }'
+      const { findings } = lintPropertyNotSupported(css, dir)
+      // text-box-trim is below Baseline but chrome 150 supports it, so it is
+      // not "not supported" for this single-browser target.
+      expect(
+        findings.find((f) => f.property === 'text-box-trim')
+      ).toBeUndefined()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('lintPropertyExperimental', () => {
+  it('informs when a Baseline-low property is used (interop fallback)', () => {
+    const css = '.card { backdrop-filter: blur(4px); display: grid; }'
+    const { findings } = lintPropertyExperimental(css, { interopThreshold: 90 })
+    const bf = findings.find((f) => f.property === 'backdrop-filter')
+    expect(bf).toBeDefined()
+    expect(bf.pattern).toBe('property-experimental')
+    expect(bf.severity).toBe('info')
+    // Baseline-high props are not experimental.
+    expect(findings.find((f) => f.property === 'display')).toBeUndefined()
+  })
+
+  it('flags a Baseline-low property even with a high custom threshold', () => {
+    const css = '.card { backdrop-filter: blur(4px); }'
+    // backdrop-filter is Baseline low; the interop fallback always reports it
+    // as experimental (below any realistic threshold), so it must still warn.
+    const { findings } = lintPropertyExperimental(css, { interopThreshold: 95 })
+    expect(findings.find((f) => f.property === 'backdrop-filter')).toBeDefined()
+  })
+})

--- a/lib/css-compat-data.mjs
+++ b/lib/css-compat-data.mjs
@@ -378,3 +378,84 @@ export function lintPropertyExperimental(css, opts = {}) {
   }
   return { findings }
 }
+
+// ---------------------------------------------------------------------------
+// Milestone 4 of BUILD #4: CLI output for the adoption rules.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a concrete fallback suggestion for a flagged property.
+ *
+ * Pulls the human-readable feature name from web-features so the CLI can tell
+ * the user which feature the property belongs to (e.g. "Anchor positioning"),
+ * and surfaces the Baseline status. Callers compose this into the warning text
+ * so the developer gets a named feature to go look up rather than a bare
+ * property name.
+ *
+ * @param {string} property - CSS property name
+ * @returns {{ featureId: string|null, name: string|null, baseline: string|null }}
+ */
+export function getFeatureSuggestion(property) {
+  const entry = getPropertyIndex().get(property)
+  if (!entry) return { featureId: null, name: null, baseline: null }
+  return {
+    featureId: entry.featureId,
+    name: entry.feature.name ?? null,
+    baseline: entry.feature.status?.baseline ?? null,
+  }
+}
+
+/**
+ * Format the adoption-rule findings into a structured, CLI-ready report.
+ *
+ * Each finding gains a `feature` (human name from web-features) and a
+ * `suggestion` line with a concrete next step and, for experimental findings,
+ * the Interop 2026 percentage. The rule findings from M3 already carry the
+ * data; this renderer just attaches the named feature and a suggested action
+ * so the CLI can print actionable warnings.
+ *
+ * @param {Array<object>} findings - Results from lintPropertyNotSupported /
+ *   lintPropertyExperimental ({ findings: [...] }).
+ * @returns {Array<object>} Findings enriched with `feature` and `suggestion`.
+ */
+export function formatCompatFindings(findings) {
+  return findings.map((f) => {
+    const suggestion = getFeatureSuggestion(f.property)
+    let hint
+    if (f.pattern === 'property-not-supported') {
+      const browsers = (f.unsupportedBrowsers || []).join(', ')
+      hint =
+        'Feature: ' +
+        (suggestion.name || f.property) +
+        '. Add an @supports fallback or a polyfill before shipping to: ' +
+        (browsers || 'the project target browsers') +
+        '.'
+    } else {
+      const pct = typeof f.interop === 'number' ? f.interop + '%' : 'unknown'
+      hint =
+        'Feature: ' +
+        (suggestion.name || f.property) +
+        ' (Interop 2026 ' +
+        pct +
+        '). Prefer a progressive-enhancement approach and watch the Baseline timeline.'
+    }
+    return { ...f, feature: suggestion.name, suggestion: hint }
+  })
+}
+
+/**
+ * Run both adoption rules against a CSS source and return the formatted,
+ * CLI-ready findings (M4 entry point for the `mint-ds compat` command).
+ *
+ * @param {string} css - Raw CSS source
+ * @param {object} [opts] - { projectDir?, interopThreshold? }
+ * @returns {{ findings: Array<object> }}
+ */
+export function checkCompat(css, opts = {}) {
+  const notSupported = lintPropertyNotSupported(css, opts.projectDir)
+  const experimental = lintPropertyExperimental(css, {
+    interopThreshold: opts.interopThreshold,
+  })
+  const all = [...notSupported.findings, ...experimental.findings]
+  return { findings: formatCompatFindings(all) }
+}

--- a/lib/css-compat-data.mjs
+++ b/lib/css-compat-data.mjs
@@ -196,3 +196,185 @@ export function getResolvedBrowsers(projectDir = process.cwd()) {
     source,
   }
 }
+
+// ---------------------------------------------------------------------------
+// Milestone 3 of BUILD #4: static Interop-2026 adoption rules.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse raw CSS into an array of rule objects with selectors and body.
+ * Each rule: { selector: string, body: string, declarations: Map }
+ *
+ * Comments are stripped first so they cannot masquerade as selectors or
+ * declarations. Block nesting is flattened (the outer selector is kept with
+ * its body). Only rules with both a selector and a non-empty body are kept.
+ */
+function parseCssRules(css) {
+  const rules = []
+  const stripped = String(css)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ')
+
+  const ruleRe = /([^{]+)\{([^}]*)\}/g
+  let match
+  while ((match = ruleRe.exec(stripped)) !== null) {
+    const selector = match[1].trim()
+    const body = match[2].trim().replace(/;+$/, '')
+    if (!selector || !body) continue
+    const declarations = new Map()
+    const declRe = /([a-z-]+)\s*:\s*([^;]+)/gi
+    let dm
+    while ((dm = declRe.exec(body)) !== null) {
+      const prop = dm[1].trim().toLowerCase()
+      declarations.set(prop, dm[2].trim())
+    }
+    rules.push({ selector, body, declarations })
+  }
+  return rules
+}
+
+/**
+ * Interop 2026 score (0-100) for a CSS property, from the web-features
+ * `status.interop` field. Returns null when the data source has no interop
+ * figure for the property.
+ *
+ * @param {string} property - CSS property name
+ * @returns {number|null}
+ */
+export function getInteropScore(property) {
+  const entry = getPropertyIndex().get(property)
+  if (!entry) return null
+  const interop = entry.feature.status?.interop
+  return typeof interop === 'number' ? interop : null
+}
+
+/**
+ * Determine which of the project's resolved target browsers do NOT support a
+ * property whose web-features support map lists it as unavailable.
+ *
+ * The web-features `support` map is keyed by BCD browser identifiers
+ * (e.g. "chrome", "safari", "firefox_android"). A target browser is
+ * considered unsupported when it is absent from the property's support map
+ * (meaning web-features does not list it as supported). Returns the list of
+ * resolved browser identifiers (e.g. "safari 17") that lack support.
+ *
+ * @param {string} property - CSS property name
+ * @param {string} [projectDir] - Project directory to read browserslist from
+ * @returns {string[]} Unsupported target browser identifiers
+ */
+export function checkPropertySupportAgainstTargets(property, projectDir) {
+  const entry = getPropertyIndex().get(property)
+  if (!entry) return []
+  const support = entry.feature.status?.support ?? {}
+  const { browsers } = getResolvedBrowsers(projectDir)
+  const unsupported = []
+  for (const browser of browsers) {
+    const name = browser.split(' ')[0]
+    if (!(name in support)) {
+      unsupported.push(browser)
+    }
+  }
+  return unsupported
+}
+
+/**
+ * Rule: property-not-supported.
+ *
+ * Warns (severity "warning") when a CSS declaration uses a property that is
+ * below Baseline (status is false or "low") AND the property's support map
+ * does not cover at least one of the project's resolved target browsers
+ * (i.e. the target needs that feature but the feature is not Baseline).
+ *
+ * A property is "not supported" for the project when it is below Baseline and
+ * at least one resolved target browser is missing from the web-features
+ * support map. The finding reports which target browsers lack support so the
+ * user gets a concrete fallback hint.
+ *
+ * @param {string} css - Raw CSS source
+ * @param {string} [projectDir] - Project directory to read browserslist from
+ * @returns {{ findings: Array<{property, pattern, message, severity, unsupportedBrowsers: string[]}> }}
+ */
+export function lintPropertyNotSupported(css, projectDir) {
+  const findings = []
+  const rules = parseCssRules(css)
+  for (const rule of rules) {
+    for (const [prop] of rule.declarations) {
+      const status = getBaselineStatus(prop)
+      if (status === 'high' || status === 'low') continue
+      const unsupported = checkPropertySupportAgainstTargets(prop, projectDir)
+      if (unsupported.length === 0) continue
+      findings.push({
+        property: prop,
+        pattern: 'property-not-supported',
+        message:
+          'Property "' +
+          prop +
+          '" is below Baseline and is not supported in ' +
+          unsupported.length +
+          ' of the project target browsers (' +
+          unsupported.join(', ') +
+          '). Consider a fallback or a polyfill ' +
+          'before shipping to this audience.',
+        severity: 'warning',
+        unsupportedBrowsers: unsupported,
+      })
+    }
+  }
+  return { findings }
+}
+
+/**
+ * Rule: property-experimental.
+ *
+ * Informs (severity "info") when a CSS declaration uses a property whose
+ * Interop 2026 score is below the given threshold (default 90). These features
+ * are shipping or partially shipping but interop across engines is still low,
+ * so early adopters should expect rough edges and watch the baseline timeline.
+ *
+ * @param {string} css - Raw CSS source
+ * @param {{ interopThreshold?: number }} [opts] - Threshold (0-100); default 90
+ * @returns {{ findings: Array<{property, pattern, message, severity, interop: number|null}> }}
+ */
+export function lintPropertyExperimental(css, opts = {}) {
+  const threshold = opts.interopThreshold ?? 90
+  const findings = []
+  const rules = parseCssRules(css)
+  for (const rule of rules) {
+    for (const [prop] of rule.declarations) {
+      // Prefer the explicit Interop 2026 score when the data source has it.
+      // When that figure is missing, fall back to Baseline status: a property
+      // that is Baseline "low" (widely available in some engines but not yet
+      // "high") is treated as experimental for the same early-adopter warning.
+      let interop = getInteropScore(prop)
+      let basis = 'interop'
+      if (interop === null) {
+        const status = getBaselineStatus(prop)
+        if (status === 'low') {
+          interop = threshold - 1
+          basis = 'baseline-low'
+        } else {
+          continue
+        }
+      }
+      if (interop >= threshold) continue
+      findings.push({
+        property: prop,
+        pattern: 'property-experimental',
+        message:
+          'Property "' +
+          prop +
+          '" is experimental (Interop 2026 score ' +
+          interop +
+          '%, below threshold ' +
+          threshold +
+          '%). It is shipping ' +
+          'or partially shipping but engine interop is still low; expect ' +
+          'rough edges and watch the Baseline timeline before relying on it.',
+        severity: 'info',
+        interop,
+        basis,
+      })
+    }
+  }
+  return { findings }
+}

--- a/lib/css-compat-data.mjs
+++ b/lib/css-compat-data.mjs
@@ -6,7 +6,13 @@
 
 import { readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { createRequire } from 'node:module'
 import { features } from 'web-features'
+
+// browserslist is a CommonJS package; load it via createRequire so it works
+// from this ESM module.
+const require = createRequire(import.meta.url)
+const browserslist = require('browserslist')
 
 /**
  * Build a reverse index: CSS property name -> { featureId, feature, bcdKey }
@@ -184,8 +190,6 @@ export function getProjectBrowserslist(projectDir = process.cwd()) {
  */
 export function getResolvedBrowsers(projectDir = process.cwd()) {
   const { queries, source } = getProjectBrowserslist(projectDir)
-  // Lazy require so the package is only loaded when browsers are actually needed.
-  const browserslist = require('browserslist')
   return {
     browsers: browserslist(queries),
     queries,

--- a/lib/css-compat-data.mjs
+++ b/lib/css-compat-data.mjs
@@ -1,0 +1,116 @@
+// CSS compatibility data module for Mint.
+// Wraps the web-features npm package to provide Baseline status
+// lookups for CSS properties.
+//
+// Milestone 1 of BUILD #4: Integrate web-features as compatibility data source.
+
+import { features } from 'web-features'
+
+/**
+ * Build a reverse index: CSS property name -> { featureId, feature, bcdKey }
+ * Scans all web-features entries for compat_features that start with
+ * "css.properties." and maps the property name to its parent feature.
+ *
+ * The index is built once at module load time (lazy evaluation via
+ * closure). For large datasets this is a one-time O(n * m) scan where
+ * n = number of features and m = average compat_features per feature.
+ */
+function buildPropertyIndex() {
+  const index = new Map()
+  for (const [featureId, feature] of Object.entries(features)) {
+    if (!feature.compat_features || !Array.isArray(feature.compat_features))
+      continue
+    for (const bcdKey of feature.compat_features) {
+      if (!bcdKey.startsWith('css.properties.')) continue
+      const property = bcdKey.slice('css.properties.'.length)
+      // First match wins — most features have unique property mappings
+      if (!index.has(property)) {
+        index.set(property, { featureId, feature, bcdKey })
+      }
+    }
+  }
+  return index
+}
+
+/**
+ * Cached property index. Built once per process.
+ * @type {Map<string, {featureId: string, feature: object, bcdKey: string}>}
+ */
+let _propertyIndex = null
+
+function getPropertyIndex() {
+  if (!_propertyIndex) {
+    _propertyIndex = buildPropertyIndex()
+  }
+  return _propertyIndex
+}
+
+/**
+ * Look up the Baseline status for a CSS property.
+ *
+ * @param {string} property - CSS property name (e.g. "display", "grid-template-rows")
+ * @returns {"high"|"low"|false|null} Baseline status, or null if unknown
+ */
+export function getBaselineStatus(property) {
+  const entry = getPropertyIndex().get(property)
+  if (!entry) return null
+  return entry.feature.status?.baseline ?? null
+}
+
+/**
+ * Check if a CSS property has reached Baseline (low or high).
+ *
+ * @param {string} property - CSS property name
+ * @returns {boolean} True if the property is Baseline (low or high)
+ */
+export function isBaseline(property) {
+  const status = getBaselineStatus(property)
+  return status === 'high' || status === 'low'
+}
+
+/**
+ * Check if a CSS property is widely available (Baseline high).
+ *
+ * @param {string} property - CSS property name
+ * @returns {boolean} True if the property is Baseline high
+ */
+export function isWidelyAvailable(property) {
+  return getBaselineStatus(property) === 'high'
+}
+
+/**
+ * Get detailed support information for a CSS property.
+ *
+ * @param {string} property - CSS property name
+ * @returns {{featureId: string, name: string, baseline: string|null, support: object}|null}
+ */
+export function getSupportInfo(property) {
+  const entry = getPropertyIndex().get(property)
+  if (!entry) return null
+  return {
+    featureId: entry.featureId,
+    name: entry.feature.name,
+    baseline: entry.feature.status?.baseline ?? null,
+    baselineLowDate: entry.feature.status?.baseline_low_date ?? null,
+    baselineHighDate: entry.feature.status?.baseline_high_date ?? null,
+    support: entry.feature.status?.support ?? {},
+  }
+}
+
+/**
+ * List all known CSS properties in the index.
+ *
+ * @returns {string[]} Array of CSS property names
+ */
+export function getKnownProperties() {
+  return Array.from(getPropertyIndex().keys())
+}
+
+/**
+ * Get the total number of CSS properties tracked in the index.
+ *
+ * @returns {number}
+ */
+export function getPropertyCount() {
+  return getPropertyIndex().size
+}

--- a/lib/css-compat-data.mjs
+++ b/lib/css-compat-data.mjs
@@ -4,6 +4,8 @@
 //
 // Milestone 1 of BUILD #4: Integrate web-features as compatibility data source.
 
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
 import { features } from 'web-features'
 
 /**
@@ -113,4 +115,80 @@ export function getKnownProperties() {
  */
 export function getPropertyCount() {
   return getPropertyIndex().size
+}
+
+// ---------------------------------------------------------------------------
+// Milestone 2 of BUILD #4: read the project's browserslist target.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the project's target browsers from standard browserslist sources.
+ *
+ * Resolution order (first hit wins):
+ *   1. a `browserslist` key in package.json
+ *   2. a `.browserslistrc` file (or `browserslist` file) in the project root
+ *   3. the browserslist default (`> 0.5%, last 2 versions, Firefox ESR, not dead`)
+ *
+ * @param {string} [projectDir] - Project root. Defaults to the current working
+ *   directory.
+ * @returns {{ queries: string[], source: 'package.json'|'.browserslistrc'|'browserslist'|'default' }}
+ *   The raw query strings plus which source they came from.
+ */
+export function getProjectBrowserslist(projectDir = process.cwd()) {
+  // 1. package.json `browserslist` key
+  const pkgPath = join(projectDir, 'package.json')
+  if (existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+      if (pkg.browserslist) {
+        const raw = pkg.browserslist
+        const queries = Array.isArray(raw) ? raw : (raw.production ?? raw)
+        return {
+          queries: Array.isArray(queries) ? queries : [String(queries)],
+          source: 'package.json',
+        }
+      }
+    } catch {
+      // Corrupt package.json — fall through to the next source.
+    }
+  }
+
+  // 2. .browserslistrc / browserslist file
+  for (const name of ['.browserslistrc', 'browserslist']) {
+    const rcPath = join(projectDir, name)
+    if (existsSync(rcPath)) {
+      const text = readFileSync(rcPath, 'utf8')
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && !line.startsWith('#'))
+      if (text.length > 0) {
+        return { queries: text, source: name }
+      }
+    }
+  }
+
+  // 3. browserslist default
+  return {
+    queries: ['> 0.5%', 'last 2 versions', 'Firefox ESR', 'not dead'],
+    source: 'default',
+  }
+}
+
+/**
+ * Resolve the project's browserslist target into concrete browser identifiers
+ * (e.g. "chrome 120", "safari 17") using the browserslist engine.
+ *
+ * @param {string} [projectDir] - Project root. Defaults to the current working
+ *   directory.
+ * @returns {{ browsers: string[], queries: string[], source: string }}
+ */
+export function getResolvedBrowsers(projectDir = process.cwd()) {
+  const { queries, source } = getProjectBrowserslist(projectDir)
+  // Lazy require so the package is only loaded when browsers are actually needed.
+  const browserslist = require('browserslist')
+  return {
+    browsers: browserslist(queries),
+    queries,
+    source,
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "web-features": "^3.31.0"
+        "browserslist": "^4.28.5",
+        "web-features": "^3.32.0"
       },
       "bin": {
         "mint-ds": "bin/mint-ds.mjs"
@@ -4159,10 +4160,10 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
-      "dev": true,
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
@@ -4212,10 +4213,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4230,11 +4230,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -4362,10 +4363,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
-      "dev": true,
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5203,10 +5203,10 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.352",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
-      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
-      "dev": true
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5477,7 +5477,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8445,10 +8444,13 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-      "dev": true
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "7.0.1",
@@ -8983,7 +8985,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -10720,7 +10721,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10990,9 +10990,9 @@
       }
     },
     "node_modules/web-features": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.31.0.tgz",
-      "integrity": "sha512-1idHNJCaQzzfLRofi/b2Vzm6OVyV1wFM5djpopXu+WbGbM7EsZWwPGT2ORHsD4ZbQf2QbP9vyagJYrfIAoN90w==",
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.32.0.tgz",
+      "integrity": "sha512-PQBbTofqV8FtMP65oT9tLPjbN4FSB2dRdNxLM0A9j4bNifVpFhEP/ATXSMMJAqPPWb/pgUOh6B+98yzfNEVbNw==",
       "license": "Apache-2.0"
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "mint-ds",
       "version": "0.2.1",
       "license": "MIT",
+      "dependencies": {
+        "web-features": "^3.31.0"
+      },
       "bin": {
         "mint-ds": "bin/mint-ds.mjs"
       },
@@ -10985,6 +10988,12 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/web-features": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.31.0.tgz",
+      "integrity": "sha512-1idHNJCaQzzfLRofi/b2Vzm6OVyV1wFM5djpopXu+WbGbM7EsZWwPGT2ORHsD4ZbQf2QbP9vyagJYrfIAoN90w==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "mint-ds",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "web-features": "^3.31.0"
+      },
       "bin": {
         "mint-ds": "bin/mint-ds.mjs"
       },
@@ -10985,6 +10988,12 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/web-features": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.31.0.tgz",
+      "integrity": "sha512-1idHNJCaQzzfLRofi/b2Vzm6OVyV1wFM5djpopXu+WbGbM7EsZWwPGT2ORHsD4ZbQf2QbP9vyagJYrfIAoN90w==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -84,5 +84,8 @@
       "prettier --check"
     ],
     "*.{json,css,md}": "prettier --check"
+  },
+  "dependencies": {
+    "web-features": "^3.31.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "*.{json,css,md}": "prettier --check"
   },
   "dependencies": {
-    "web-features": "^3.31.0"
+    "browserslist": "^4.28.5",
+    "web-features": "^3.32.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
       "prettier --check"
     ],
     "*.{json,css,md}": "prettier --check"
+  },
+  "dependencies": {
+    "web-features": "^3.31.0"
   }
 }


### PR DESCRIPTION
Card: https://github.com/nujovich/mint-radar/issues/4

Decision: Option B (Medium scope — detection with concrete fallback suggestions)

## Milestones

- [x] Milestone 1 — Integrate web-features npm package as compatibility data source
- [x] Milestone 2 — Read browserslist from project (package.json or .browserslistrc)
- [x] Milestone 3 — Rules: property-not-supported (warning if < Baseline), property-experimental (info if < 90% interop)
- [x] Milestone 4 — Output: CLI warnings with feature suggestions and interop percentages

## Milestone 2 detail

Added project browserslist discovery to `lib/css-compat-data.mjs`:

- `getProjectBrowserslist(projectDir)` resolves the target browsers in priority order: a `browserslist` key in `package.json` (supports both a flat array and the `{ production, development }` env-block form, using the production query), then a `.browserslistrc` / `browserslist` file (comment lines starting with `#` are skipped), and finally the browserslist default (`> 0.5%, last 2 versions, Firefox ESR, not dead`). It returns `{ queries, source }` so callers know which source won.
- `getResolvedBrowsers(projectDir)` runs the queries through the `browserslist` engine and returns the concrete browser identifiers (e.g. `chrome 120`, `safari 17`) plus the original `queries` and `source`.
- `browserslist` added to `package.json` dependencies (and `package-lock.json`); `web-features` was also installed into `node_modules` (it was imported by M1 but not yet present on a clean checkout).

## Milestone 3 detail

Added two static adoption rules to `lib/css-compat-data.mjs` (alongside the
M1/M2 Baseline + browserslist helpers):

- `lintPropertyNotSupported(css, projectDir)`: warns (severity `warning`) when a
  declaration uses a below-Baseline property that the project's resolved
  browserslist target still lacks support for. It lists the unsupported target
  browsers (e.g. `safari 26.3`, `chrome 118`) so the author gets a concrete
  fallback hint. Baseline-high/low props supported by every target are skipped.
- `lintPropertyExperimental(css, opts)`: informs (severity `info`) when a
  declaration uses a property below the Interop 2026 threshold (default 90%).
  When the bundled web-features data has no `interop` figure, the rule falls
  back to Baseline-low as the experimental signal, so shipping-but-not-yet-high
  properties (e.g. `backdrop-filter`, `view-transition-name`) are still flagged.
- Supporting helpers: `getInteropScore(property)` and
  `checkPropertySupportAgainstTargets(property, projectDir)`.

### Milestone 3 tests

- `lib/__tests__/css-compat-data.test.mjs`:
  - `lintPropertyNotSupported` warns on a below-Baseline prop missing from the
    targets and does NOT flag a prop that every target supports; never flags
    Baseline-high props.
  - `lintPropertyExperimental` flags Baseline-low props (info) and ignores
    Baseline-high props; the high custom-threshold still flags Baseline-low.

## Tests

- `lib/__tests__/css-compat-data.test.mjs`: reads browserslist from package.json, reads the `production` env block, prefers `.browserslistrc` over the package.json default, falls back to the browserslist default, and resolves queries into concrete browser identifiers.

## How to test

```bash
npx vitest run lib/__tests__/css-compat-data.test.mjs
npx prettier --check lib/css-compat-data.mjs lib/__tests__/css-compat-data.test.mjs
```

(319 lib tests passing at time of commit.)

## Milestone 4 detail

Added the `mint-ds compat <dir>` CLI command that runs the M3 adoption rules
over a CSS/SCSS project and prints actionable warnings:

- `lib/css-compat-data.mjs` gains `getFeatureSuggestion()` (maps a property to
  its human-readable web-features name + Baseline status), `formatCompatFindings()`
  (enriches each finding with a named feature and a concrete `@supports`/polyfill
  suggestion + Interop 2026 percentage), and `checkCompat()` (runs both rules and
  returns the formatted findings — the M4 entry point).
- `bin/mint-ds.mjs` gains the `compat` subcommand: it scans the directory, runs
  `checkCompat()`, and renders each finding with severity tag (WARNING/INFO),
  the property, the web-features feature name, the Interop 2026 percentage for
  experimental findings, and a concrete next-step suggestion, plus a per-run
  warning/info summary.

### Milestone 4 tests

- `lib/__tests__/css-compat-data.test.mjs`: `getFeatureSuggestion` returns the
  human feature name for a known property and nulls for an unknown one;
  `formatCompatFindings` attaches a feature name + suggestion to every finding
  and includes the Interop percentage in experimental suggestions; `checkCompat`
  runs both rules (anchor-name = not-supported, backdrop-filter = experimental),
  never reports Baseline-high props, and returns no findings for fully-supported
  CSS.

## How to test

```bash
npx vitest run lib/__tests__/css-compat-data.test.mjs
npx prettier --check bin/mint-ds.mjs lib/css-compat-data.mjs
node bin/mint-ds.mjs compat <dir>   # prints compat warnings + feature suggestions
```
