### PR TITLE
ci: drop registry-url so OIDC trusted publishing is used for auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
## Problem
After fixing the `sigstore` crash, `npm publish --provenance` signed provenance successfully but then failed to authenticate:

```
npm warn Unknown user config "always-auth"
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/mint-ds
  'mint-ds@0.2.1' could not be found or you do not have permission
```

Root cause: `actions/setup-node` with `registry-url` writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` (plus `always-auth`). With no `NPM_TOKEN`, `NODE_AUTH_TOKEN` is empty, so npm attempts token auth with an empty token and never falls back to OIDC trusted publishing → 404.

## Fix
Remove `registry-url` from the `setup-node` step. Without the token-based `.npmrc`, npm (running with `id-token: write`) uses OIDC trusted publishing for authentication. The default registry is already `registry.npmjs.org` and `publishConfig.access: public` handles access.

## After merge
Re-point the `v0.2.1` tag to this commit and re-push so the corrected workflow publishes `0.2.1` with provenance via OIDC.