### PR TITLE
chore: source GITHUB_TOKEN from gh CLI in release scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "vitest run",
     "prepare": "husky",
-    "release": "release-it",
-    "release:dry": "release-it --dry-run"
+    "release": "GITHUB_TOKEN=$(gh auth token) release-it",
+    "release:dry": "GITHUB_TOKEN=$(gh auth token) release-it --dry-run"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.1",


### PR DESCRIPTION
## What
Make `npm run release` and `npm run release:dry` work without manually exporting `GITHUB_TOKEN` each time.

## How
The release scripts now source the token from the authenticated `gh` CLI at runtime:

```
GITHUB_TOKEN=$(gh auth token) release-it
```

No long-lived PAT stored in a dotfile, nothing to rotate — the token is minted fresh per run from your `gh` session (which already has `repo` scope). If `gh` isn't available, `GITHUB_TOKEN` is empty and release-it gracefully falls back to the web-based GitHub release.

## Verified
`npm run release:dry` no longer emits the `GITHUB_TOKEN is required / Falling back to web-based GitHub Release` warning — release-it reaches the release stage with the token present.

## Note
Uses POSIX `$(...)` command substitution (the `sh` npm uses on Linux/macOS). A maintainer releasing from Windows cmd/PowerShell would set `GITHUB_TOKEN` another way.