### PR TITLE
feat: per-provider environment variables

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,3 +9,9 @@ API_KEY=sk-ant-...           # Universal fallback for all providers
 # ANTHROPIC_MODEL_NAME=       # Overrides LLM_MODEL_NAME for Anthropic
 # OPENROUTER_MODEL_NAME=      # Overrides LLM_MODEL_NAME for OpenRouter
 # OLLAMA_MODEL_NAME=          # Overrides LLM_MODEL_NAME for Ollama
+
+# API URLs
+# LLM_API_URL=                 # Universal fallback for all providers
+# ANTHROPIC_API_URL=           # Overrides LLM_API_URL for Anthropic
+# OPENROUTER_API_URL=          # Overrides LLM_API_URL for OpenRouter
+# OLLAMA_API_URL=              # Overrides LLM_API_URL for Ollama

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,1 +1,5 @@
-API_KEY=sk-ant-...
+# API Keys
+API_KEY=sk-ant-...           # Universal fallback for all providers
+# ANTHROPIC_API_KEY=         # Overrides API_KEY for Anthropic
+# OPENROUTER_API_KEY=        # Overrides API_KEY for OpenRouter
+# OLLAMA_API_KEY=            # Overrides API_KEY for Ollama (optional)

--- a/.env.local.example
+++ b/.env.local.example
@@ -3,3 +3,9 @@ API_KEY=sk-ant-...           # Universal fallback for all providers
 # ANTHROPIC_API_KEY=         # Overrides API_KEY for Anthropic
 # OPENROUTER_API_KEY=        # Overrides API_KEY for OpenRouter
 # OLLAMA_API_KEY=            # Overrides API_KEY for Ollama (optional)
+
+# Model names
+# LLM_MODEL_NAME=             # Universal fallback for all providers
+# ANTHROPIC_MODEL_NAME=       # Overrides LLM_MODEL_NAME for Anthropic
+# OPENROUTER_MODEL_NAME=      # Overrides LLM_MODEL_NAME for OpenRouter
+# OLLAMA_MODEL_NAME=          # Overrides LLM_MODEL_NAME for Ollama

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ npx mint-ds export --target css          # → variables.css
 
 ### Authentication
 
-Every command needs an LLM provider API key. You have two options — pick whichever fits your workflow:
+Every command needs an LLM provider API key. You have three options — pick whichever fits your workflow:
 
 **Option 1 — pass it per-command with `--api-key`:**
 
@@ -252,7 +252,15 @@ npx mint-ds audit ./src/styles --api-key sk-ant-...
 
 Useful for one-off runs, CI jobs, or when you don't want the key persisted in your shell.
 
-**Option 2 — set the `API_KEY` env var.** Syntax depends on your shell:
+**Option 2 — set a per-provider env var** (recommended when you use multiple providers):
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENROUTER_API_KEY=sk-or-...
+export OLLAMA_API_KEY=sk-ollama-...    # optional — Ollama doesn't require a key
+```
+
+**Option 3 — set the generic `API_KEY` env var** (works with any provider):
 
 | Shell                               | Command                       |
 | ----------------------------------- | ----------------------------- |
@@ -263,7 +271,7 @@ Useful for one-off runs, CI jobs, or when you don't want the key persisted in yo
 
 These commands set the key only for the current shell session. To persist it, add the line to your shell rc file (`~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, your PowerShell `$PROFILE`, etc.) or use the system Environment Variables dialog on Windows.
 
-`--api-key` always wins over the env var when both are present.
+`--api-key` always wins over env vars. Per-provider env vars (`ANTHROPIC_API_KEY`, etc.) win over the generic `API_KEY`.
 
 Where to get a key:
 
@@ -274,11 +282,13 @@ Where to get a key:
 
 Mint talks to an LLM for audit, resolve, and export. By default it uses Anthropic Claude; you can swap to a local backend with `--provider`.
 
