### PR TITLE
feat: add Vanilla Extract export target

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,16 +410,16 @@ Add `mint-ds.cache.json` to `.gitignore` if you don't want to commit it.
 
 ### Export options
 
-| Flag                | Description                                                                                                                                                                                                                                    |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--target <name>`   | **Required.** Accepts: `tailwind`, `react`, `vue`, `svelte`, `astro`, `css`, `scss`, `ts`, `css-modules`, `styled`, `emotion`, `angular`, `angular-legacy`, `solidjs`, `qwik` (full names like `tailwind-config`, `react-component` also work) |
-| `--tokens <file>`   | Tokens input path (default: `mint-ds.tokens.json`)                                                                                                                                                                                             |
-| `--out <file>`      | Override the default output filename                                                                                                                                                                                                           |
-| `--provider <name>` | LLM backend: `anthropic` (default), `ollama`, or `openrouter`                                                                                                                                                                                  |
-| `--api-key <value>` | LLM provider API key (overrides all API key env vars)                                                                                                                                                                                          |
-| `--model <name>`    | Model name (overrides all model env vars)                                                                                                                                                                                                      |
-| `--url <url>`       | API endpoint URL (overrides all URL env vars)                                                                                                                                                                                                  |
-| `--stdout`          | Print to stdout instead of writing a file                                                                                                                                                                                                      |
+| Flag                | Description                                                                                                                                                                                                                                                       |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--target <name>`   | **Required.** Accepts: `tailwind`, `react`, `vue`, `svelte`, `astro`, `css`, `scss`, `ts`, `css-modules`, `styled`, `emotion`, `vanilla-extract`, `angular`, `angular-legacy`, `solidjs`, `qwik` (full names like `tailwind-config`, `react-component` also work) |
+| `--tokens <file>`   | Tokens input path (default: `mint-ds.tokens.json`)                                                                                                                                                                                                                |
+| `--out <file>`      | Override the default output filename                                                                                                                                                                                                                              |
+| `--provider <name>` | LLM backend: `anthropic` (default), `ollama`, or `openrouter`                                                                                                                                                                                                     |
+| `--api-key <value>` | LLM provider API key (overrides all API key env vars)                                                                                                                                                                                                             |
+| `--model <name>`    | Model name (overrides all model env vars)                                                                                                                                                                                                                         |
+| `--url <url>`       | API endpoint URL (overrides all URL env vars)                                                                                                                                                                                                                     |
+| `--stdout`          | Print to stdout instead of writing a file                                                                                                                                                                                                                         |
 
 ### Local development without publishing
 
@@ -440,7 +440,7 @@ node bin/mint-ds.mjs audit ./examples/site --provider ollama
 | Category   | Formats                                                                                |
 | ---------- | -------------------------------------------------------------------------------------- |
 | Tokens     | CSS Custom Properties, SCSS Variables, JS/TS Object                                    |
-| Frameworks | Tailwind Config, Styled Components, Emotion Theme, CSS Modules                         |
+| Frameworks | Tailwind Config, Styled Components, Emotion Theme, CSS Modules, Vanilla Extract        |
 | Components | React + TypeScript, Vue 3 SFC, Svelte, Astro, Angular, Angular (Legacy), SolidJS, Qwik |
 
 ## Stack

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -33,6 +33,14 @@ describe('resolveTarget', () => {
     expect(resolveTarget('qwik')).toBe('qwik-component')
   })
 
+  it('resolves the vanilla-extract canonical key unchanged', () => {
+    expect(resolveTarget('vanilla-extract')).toBe('vanilla-extract')
+  })
+
+  it('resolves ve alias', () => {
+    expect(resolveTarget('ve')).toBe('vanilla-extract')
+  })
+
   it('returns null for an unknown target', () => {
     expect(resolveTarget('unknown-xyz')).toBeNull()
   })
