### PR TITLE
fix: include lib/dtcg-validator.mjs in npm files allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lib/css-utils.mjs",
     "lib/css-auditor.mjs",
     "lib/config.mjs",
+    "lib/dtcg-validator.mjs",
     "lib/llm_providers/**/*.mjs",
     "README.md"
   ],


### PR DESCRIPTION
## Problem
`bin/mint-ds.mjs` has a static top-level import of `lib/dtcg-validator.mjs` (added in #69), but that file was missing from the `files` allowlist in `package.json`. A tarball built from `main` ships the bin without the module it imports, so the installed CLI crashes on load (`Cannot find module`) for **every** command — not just `validate` — because the import resolves before anything runs.

## Fix
Add `lib/dtcg-validator.mjs` to `files`. The `templates/dtcg/*` files are intentionally left out: nothing in `bin/`/`lib/` references them at runtime (they are user-facing scaffolding), so the package stays lean.

## Verification
Packed the tarball, installed it in a clean directory, and ran the CLI from the install (not the source tree):
- `mint-ds --version` → `mint-ds 0.1.0` (CLI loads)
- `mint-ds validate tokens.json --spec dtcg` → `✓ Valid DTCG v1 tokens file` (exit 0)

Tarball now contains 18 files (was 17); `lib/dtcg-validator.mjs` (22.9 kB) is included.