### PR TITLE
chore: npm packaging setup for mint-ds 0.1.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nadia Nujovich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -228,8 +228,6 @@ The committed artifacts ([`mint-ds.tokens.json`](examples/frankenstein/mint-ds.t
 
 ## CLI
 
-> **Pre-release.** `mint-ds` isn't on npm yet, so the `npx mint-ds …` commands below won't resolve. Run it from a clone or use `npm link` while we're publishing — see [Local development without publishing](#local-development-without-publishing).
-
 ```bash
 # Analyze every CSS/SCSS/HTML file in a directory and write mint-ds.tokens.json
 npx mint-ds audit ./src/styles

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "lib/prompts.mjs",
     "lib/css-utils.mjs",
     "lib/css-auditor.mjs",
-    "lib/css-lint-rules.mjs",
     "lib/config.mjs",
     "lib/llm_providers/**/*.mjs",
     "README.md"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,16 @@
   "files": [
     "bin",
     "lib/prompts.mjs",
+    "lib/css-utils.mjs",
+    "lib/css-auditor.mjs",
+    "lib/css-lint-rules.mjs",
+    "lib/config.mjs",
+    "lib/llm_providers/**/*.mjs",
     "README.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=20"
   },
@@ -45,6 +53,7 @@
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
     "typecheck": "tsc --noEmit",
+    "prepublishOnly": "vitest run",
     "prepare": "husky",
     "release": "release-it",
     "release:dry": "release-it --dry-run"


### PR DESCRIPTION
## What
npm packaging setup for the first public release of `mint-ds` (0.1.0).

## Changes
- Add packaging metadata to `package.json`: `files` allowlist, `bin`, `publishConfig.access: public`, `prepublishOnly` test gate, repo/bugs/homepage/keywords/engines.
- Add MIT `LICENSE`.
- Remove the "Pre-release" note from the README now that the package is on npm.

## Status
`mint-ds@0.1.0` is already published to npm and verified end-to-end (`npx mint-ds@0.1.0 --version` installs from the registry and runs). Merging this brings `main` in sync with the published state; `v0.1.0` will be tagged on `main` after merge.

## Verification
- 172/172 tests green (`prepublishOnly` gate)
- `npm pack --dry-run`: 17 clean files, no secrets/tests/fixtures
- Runtime import graph confirmed self-contained within the published tarball