### PR TITLE
feat: add SolidJS and Qwik export targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,16 +410,16 @@ Add `mint-ds.cache.json` to `.gitignore` if you don't want to commit it.
 
 ### Export options
 
-| Flag                | Description                                                                                                                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--target <name>`   | **Required.** Accepts: `tailwind`, `react`, `vue`, `svelte`, `astro`, `css`, `scss`, `ts`, `css-modules`, `styled`, `emotion` (full names like `tailwind-config`, `react-component` also work) |
-| `--tokens <file>`   | Tokens input path (default: `mint-ds.tokens.json`)                                                                                                                                             |
-| `--out <file>`      | Override the default output filename                                                                                                                                                           |
-| `--provider <name>` | LLM backend: `anthropic` (default), `ollama`, or `openrouter`                                                                                                                                  |
-| `--api-key <value>` | LLM provider API key (overrides all API key env vars)                                                                                                                                          |
-| `--model <name>`    | Model name (overrides all model env vars)                                                                                                                                                      |
-| `--url <url>`       | API endpoint URL (overrides all URL env vars)                                                                                                                                                  |
-| `--stdout`          | Print to stdout instead of writing a file                                                                                                                                                      |
+| Flag                | Description                                                                                                                                                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--target <name>`   | **Required.** Accepts: `tailwind`, `react`, `vue`, `svelte`, `astro`, `css`, `scss`, `ts`, `css-modules`, `styled`, `emotion`, `angular`, `angular-legacy`, `solidjs`, `qwik` (full names like `tailwind-config`, `react-component` also work) |
+| `--tokens <file>`   | Tokens input path (default: `mint-ds.tokens.json`)                                                                                                                                                                                             |
+| `--out <file>`      | Override the default output filename                                                                                                                                                                                                           |
+| `--provider <name>` | LLM backend: `anthropic` (default), `ollama`, or `openrouter`                                                                                                                                                                                  |
+| `--api-key <value>` | LLM provider API key (overrides all API key env vars)                                                                                                                                                                                          |
+| `--model <name>`    | Model name (overrides all model env vars)                                                                                                                                                                                                      |
+| `--url <url>`       | API endpoint URL (overrides all URL env vars)                                                                                                                                                                                                  |
+| `--stdout`          | Print to stdout instead of writing a file                                                                                                                                                                                                      |
 
 ### Local development without publishing
 
@@ -437,11 +437,11 @@ node bin/mint-ds.mjs audit ./examples/site --provider ollama
 
 ## Export formats
 
-| Category   | Formats                                                        |
-| ---------- | -------------------------------------------------------------- |
-| Tokens     | CSS Custom Properties, SCSS Variables, JS/TS Object            |
-| Frameworks | Tailwind Config, Styled Components, Emotion Theme, CSS Modules |
-| Components | React + TypeScript, Vue 3 SFC, Svelte, Astro                   |
+| Category   | Formats                                                                                |
+| ---------- | -------------------------------------------------------------------------------------- |
+| Tokens     | CSS Custom Properties, SCSS Variables, JS/TS Object                                    |
+| Frameworks | Tailwind Config, Styled Components, Emotion Theme, CSS Modules                         |
+| Components | React + TypeScript, Vue 3 SFC, Svelte, Astro, Angular, Angular (Legacy), SolidJS, Qwik |
 
 ## Stack
 

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -21,6 +21,18 @@ describe('resolveTarget', () => {
     expect(resolveTarget('tailwind')).toBe('tailwind-config')
   })
 
+  it('resolves solidjs alias', () => {
+    expect(resolveTarget('solidjs')).toBe('solidjs-component')
+  })
+
+  it('resolves solid alias', () => {
+    expect(resolveTarget('solid')).toBe('solidjs-component')
+  })
+
+  it('resolves qwik alias', () => {
+    expect(resolveTarget('qwik')).toBe('qwik-component')
+  })
+
   it('returns null for an unknown target', () => {
     expect(resolveTarget('unknown-xyz')).toBeNull()
   })
