### PR TITLE
ci: fix provenance publish by removing broken npm upgrade step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: npm
 
-      # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 24 bundles an older npm.
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - run: npm ci
 
       - name: Verify tag matches package.json version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
 ## [0.2.1](https://github.com/nujovich/mint/compare/v0.2.0...v0.2.1) (2026-07-10)
 
-All notable changes to this project will be documented in this file.
+Maintenance release: release automation and CI publishing (OIDC + provenance). No user-facing changes.
 
 ## [0.2.0] - 2026-07-10
 


### PR DESCRIPTION
## Problem
The `v0.2.1` tag triggered `publish.yml`, but the `npm publish --provenance` step failed:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
  .../node_modules/npm/node_modules/libnpmpublish/lib/provenance.js
```

The `npm install -g npm@latest` step leaves the global npm in a broken state missing `sigstore` (the module that generates provenance attestations) — a known issue with reinstalling npm over the Node-bundled one.

## Fix
Remove the `Update npm` step. Node 24's bundled npm already supports OIDC trusted publishing and ships `sigstore` intact, so the manual upgrade was both unnecessary and the cause of the failure.

Also tidies `CHANGELOG.md`: `release-it` had inserted the `0.2.1` heading above the intro line and left the section empty — restored the intro and gave `0.2.1` an honest "maintenance release, no user-facing changes" note.

## After merge
Re-point the `v0.2.1` tag to this fix commit and re-push so the corrected workflow publishes `0.2.1` to npm with provenance.