### PR TITLE
fix: ship compat/lint lib modules in npm files allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "lib/css-auditor.mjs",
     "lib/config.mjs",
     "lib/dtcg-validator.mjs",
+    "lib/audit-summary.mjs",
+    "lib/css-compat-data.mjs",
+    "lib/css-lint-rules.mjs",
     "lib/llm_providers/**/*.mjs",
     "README.md"
   ],


### PR DESCRIPTION
## Problem

`bin/mint-ds.mjs` imports three `lib/*.mjs` modules that are **not** listed in `package.json` `files`:

- `lib/audit-summary.mjs` — the `audit` chaos/lint summary line
- `lib/css-compat-data.mjs` — the `compat` command
- `lib/css-lint-rules.mjs` — the `lint` command

`files` is an allowlist, so the published npm tarball omitted them. On an npm-installed copy, `mint-ds compat`, `mint-ds lint` (and the `audit` summary import) crash with `ERR_MODULE_NOT_FOUND`. This is the same class of bug fixed for `lib/dtcg-validator.mjs` in #79.

## Fix

Add the three modules to the `files` allowlist.

## Verification

`npm pack --dry-run` before vs. after this change:

| Module | Before (main) | After |
| --- | --- | --- |
| `lib/audit-summary.mjs` | ❌ omitted | ✅ shipped |
| `lib/css-compat-data.mjs` | ❌ omitted | ✅ shipped |
| `lib/css-lint-rules.mjs` | ❌ omitted | ✅ shipped |

Their runtime dependencies (`web-features`, `browserslist`) are already declared in `dependencies`, so no dependency change is needed.

## Notes

Follow-up worth doing separately: a `prepublishOnly` / CI check that asserts every `lib/*.mjs` reachable from `bin/` is present in the packed tarball, so this class of bug can't recur silently.