@@ -439,6 +447,21 @@ describe('buildExportPrompt', () => {
     expect(content).toContain('Qwik')
     expect(content).toContain('component$')
     expect(content).toContain('useSignal')
+  })
+
+  it('returns an object with content and null system for vanilla-extract target', () => {
+    const result = buildExportPrompt(tokens, 'vanilla-extract')
+    expect(typeof result).toBe('object')
+    expect(result.content.length).toBeGreaterThan(0)
+    expect(result.system).toBeNull()
+  })
+
+  it('builds a Vanilla Extract prompt using createGlobalThemeContract and createGlobalTheme for vanilla-extract target', () => {
+    const content = buildExportPrompt(tokens, 'vanilla-extract').content
+    expect(content).toContain('@vanilla-extract/css')
+    expect(content).toContain('createGlobalThemeContract')
+    expect(content).toContain('createGlobalTheme')
+    expect(content).toContain('vars')
   })
 
   it('includes motion tokens in the export prompt when present', () => {

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -633,6 +633,23 @@ Requirements:
 - Use <Slot /> for projected content (Button label, Card, Badge) — Qwik does not use a children prop
 - Named exports for each component
 - Use motion tokens (var(--transition-duration-*) and var(--transition-timing-function-*)) for transition properties`,
+
+  'vanilla-extract': (
+    shared
+  ) => `Generate a complete Vanilla Extract theme contract as a .css.ts file for these design tokens.${shared}
+
+Requirements:
+- Import { createGlobalThemeContract, createGlobalTheme } from '@vanilla-extract/css'
+- Export a single typed \`vars\` via createGlobalThemeContract so consumers get autocomplete on vars.colors.primary['500']. The contract shape must cover every token category:
+  - colors: one entry per color token, each an object with the full 50–900 scale (keys "50","100",…,"900")
+  - space (from spacing), radii (from borderRadius), shadows
+  - fonts (from typography.fontFamilies), fontSizes, fontWeights, lineHeights
+  - transitionDuration and transitionTimingFunction from typography.motion (durations/easings)
+- In createGlobalThemeContract, map each leaf to a stable CSS variable name using the second-argument path mapper (e.g. (_value, path) => path.join('-')) so variable names are unique and readable
+- Apply the light theme with createGlobalTheme(':root', vars, { ... }) filling every contract leaf with the actual token value
+- Apply dark mode with createGlobalTheme('[data-theme="dark"]', vars, { ... }) overriding the background, surface, text, and muted color roles (reuse the light values for everything else)
+- Add a short usage comment at the top showing how to consume vars from a separate .css.ts style file, e.g. import { style } from '@vanilla-extract/css' and style({ color: vars.colors.primary['500'], padding: vars.space['4'] })
+- Do not emit any runtime CSS-in-JS beyond the theme wiring; keep it zero-runtime and type-safe`,
 }
 
 export function buildExportPrompt(tokens, target) {
@@ -660,6 +677,7 @@ export const EXPORT_OUTPUT = {
   'angular-legacy-component': { filename: 'components.module', ext: 'ts' },
   'solidjs-component': { filename: 'components', ext: 'tsx' },
   'qwik-component': { filename: 'components', ext: 'tsx' },
+  'vanilla-extract': { filename: 'theme.css', ext: 'ts' },
 }
 
 // Short aliases the CLI accepts for --target.
@@ -684,6 +702,8 @@ export const TARGET_ALIASES = {
   solidjs: 'solidjs-component',
   solid: 'solidjs-component',
   qwik: 'qwik-component',
+  'vanilla-extract': 'vanilla-extract',
+  ve: 'vanilla-extract',
 }
 
 // Curated short list shown in --help and validation errors. Keeps the public
@@ -704,6 +724,7 @@ export const ADVERTISED_TARGETS = [
   'angular-legacy',
   'solidjs',
   'qwik',
+  'vanilla-extract',
 ]
 
 export function resolveTarget(input) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -41,6 +41,7 @@ export type ExportTarget =
   | 'angular-legacy-component'
   | 'solidjs-component'
   | 'qwik-component'
+  | 'vanilla-extract'
 
 export interface ExportConfig {
   target: ExportTarget
@@ -252,6 +253,14 @@ export const EXPORT_TARGETS: ExportConfig[] = [
     ext: 'module.css',
     category: 'Frameworks CSS',
     description: '@value declarations + utility classes',
+  },
+  {
+    target: 'vanilla-extract',
+    label: 'Vanilla Extract',
+    filename: 'theme.css',
+    ext: 'ts',
+    category: 'Frameworks CSS',
+    description: 'Typed theme contract + light/dark (.css.ts)',
   },
   {
     target: 'react-component',


### PR DESCRIPTION
Closes #9.

Adds a `vanilla-extract` export target so users on the [Vanilla Extract](https://vanilla-extract.style/) stack get their tokens without hand-translating them.

## What's new
- CLI: `npx mint-ds export --target vanilla-extract` (alias `ve`) → writes `theme.css.ts`
- Playground: a **Vanilla Extract** button under *Frameworks CSS*

## Generated output
The prompt instructs the model to emit a zero-runtime `.css.ts` theme contract:
- `createGlobalThemeContract` defining a single typed `vars` (colors with full 50–900 scales, spacing, radii, shadows, typography and motion) so consumers get autocomplete on `vars.colors.primary['500']`
- `createGlobalTheme(':root', vars, …)` for light + `createGlobalTheme('[data-theme="dark"]', vars, …)` for dark overrides
- a short usage comment showing how to consume `vars` from a `.css.ts` style file

## Wiring (same pattern as `styled-components`/`emotion`)
- `EXPORT_PROMPTS`, `EXPORT_OUTPUT` (`theme.css.ts`), `TARGET_ALIASES` (`vanilla-extract`, `ve`), `ADVERTISED_TARGETS`
- `ExportTarget` union + `EXPORT_TARGETS` UI metadata (Frameworks CSS)
- README target docs

## Testing
- New unit tests for alias resolution (`vanilla-extract`, `ve`) and prompt shape (`@vanilla-extract/css`, `createGlobalThemeContract`, `createGlobalTheme`, typed `vars`)
- Full suite green (335 tests), `tsc --noEmit` clean, `next lint` clean
- Exercised the `resolveTarget → buildExportPrompt` chain against `examples/frankenstein/mint-ds.tokens.json`: resolves, output filename `theme.css.ts`, prompt embeds the real tokens

Note: exports are LLM-generated from prompts (no committed example output), consistent with the other targets.