### PR TITLE
ci: authenticate npm publish with NPM_TOKEN secret

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write # required for OIDC trusted publishing + provenance
+  id-token: write # required for build provenance (--provenance)
 
 jobs:
   publish:
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          registry-url: 'https://registry.npmjs.org'
           cache: npm
 
       - run: npm ci
@@ -36,3 +37,5 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What
Switch the publish workflow from OIDC trusted publishing to `NPM_TOKEN` auth. OIDC kept returning `ENEEDAUTH` (npm never performed the trusted-publishing handshake despite npm 11.16.0, `id-token: write`, and a configured trusted publisher), so we move to the reliable token path.

## Changes
- `setup-node` gets `registry-url` back so it writes the auth `.npmrc`.
- The `Publish to npm` step sets `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`.
- `--provenance` and `id-token: write` are kept — build provenance still works with token auth.

## Required repo secret (before the next publish)
Add an `NPM_TOKEN` secret (Settings → Secrets and variables → Actions):
- Create a **granular access token** on npmjs.com scoped to the `mint-ds` package with read/write (publish) permission and an expiry.
- Paste it as the `NPM_TOKEN` repository secret.

## After merge
Re-point the `v0.2.1` tag to this commit and re-push so the workflow publishes `0.2.1` with provenance.