@@ -399,6 +411,34 @@ describe('buildExportPrompt', () => {
     expect(typeof result).toBe('object')
     expect(result.content.length).toBeGreaterThan(0)
     expect(result.system).toBeNull()
+  })
+
+  it('returns an object with content and null system for solidjs-component target', () => {
+    const result = buildExportPrompt(tokens, 'solidjs-component')
+    expect(typeof result).toBe('object')
+    expect(result.content.length).toBeGreaterThan(0)
+    expect(result.system).toBeNull()
+  })
+
+  it('builds a SolidJS prompt using createSignal and splitProps for solidjs-component target', () => {
+    const content = buildExportPrompt(tokens, 'solidjs-component').content
+    expect(content).toContain('Solid')
+    expect(content).toContain('createSignal')
+    expect(content).toContain('splitProps')
+  })
+
+  it('returns an object with content and null system for qwik-component target', () => {
+    const result = buildExportPrompt(tokens, 'qwik-component')
+    expect(typeof result).toBe('object')
+    expect(result.content.length).toBeGreaterThan(0)
+    expect(result.system).toBeNull()
+  })
+
+  it('builds a Qwik prompt using component$ and useSignal for qwik-component target', () => {
+    const content = buildExportPrompt(tokens, 'qwik-component').content
+    expect(content).toContain('Qwik')
+    expect(content).toContain('component$')
+    expect(content).toContain('useSignal')
   })
 
   it('includes motion tokens in the export prompt when present', () => {

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -573,6 +573,66 @@ Requirements:
 - Add a "// Usage" comment at the top showing how to import MintDesignSystemModule and add to @NgModule.imports
 - Named exports for each component and the module
 - Use motion tokens (var(--transition-duration-*) and var(--transition-timing-function-*)) for transition properties`,
+
+  'solidjs-component': (
+    shared
+  ) => `Generate production-ready SolidJS TypeScript components using these design tokens.${shared}
+
+Generate Button, Card, Badge, and Input components in a single .tsx file:
+
+Button:
+- Props: variant (primary|secondary|ghost|danger), size (sm|md|lg), loading, disabled, fullWidth, onClick, children
+- Loading state with spinner SVG shown via Solid's <Show> control flow
+- Use local state with createSignal only where a component genuinely needs it
+
+Card:
+- Props: title?, description?, children, variant (default|elevated|outlined), padding (sm|md|lg)
+
+Badge:
+- Props: variant (primary|secondary|accent|neutral|success|danger), size (sm|md), children
+
+Input:
+- Props: label?, placeholder?, value, onInput, error?, hint?, disabled, type
+
+Requirements:
+- Import from 'solid-js' (createSignal, Show, type Component, splitProps, mergeProps)
+- Use splitProps to separate local props from the rest, and mergeProps to apply defaults — never destructure props directly (it breaks Solid reactivity)
+- Full TypeScript interfaces with JSDoc for each component's props
+- Use the class attribute and inline style objects with CSS custom properties (var(--color-primary) etc.) — no hardcoded values
+- Style object keys must be kebab-case (e.g. "background-color", not backgroundColor) — Solid's style prop maps directly to the native DOM style API
+- Use children as a prop (props.children), not a slot
+- Named exports for each component
+- Use motion tokens (var(--transition-duration-*) and var(--transition-timing-function-*)) for transition properties`,
+
+  'qwik-component': (
+    shared
+  ) => `Generate production-ready Qwik components using these design tokens.${shared}
+
+Generate Button, Card, Badge, and Input components in a single .tsx file using Qwik's component$ pattern:
+
+Button:
+- Props: variant (primary|secondary|ghost|danger), size (sm|md|lg), loading, disabled, fullWidth, onClick$ — render label content via <Slot />
+- Loading state with spinner SVG shown via a plain ternary/conditional in JSX
+- Use useSignal only where a component genuinely needs local reactive state
+
+Card:
+- Props: title?, description?, variant (default|elevated|outlined), padding (sm|md|lg) — render children via <Slot />
+
+Badge:
+- Props: variant (primary|secondary|accent|neutral|success|danger), size (sm|md) — render children via <Slot />
+
+Input:
+- Props: label?, placeholder?, value, onInput$, error?, hint?, disabled, type
+
+Requirements:
+- Import from '@builder.io/qwik' (component$, useSignal, Slot, type PropFunction, type QRL)
+- Wrap every component in component$(() => { ... })
+- Type event handler props as PropFunction / QRL and invoke them with $ semantics (onClick$, onInput$)
+- Full TypeScript interfaces with JSDoc for each component's props
+- Use the class attribute and inline style objects with CSS custom properties (var(--color-primary) etc.) — no hardcoded values
+- Use <Slot /> for projected content (Button label, Card, Badge) — Qwik does not use a children prop
+- Named exports for each component
+- Use motion tokens (var(--transition-duration-*) and var(--transition-timing-function-*)) for transition properties`,
 }
 
 export function buildExportPrompt(tokens, target) {
@@ -598,6 +658,8 @@ export const EXPORT_OUTPUT = {
   'astro-component': { filename: 'components', ext: 'astro' },
   'angular-component': { filename: 'components', ext: 'ts' },
   'angular-legacy-component': { filename: 'components.module', ext: 'ts' },
+  'solidjs-component': { filename: 'components', ext: 'tsx' },
+  'qwik-component': { filename: 'components', ext: 'tsx' },
 }
 
 // Short aliases the CLI accepts for --target.
@@ -619,6 +681,9 @@ export const TARGET_ALIASES = {
   astro: 'astro-component',
   angular: 'angular-component',
   'angular-legacy': 'angular-legacy-component',
+  solidjs: 'solidjs-component',
+  solid: 'solidjs-component',
+  qwik: 'qwik-component',
 }
 
 // Curated short list shown in --help and validation errors. Keeps the public
@@ -637,6 +702,8 @@ export const ADVERTISED_TARGETS = [
   'emotion',
   'angular',
   'angular-legacy',
+  'solidjs',
+  'qwik',
 ]
 
 export function resolveTarget(input) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,6 +39,8 @@ export type ExportTarget =
   | 'astro-component'
   | 'angular-component'
   | 'angular-legacy-component'
+  | 'solidjs-component'
+  | 'qwik-component'
 
 export interface ExportConfig {
   target: ExportTarget
@@ -298,5 +300,21 @@ export const EXPORT_TARGETS: ExportConfig[] = [
     ext: 'ts',
     category: 'Components',
     description: 'Classic @NgModule with @Input/@Output decorators',
+  },
+  {
+    target: 'solidjs-component',
+    label: 'SolidJS',
+    filename: 'components',
+    ext: 'tsx',
+    category: 'Components',
+    description: 'Fine-grained reactive components with createSignal',
+  },
+  {
+    target: 'qwik-component',
+    label: 'Qwik',
+    filename: 'components',
+    ext: 'tsx',
+    category: 'Components',
+    description: 'Resumable component$ with typed props and Slot',
   },
 ]


### PR DESCRIPTION
Closes #7

Adds SolidJS and Qwik as component export targets, so `mint-ds export --target solidjs|qwik` works from the CLI and both show up as buttons in the playground.

## What changed
- **lib/prompts.mjs** — `solidjs-component` and `qwik-component` prompt builders, plus registration in `EXPORT_OUTPUT`, `TARGET_ALIASES` (`solidjs`/`solid`/`qwik`), and `ADVERTISED_TARGETS`.
- **lib/types.ts** — `ExportTarget` union entries and `EXPORT_TARGETS` metadata. The playground grid is generated from this table, so the buttons appear automatically under **Components** — no UI change needed.
- **lib/__tests__/prompts.test.mjs** — 7 new tests (alias resolution + prompt building for both targets), written test-first.
- **README.md** — target/format tables updated; also backfills the previously missing Angular entries.

## Prompt design notes
- **SolidJS** (`.tsx`): `splitProps`/`mergeProps` instead of destructuring props, `createSignal` for local state, and kebab-case style-object keys (Solid's `style` prop maps to the native DOM style API).
- **Qwik** (`.tsx`): `component$`, `useSignal`, `<Slot />`-based content projection, and `PropFunction`/`QRL` event handlers (`onClick$` / `onInput$`).

## Verification
- 331 tests pass (`vitest run`), including the 7 new ones
- `tsc --noEmit` clean
- `next lint` + `prettier --check` clean
