### PR TITLE
ci: release publish workflow, PR-title validation, and commit conventions

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,18 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      # PRs are squash-merged, so the PR title becomes the changelog entry.
+      # commitlint only checks local commits, not the PR title — this closes that gap.
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write # required for OIDC trusted publishing + provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 24 bundles an older npm.
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - run: npm ci
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+      - run: npm test
+
+      - name: Publish to npm
+        run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 permissions:
   contents: read
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
           cache: npm
 
       # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 24 bundles an older npm.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ All four commands run automatically in CI on every PR. The pre-commit hook runs 
 
 - Use the PR template — fill out all sections
 - Keep PRs focused: one logical change per PR
+- **PR titles must be Conventional Commits.** PRs are squash-merged, so the PR title becomes the commit on `main` and the corresponding changelog entry — use `feat: …`, `fix: …`, etc. The `PR Title` CI check enforces this.
 - For anything that changes Claude prompts or the AuditReport/DSTokens shape, include a before/after example of the JSON output in the PR description
 
 ## Commit message convention
@@ -109,7 +110,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) s
 
 Breaking changes: add `!` after the prefix or a `BREAKING CHANGE:` footer, e.g. `feat!: redesign token schema`.
 
-The `commit-msg` hook enforces this format automatically via commitlint.
+The `commit-msg` hook enforces this format automatically via commitlint. You never edit `CHANGELOG.md` by hand — it is generated from these commit messages at release time.
 
 ## Releasing a new version
 
@@ -130,3 +131,5 @@ GITHUB_TOKEN=<your-token> npm run release
 3. Commit both files with `chore: release vX.Y.Z`
 4. Create and push the git tag `vX.Y.Z`
 5. Publish a GitHub Release with the generated notes
+
+Pushing the `vX.Y.Z` tag triggers the `publish.yml` workflow, which publishes the package to npm with provenance via OIDC trusted publishing — there is no manual `npm publish` step.


### PR DESCRIPTION
## What
Bundles the release automation (Fase 4) and the guardrails that keep the auto-generated changelog clean.

## Changes
- **`.github/workflows/publish.yml`** — publishes to npm on `v*` tags via OIDC trusted publishing (no `NPM_TOKEN` secret) with build provenance. Verifies the tag matches `package.json` version before publishing.
- **`.github/workflows/pr-title.yml`** — validates PR titles are Conventional Commits. Since PRs are squash-merged, the PR title becomes the changelog entry; commitlint only checks local commits, so this closes that gap.
- **`CONTRIBUTING.md`** — documents that PR titles must be conventional, that `CHANGELOG.md` is never hand-edited (generated at release time), and that pushing a tag auto-publishes to npm via CI.

## Repo setting (applied, not part of the diff)
Merges are now **squash-only** (merge-commit and rebase disabled), so each PR lands as one conventional commit → one clean changelog entry.

## Required setup on npmjs.com (one-time, before the next tag)
`mint-ds` package → **Settings → Trusted Publisher** → add a GitHub Actions publisher:
- Repository: `nujovich/mint`
- Workflow filename: `publish.yml`

Without this, the publish step fails with an auth error. No repo secret needed.

## Testing
- `publish.yml` runs only on tag push — first real exercise is the next release tag after the trusted publisher is configured.
- `pr-title.yml` runs on this PR and validates its own (conventional) title.
- YAML validated locally; CI green (format/lint/typecheck/test/build).