-| Value                 | Description                                                                                                                                         |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `anthropic` (default) | Anthropic Claude API. Uses `API_KEY` / `--api-key`. Default model `claude-sonnet-4-20250514`.                                                       |
-| `ollama`              | Local Ollama server. No API key required. Defaults to `http://localhost:11434/api/chat`, model `gemma4`.                                            |
-| `openrouter`          | OpenRouter API. Uses `API_KEY` / `--api-key`. Default model `deepseek/deepseek-v4-flash`, endpoint `https://openrouter.ai/api/v1/chat/completions`. |
+| Value                 | Description                                                                                                           |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `anthropic` (default) | Anthropic Claude API. Default model `claude-sonnet-4-20250514`.                                                       |
+| `ollama`              | Local Ollama server. No API key required. Defaults to `http://localhost:11434/api/chat`, model `gemma4`.              |
+| `openrouter`          | OpenRouter API. Default model `deepseek/deepseek-v4-flash`, endpoint `https://openrouter.ai/api/v1/chat/completions`. |
+
+Override model or URL with `--model`/`--url` or the corresponding env vars. See [Environment variables](#environment-variables) for the full precedence chain.
 
 ```bash
 # Run the audit against a local Ollama instance
@@ -306,6 +316,9 @@ npx mint-ds export --target tailwind --provider ollama
 | `--out <file>`      | Tokens output path (default: `mint-ds.tokens.json`)                       |
 | `--report <file>`   | Also write the raw `AuditReport` JSON for inspection                      |
 | `--provider <name>` | LLM backend: `anthropic` (default), `ollama`, or `openrouter`             |
+| `--api-key <value>` | LLM provider API key (overrides all API key env vars)                     |
+| `--model <name>`    | Model name (overrides all model env vars)                                 |
+| `--url <url>`       | API endpoint URL (overrides all URL env vars)                             |
 | `--quiet`           | Skip the chaos summary printout                                           |
 | `--no-cache`        | Skip the cache lookup and overwrite any existing cache entry for this CSS |
 
@@ -332,6 +345,9 @@ Add `mint-ds.cache.json` to `.gitignore` if you don't want to commit it.
 | `--tokens <file>`   | Tokens input path (default: `mint-ds.tokens.json`)                                                                                                                                             |
 | `--out <file>`      | Override the default output filename                                                                                                                                                           |
 | `--provider <name>` | LLM backend: `anthropic` (default), `ollama`, or `openrouter`                                                                                                                                  |
+| `--api-key <value>` | LLM provider API key (overrides all API key env vars)                                                                                                                                          |
+| `--model <name>`    | Model name (overrides all model env vars)                                                                                                                                                      |
+| `--url <url>`       | API endpoint URL (overrides all URL env vars)                                                                                                                                                  |
 | `--stdout`          | Print to stdout instead of writing a file                                                                                                                                                      |
 
 ### Local development without publishing
@@ -385,10 +401,40 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## Environment variables
 
-| Variable            | Required | Description                                                         |
-| ------------------- | -------- | ------------------------------------------------------------------- |
-| `API_KEY`           | No       | LLM provider API key — works with Anthropic, OpenRouter, and others |
-| `ANTHROPIC_API_KEY` | Yes      | Anthropic API key (Deprecated — use `API_KEY` instead)              |
+Mint resolves configuration through a precedence chain: **CLI flag > per-provider env var > generic env var > provider default**.
+
+### API keys
+
+| Variable             | Description                                   |
+| -------------------- | --------------------------------------------- |
+| `ANTHROPIC_API_KEY`  | Anthropic API key                             |
+| `OPENROUTER_API_KEY` | OpenRouter API key                            |
+| `OLLAMA_API_KEY`     | Ollama API key (optional — Ollama needs none) |
+| `API_KEY`            | Universal fallback for all providers          |
+
+Precedence: `--api-key` > `{PROVIDER}_API_KEY` > `API_KEY` > provider default (none for Anthropic/OpenRouter, undefined for Ollama).
+
+### Model name
+
+| Variable                | Description                          |
+| ----------------------- | ------------------------------------ |
+| `ANTHROPIC_MODEL_NAME`  | Model name for Anthropic             |
+| `OPENROUTER_MODEL_NAME` | Model name for OpenRouter            |
+| `OLLAMA_MODEL_NAME`     | Model name for Ollama                |
+| `LLM_MODEL_NAME`        | Universal fallback for all providers |
+
+Precedence: `--model` > `{PROVIDER}_MODEL_NAME` > `LLM_MODEL_NAME` > provider default.
+
+### API URL
+
+| Variable             | Description                          |
+| -------------------- | ------------------------------------ |
+| `ANTHROPIC_API_URL`  | API endpoint for Anthropic           |
+| `OPENROUTER_API_URL` | API endpoint for OpenRouter          |
+| `OLLAMA_API_URL`     | API endpoint for Ollama              |
+| `LLM_API_URL`        | Universal fallback for all providers |
+
+Precedence: `--url` > `{PROVIDER}_API_URL` > `LLM_API_URL` > provider default.
 
 ## Project structure
 

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -108,6 +108,7 @@ ${styles.bold('PROVIDER')}
                                  ollama     — Local Ollama (no key required)
                                  openrouter — OpenRouter API
   --model <name>               Model name (overrides LLM_MODEL_NAME env var)
+  --url <url>                  API endpoint URL (overrides LLM_API_URL env var)
 
 ${styles.bold('ENVIRONMENT')}
   API_KEY            LLM provider API key (Anthropic, OpenRouter, etc.)

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -107,6 +107,7 @@ ${styles.bold('PROVIDER')}
                                  anthropic  — Claude API (default)
                                  ollama     — Local Ollama (no key required)
                                  openrouter — OpenRouter API
+  --model <name>               Model name (overrides LLM_MODEL_NAME env var)
 
 ${styles.bold('ENVIRONMENT')}
   API_KEY            LLM provider API key (Anthropic, OpenRouter, etc.)

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -111,9 +111,18 @@ ${styles.bold('PROVIDER')}
   --url <url>                  API endpoint URL (overrides LLM_API_URL env var)
 
 ${styles.bold('ENVIRONMENT')}
-  API_KEY            LLM provider API key (Anthropic, OpenRouter, etc.)
+  API_KEY            LLM provider API key (universal fallback)
                        Anthropic:  https://console.anthropic.com
                        OpenRouter: https://openrouter.ai/keys
+  LLM_MODEL_NAME     Model name (universal fallback)
+  LLM_API_URL        API endpoint URL (universal fallback)
+
+  Per-provider overrides (take priority over the generic vars):
+    API key          ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OLLAMA_API_KEY
+    Model            ANTHROPIC_MODEL_NAME, OPENROUTER_MODEL_NAME, OLLAMA_MODEL_NAME
+    URL              ANTHROPIC_API_URL, OPENROUTER_API_URL, OLLAMA_API_URL
+
+  Precedence: --flag > {PROVIDER}_ENV > generic env > provider default
 
 ${styles.bold('EXAMPLES')}
   npx mint-ds audit ./src/styles

--- a/lib/__tests__/clients.test.mjs
+++ b/lib/__tests__/clients.test.mjs
@@ -582,6 +582,73 @@ describe('buildConfigFromFlags', () => {
     expect(config.apiKey).toBe('injected-key')
   })
 
+  it.each([
+    {
+      provider: 'anthropic',
+      envVar: 'ANTHROPIC_API_KEY',
+      provKey: 'anthro-key',
+    },
+    { provider: 'ollama', envVar: 'OLLAMA_API_KEY', provKey: 'ollama-key' },
+    { provider: 'openrouter', envVar: 'OPENROUTER_API_KEY', provKey: 'or-key' },
+  ])(
+    'prefers --api-key flag over $envVar and generic API_KEY when using --provider $provider',
+    ({ provider, envVar, provKey }) => {
+      const config = buildConfigFromFlags(
+        { provider, 'api-key': 'flag-key' },
+        { [envVar]: provKey, API_KEY: 'gen-key' }
+      )
+      expect(config.apiKey).toBe('flag-key')
+      expect(config.name).toBe(provider)
+    }
+  )
+
+  it.each([
+    { provider: 'anthropic', envVar: 'ANTHROPIC_API_KEY', key: 'sk-ant-123' },
+    { provider: 'ollama', envVar: 'OLLAMA_API_KEY', key: 'sk-ollama-123' },
+    { provider: 'openrouter', envVar: 'OPENROUTER_API_KEY', key: 'sk-or-123' },
+  ])(
+    'prefers $envVar over generic API_KEY when using --provider $provider',
+    ({ provider, envVar, key }) => {
+      const config = buildConfigFromFlags(
+        { provider },
+        { API_KEY: 'generic-fallback', [envVar]: key }
+      )
+      expect(config.apiKey).toBe(key)
+      expect(config.name).toBe(provider)
+    }
+  )
+
+  it.each([
+    { provider: 'anthropic' },
+    { provider: 'ollama' },
+    { provider: 'openrouter' },
+  ])(
+    'falls back to API_KEY when provider-specific env var is not set (--provider $provider)',
+    ({ provider }) => {
+      const config = buildConfigFromFlags(
+        { provider },
+        { API_KEY: 'fallback-key' }
+      )
+      expect(config.apiKey).toBe('fallback-key')
+      expect(config.name).toBe(provider)
+    }
+  )
+
+  it('ollama works without any API key set', () => {
+    const config = buildConfigFromFlags({ provider: 'ollama' }, {})
+    expect(config.name).toBe('ollama')
+    expect(config.apiKey).toBeUndefined()
+  })
+
+  it('uses ANTHROPIC_API_KEY as per-provider key when provider defaults to anthropic', () => {
+    const config = buildConfigFromFlags(
+      {},
+      { ANTHROPIC_API_KEY: 'backcompat-key' }
+    )
+    expect(config.name).toBe('anthropic')
+    expect(config.apiKey).toBe('backcompat-key')
+  })
+
   it('falls back to defaults when injected env is empty', () => {
     const config = buildConfigFromFlags({}, {})
     expect(config.name).toBe('anthropic')

--- a/lib/__tests__/clients.test.mjs
+++ b/lib/__tests__/clients.test.mjs
@@ -649,6 +649,91 @@ describe('buildConfigFromFlags', () => {
     expect(config.apiKey).toBe('backcompat-key')
   })
 
+  it.each([
+    {
+      provider: 'anthropic',
+      envVar: 'ANTHROPIC_MODEL_NAME',
+      provModel: 'claude-prov-env',
+      genericModel: 'generic-env-model',
+      flagModel: 'claude-flag',
+    },
+    {
+      provider: 'ollama',
+      envVar: 'OLLAMA_MODEL_NAME',
+      provModel: 'ollama-prov-env',
+      genericModel: 'generic-env-model',
+      flagModel: 'ollama-flag',
+    },
+    {
+      provider: 'openrouter',
+      envVar: 'OPENROUTER_MODEL_NAME',
+      provModel: 'or-prov-env',
+      genericModel: 'generic-env-model',
+      flagModel: 'or-flag',
+    },
+  ])(
+    'prefers --model flag over $envVar and generic LLM_MODEL_NAME when using --provider $provider',
+    ({ provider, envVar, provModel, genericModel, flagModel }) => {
+      const config = buildConfigFromFlags(
+        { provider, model: flagModel },
+        { [envVar]: provModel, LLM_MODEL_NAME: genericModel }
+      )
+      expect(config.model).toBe(flagModel)
+      expect(config.name).toBe(provider)
+    }
+  )
+
+  it.each([
+    {
+      provider: 'anthropic',
+      envVar: 'ANTHROPIC_MODEL_NAME',
+      model: 'claude-opus-5',
+    },
+    { provider: 'ollama', envVar: 'OLLAMA_MODEL_NAME', model: 'llama4-custom' },
+    {
+      provider: 'openrouter',
+      envVar: 'OPENROUTER_MODEL_NAME',
+      model: 'google/gemini-pro',
+    },
+  ])(
+    'prefers $envVar over generic LLM_MODEL_NAME when using --provider $provider',
+    ({ provider, envVar, model }) => {
+      const config = buildConfigFromFlags(
+        { provider },
+        { LLM_MODEL_NAME: 'generic-model', [envVar]: model }
+      )
+      expect(config.model).toBe(model)
+      expect(config.name).toBe(provider)
+    }
+  )
+
+  it.each([
+    { provider: 'anthropic', defaultModel: 'claude-sonnet-4-20250514' },
+    { provider: 'ollama', defaultModel: 'gemma4' },
+    { provider: 'openrouter', defaultModel: 'deepseek/deepseek-v4-flash' },
+  ])(
+    'falls back to LLM_MODEL_NAME when provider-specific env var is not set (--provider $provider)',
+    ({ provider, defaultModel }) => {
+      const config = buildConfigFromFlags(
+        { provider },
+        { LLM_MODEL_NAME: 'fallback-model' }
+      )
+      expect(config.model).toBe('fallback-model')
+      expect(config.name).toBe(provider)
+    }
+  )
+
+  it('uses provider default model when no env vars or flags set', () => {
+    const anthropic = buildConfigFromFlags({ provider: 'anthropic' }, {})
+    expect(anthropic.model).toBe('claude-sonnet-4-20250514')
+
+    const ollama = buildConfigFromFlags({ provider: 'ollama' }, {})
+    expect(ollama.model).toBe('gemma4')
+
+    const openrouter = buildConfigFromFlags({ provider: 'openrouter' }, {})
+    expect(openrouter.model).toBe('deepseek/deepseek-v4-flash')
+  })
+
   it('falls back to defaults when injected env is empty', () => {
     const config = buildConfigFromFlags({}, {})
     expect(config.name).toBe('anthropic')

--- a/lib/__tests__/clients.test.mjs
+++ b/lib/__tests__/clients.test.mjs
@@ -734,6 +734,101 @@ describe('buildConfigFromFlags', () => {
     expect(openrouter.model).toBe('deepseek/deepseek-v4-flash')
   })
 
+  it.each([
+    {
+      provider: 'anthropic',
+      envVar: 'ANTHROPIC_API_URL',
+      provURL: 'https://prov-anthropic.example.com',
+      genericURL: 'https://generic.example.com',
+      flagURL: 'https://flag.example.com',
+    },
+    {
+      provider: 'ollama',
+      envVar: 'OLLAMA_API_URL',
+      provURL: 'https://prov-ollama.example.com',
+      genericURL: 'https://generic.example.com',
+      flagURL: 'https://flag.example.com',
+    },
+    {
+      provider: 'openrouter',
+      envVar: 'OPENROUTER_API_URL',
+      provURL: 'https://prov-openrouter.example.com',
+      genericURL: 'https://generic.example.com',
+      flagURL: 'https://flag.example.com',
+    },
+  ])(
+    'prefers --url flag over $envVar and generic LLM_API_URL when using --provider $provider',
+    ({ provider, envVar, provURL, genericURL, flagURL }) => {
+      const config = buildConfigFromFlags(
+        { provider, url: flagURL },
+        { [envVar]: provURL, LLM_API_URL: genericURL }
+      )
+      expect(config.url).toBe(flagURL)
+      expect(config.name).toBe(provider)
+    }
+  )
+
+  it.each([
+    {
+      provider: 'anthropic',
+      envVar: 'ANTHROPIC_API_URL',
+      url: 'https://custom-anthropic.example.com',
+    },
+    {
+      provider: 'ollama',
+      envVar: 'OLLAMA_API_URL',
+      url: 'https://custom-ollama.example.com',
+    },
+    {
+      provider: 'openrouter',
+      envVar: 'OPENROUTER_API_URL',
+      url: 'https://custom-openrouter.example.com',
+    },
+  ])(
+    'prefers $envVar over generic LLM_API_URL when using --provider $provider',
+    ({ provider, envVar, url }) => {
+      const config = buildConfigFromFlags(
+        { provider },
+        { LLM_API_URL: 'https://generic.example.com', [envVar]: url }
+      )
+      expect(config.url).toBe(url)
+      expect(config.name).toBe(provider)
+    }
+  )
+
+  it.each([
+    {
+      provider: 'anthropic',
+      defaultURL: 'https://api.anthropic.com/v1/messages',
+    },
+    { provider: 'ollama', defaultURL: 'http://localhost:11434/api/chat' },
+    {
+      provider: 'openrouter',
+      defaultURL: 'https://openrouter.ai/api/v1/chat/completions',
+    },
+  ])(
+    'falls back to LLM_API_URL when provider-specific env var is not set (--provider $provider)',
+    ({ provider, defaultURL }) => {
+      const config = buildConfigFromFlags(
+        { provider },
+        { LLM_API_URL: 'https://fallback.example.com' }
+      )
+      expect(config.url).toBe('https://fallback.example.com')
+      expect(config.name).toBe(provider)
+    }
+  )
+
+  it('uses provider default URL when no env vars or flags set', () => {
+    const anthropic = buildConfigFromFlags({ provider: 'anthropic' }, {})
+    expect(anthropic.url).toBe('https://api.anthropic.com/v1/messages')
+
+    const ollama = buildConfigFromFlags({ provider: 'ollama' }, {})
+    expect(ollama.url).toBe('http://localhost:11434/api/chat')
+
+    const openrouter = buildConfigFromFlags({ provider: 'openrouter' }, {})
+    expect(openrouter.url).toBe('https://openrouter.ai/api/v1/chat/completions')
+  })
+
   it('falls back to defaults when injected env is empty', () => {
     const config = buildConfigFromFlags({}, {})
     expect(config.name).toBe('anthropic')

--- a/lib/__tests__/clients.test.mjs
+++ b/lib/__tests__/clients.test.mjs
@@ -574,13 +574,24 @@ describe('buildConfigFromFlags', () => {
     expect(config.apiKey).toBe('injected-key')
   })
 
-  it('reads apiKey from injected env with deprecated ANTHROPIC_API_KEY env var', () => {
+  it('reads apiKey from ANTHROPIC_API_KEY when provider defaults to anthropic', () => {
     const config = buildConfigFromFlags(
       {},
       { ANTHROPIC_API_KEY: 'injected-key' }
     )
     expect(config.apiKey).toBe('injected-key')
   })
+
+  it.each([{ provider: 'openrouter' }, { provider: 'ollama' }])(
+    'does NOT use ANTHROPIC_API_KEY as fallback for --provider $provider',
+    ({ provider }) => {
+      const config = buildConfigFromFlags(
+        { provider },
+        { ANTHROPIC_API_KEY: 'anthro-key' }
+      )
+      expect(config.apiKey).toBeUndefined()
+    }
+  )
 
   it.each([
     {

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -2,56 +2,85 @@ import { getProvider } from './llm_providers/registry.mjs'
 
 function readEnv(env = process.env) {
   return {
-    llmProvider: {
-      name: env.LLM_PROVIDER_NAME ?? 'anthropic',
-      // TODO: read from env.LLM_API_URL
-      url: undefined,
-      // TODO: read from env.LLM_MODEL_NAME
-      model: undefined,
-      apiKey: env.API_KEY || env.ANTHROPIC_API_KEY,
-    },
-    cssAuditor: {
-      maxTokens: {
-        // TODO: read from env.CSS_MAX_TOKENS_AUDIT
-        audit: undefined,
-        // TODO: read from env.CSS_MAX_TOKENS_PARSE
-        parse: undefined,
-        // TODO: read from env.CSS_MAX_TOKENS_EXPORT
-        export: undefined,
+    parsed: {
+      llmProvider: {
+        name: env.LLM_PROVIDER_NAME ?? 'anthropic',
+      },
+      cssAuditor: {
+        maxTokens: {
+          // TODO: read from env.CSS_MAX_TOKENS_AUDIT
+          audit: undefined,
+          // TODO: read from env.CSS_MAX_TOKENS_PARSE
+          parse: undefined,
+          // TODO: read from env.CSS_MAX_TOKENS_EXPORT
+          export: undefined,
+        },
       },
     },
+    raw: env,
   }
 }
 
-function buildDefaults(providerName, env) {
+function buildEnvVarName(providerName, suffix) {
+  return `${providerName.toUpperCase()}_${suffix}`
+}
+
+function resolveProviderProperty({
+  rawEnv,
+  providerName,
+  suffix,
+  fallbackEnvVar,
+}) {
+  const perProviderKey = buildEnvVarName(providerName, suffix)
+  if (rawEnv[perProviderKey]) return rawEnv[perProviderKey]
+  if (rawEnv[fallbackEnvVar]) return rawEnv[fallbackEnvVar]
+  return undefined
+}
+
+function buildDefaults(providerName, parsed, rawEnv) {
   const provider = getProvider(providerName)
-  const { maxTokens, ...rest } = provider.defaults
+
+  const { maxTokens: providerDefaultMaxTokens, ...providerDefaults } =
+    provider.defaults
+
+  const resolvedAPIKey = resolveProviderProperty({
+    rawEnv,
+    providerName,
+    suffix: 'API_KEY',
+    fallbackEnvVar: 'API_KEY',
+  })
+
   return {
-    ...rest,
-    url: env.llmProvider.url || rest.url,
-    model: env.llmProvider.model || rest.model,
-    apiKey: env.llmProvider.apiKey ?? undefined,
+    ...providerDefaults,
+    apiKey: resolvedAPIKey,
     cssAuditor: {
       maxTokens: {
-        audit: env.cssAuditor.maxTokens.audit || maxTokens.audit,
-        parse: env.cssAuditor.maxTokens.parse || maxTokens.parse,
-        export: env.cssAuditor.maxTokens.export || maxTokens.export,
+        audit:
+          parsed.cssAuditor.maxTokens.audit || providerDefaultMaxTokens.audit,
+        parse:
+          parsed.cssAuditor.maxTokens.parse || providerDefaultMaxTokens.parse,
+        export:
+          parsed.cssAuditor.maxTokens.export || providerDefaultMaxTokens.export,
       },
     },
   }
 }
 
-function buildConfig(env, flags = {}) {
+function buildConfig(parsedEnv, flags = {}, rawEnv) {
   const provider =
     typeof flags?.['provider'] === 'string'
       ? flags['provider']
-      : env.llmProvider.name
-  const base = buildDefaults(provider, env)
+      : parsedEnv.llmProvider.name
+
+  const base = buildDefaults(provider, parsedEnv, rawEnv)
+
   const apiKey =
     typeof flags?.['api-key'] === 'string' ? flags['api-key'] : base.apiKey
+
   return { ...base, apiKey, name: provider }
 }
 
-export function buildConfigFromFlags(flags, env = process.env) {
-  return buildConfig(readEnv(env), flags)
+export function buildConfigFromFlags(flags = {}, rawEnv = process.env) {
+  const { parsed, raw } = readEnv(rawEnv)
+  return buildConfig(parsed, flags, raw)
 }

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -57,10 +57,18 @@ function buildDefaults(providerName, parsed, rawEnv) {
     fallbackEnvVar: 'LLM_MODEL_NAME',
   })
 
+  const resolvedURL = resolveProviderProperty({
+    rawEnv,
+    providerName,
+    suffix: 'API_URL',
+    fallbackEnvVar: 'LLM_API_URL',
+  })
+
   return {
     ...providerDefaults,
     apiKey: resolvedAPIKey,
     model: resolvedModel ?? providerDefaults.model,
+    url: resolvedURL ?? providerDefaults.url,
     cssAuditor: {
       maxTokens: {
         audit:
@@ -88,7 +96,9 @@ function buildConfig(parsedEnv, flags = {}, rawEnv) {
   const model =
     typeof flags?.['model'] === 'string' ? flags['model'] : base.model
 
-  return { ...base, apiKey, model, name: provider }
+  const url = typeof flags?.['url'] === 'string' ? flags['url'] : base.url
+
+  return { ...base, apiKey, model, url, name: provider }
 }
 
 export function buildConfigFromFlags(flags = {}, rawEnv = process.env) {

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -50,9 +50,17 @@ function buildDefaults(providerName, parsed, rawEnv) {
     fallbackEnvVar: 'API_KEY',
   })
 
+  const resolvedModel = resolveProviderProperty({
+    rawEnv,
+    providerName,
+    suffix: 'MODEL_NAME',
+    fallbackEnvVar: 'LLM_MODEL_NAME',
+  })
+
   return {
     ...providerDefaults,
     apiKey: resolvedAPIKey,
+    model: resolvedModel ?? providerDefaults.model,
     cssAuditor: {
       maxTokens: {
         audit:
@@ -77,7 +85,10 @@ function buildConfig(parsedEnv, flags = {}, rawEnv) {
   const apiKey =
     typeof flags?.['api-key'] === 'string' ? flags['api-key'] : base.apiKey
 
-  return { ...base, apiKey, name: provider }
+  const model =
+    typeof flags?.['model'] === 'string' ? flags['model'] : base.model
+
+  return { ...base, apiKey, model, name: provider }
 }
 
 export function buildConfigFromFlags(flags = {}, rawEnv = process.env) {


### PR DESCRIPTION
## Summary

- Add per-provider environment variable resolution for API keys (`{PROVIDER}_API_KEY`), model names (`{PROVIDER}_MODEL_NAME`), and API URLs (`{PROVIDER}_API_URL`), with generic fallback (`API_KEY`, `LLM_MODEL_NAME`, `LLM_API_URL`)
- Add `--model` and `--url` CLI flags, completing the flag surface alongside `--api-key` and `--provider`
- Design is provider-agnostic: env var names are derived automatically from provider names in `lib/llm_providers/registry.mjs`. Adding a new provider requires zero changes to config.mjs or provider code
- Added a test documenting that `ANTHROPIC_API_KEY` only resolves for the anthropic provider, not as a universal fallback. The old `env.API_KEY || env.ANTHROPIC_API_KEY` behavior sent the wrong key to non-Anthropic providers. The new per-provider resolution is stricter and intentionally correct.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Dependency update

## How to test

1. Per-provider env vars take priority over generic:

```bash
API_KEY=sk-generic ANTHROPIC_API_KEY=sk-ant-123 node bin/mint-ds.mjs audit ./examples/frankenstein --quiet
```

Should use `ANTHROPIC_API_KEY` (sk-ant-123), not `API_KEY`.

2. `--model` flag overrides env vars:

```bash
LLM_MODEL_NAME=fallback-model node bin/mint-ds.mjs audit ./examples/frankenstein --model claude-opus-5 --quiet
```
Should use claude-opus-5, not fallback-model.

3. Run the full test suite:

```bash
npm test
```

## Checklist

- [x] `npx tsc --noEmit` passes with no errors
- [x] Tested with real CSS input through the full audit → tokens → export flow
- [x] UI is responsive on mobile (tested at 375px width)
- [x] No new Spanish strings introduced — all user-facing text is English
- [x] No hardcoded colors or values that should be CSS variables

Closes #71. 
