### PR TITLE
feat: add `diff` command to compare two token files

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ npx mint-ds export --target tailwind --provider ollama
 | `mint-ds audit <dir>`            | Walk `<dir>` for `.css`, `.scss`, `.sass`, `.less`, `.html` files, audit them with Claude, and write `mint-ds.tokens.json` |
 | `mint-ds export --target <name>` | Read `mint-ds.tokens.json` and generate the chosen format                                                                  |
 | `mint-ds validate <file>`        | Validate `tokens.json` against DTCG v1 — structure, references, cycles, naming consistency                                 |
+| `mint-ds diff <old> <new>`       | Show what changed between two token files — added, removed, renamed, value-changed, scale-changed (no LLM)                 |
 | `mint-ds cache --clear`          | Delete the local `mint-ds.cache.json` cache file                                                                           |
 | `mint-ds compat <dir>`           | Flag CSS properties below Baseline / Interop 2026 for your browserslist target, with fallback suggestions (no LLM)         |
 | `mint-ds lint <dir>`             | Run static CSS lint rules (gap-decoration hacks) plus a modern-CSS adoption report — no LLM                                |
@@ -343,6 +344,47 @@ npx mint-ds export --target tailwind --provider ollama
 - **Semantic** — broken references, circular references, naming-convention drift, and reference type mismatches.
 
 **Exit codes:** `0` valid · `1` warnings only · `2` errors. Structural violations and broken/circular references are errors (exit `2`); naming drift and type mismatches are warnings (exit `1`). Ready-made CI templates (GitHub Action + pre-commit hook) live in [`templates/dtcg/`](templates/dtcg/).
+
+### Diff
+
+`mint-ds diff <old.tokens.json> <new.tokens.json>` compares two token files and reports what changed — semantically, not line-by-line. Every re-`audit` produces a fresh `mint-ds.tokens.json`; `diff` tells a PR reviewer whether a color shifted, a token was renamed, or a scale stop moved. No API key or LLM call required.
+
+Changes are grouped by category (`colors`, `spacing`, `fontFamilies`, …) and classified:
+
+| Symbol | Change        | Meaning                                             |
+| ------ | ------------- | --------------------------------------------------- |
+| `+`    | added         | Present in the new file only                        |
+| `–`    | removed       | Present in the old file only                        |
+| `↻`    | renamed       | Same value under a different name (heuristic)       |
+| `~`    | value changed | Same name, different value                          |
+| `~`    | scale changed | A color scale stop was added, removed, or re-valued |
+
+```bash
+# Human-readable report
+npx mint-ds diff old.tokens.json mint-ds.tokens.json
+
+# Machine-readable output for CI / PR bots
+npx mint-ds diff old.tokens.json mint-ds.tokens.json --json
+```
+
+Example output:
+
+```
+colors
+  + accent (#f59e0b)
+  ~ primary.500: #1976d2 → #1f77d8
+  – legacy-blue (was #1a73e8)
+spacing
+  ↻ renamed "4" → "5" (value 20px)
+
+Summary: 3 change(s) — 1 added, 1 removed, 1 renamed — breaking
+```
+
+| Flag     | Description                          |
+| -------- | ------------------------------------ |
+| `--json` | Emit machine-readable JSON to stdout |
+
+**Exit codes:** `0` no breaking changes · `1` breaking changes. Removed, value-changed, and scale-changed tokens are **breaking** (they alter what downstream exports emit); additions and renames preserve existing values and are non-breaking. Gate CI on the exit code to block breaking token changes from merging unnoticed.
 
 ### Compat
 

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -18,6 +18,7 @@ import {
 } from '../lib/prompts.mjs'
 import { getCssAuditor } from '../lib/css-auditor.mjs'
 import { validateFile } from '../lib/dtcg-validator.mjs'
+import { diffFiles } from '../lib/token-diff.mjs'
 import { formatLintSummary } from '../lib/audit-summary.mjs'
 import { checkCompat } from '../lib/css-compat-data.mjs'
 import { lintCss, lintGapDecorationAdoption } from '../lib/css-lint-rules.mjs'
@@ -89,6 +90,7 @@ ${styles.bold('COMMANDS')}
   audit <dir>                  Analyze CSS/SCSS files in <dir> and write ${DEFAULT_TOKENS_FILE}
   export --target <name>       Generate exports from ${DEFAULT_TOKENS_FILE}
   validate <file> [options]    Validate tokens.json against a spec (e.g. dtcg)
+  diff <old> <new>             Show changes between two token files
   cache --clear                Delete the local ${CACHE_FILE}
   compat <dir>                 Scan CSS for Interop 2026 browser-compat issues (warnings + suggestions)
   lint <dir>                   Run static CSS lint rules on files in <dir>
@@ -111,6 +113,10 @@ ${styles.bold('VALIDATE OPTIONS')}
   --json                       Output results as JSON
   --quiet                      Suppress non-error output
   --no-semantic                Skip semantic checks (refs, cycles, naming, type mismatch)
+
+${styles.bold('DIFF OPTIONS')}
+  --json                       Output the diff as JSON (for CI / PR bots)
+                                 Exits non-zero on breaking changes (removed / value-changed)
 
 ${styles.bold('AUTH (any command)')}
   --api-key <value>            LLM provider API key (overrides API_KEY env var)
@@ -145,6 +151,7 @@ ${styles.bold('EXAMPLES')}
   npx mint-ds export --target css --stdout > variables.css
   npx mint-ds validate tokens.json --spec dtcg
   npx mint-ds validate tokens.json --spec dtcg --json
+  npx mint-ds diff old.tokens.json mint-ds.tokens.json
   npx mint-ds lint ./src/styles
 `)
 }
@@ -585,6 +592,38 @@ async function cmdValidate(argv) {
   process.exit(result.exitCode)
 }
 
+async function cmdDiff(argv) {
+  const { flags, rest } = parseFlags(argv)
+  const oldPath = rest[0]
+  const newPath = rest[1]
+  if (!oldPath || !newPath) {
+    die('Usage: mint-ds diff <old.tokens.json> <new.tokens.json> [--json]')
+  }
+
+  const asJson = Boolean(flags.json)
+
+  let diff
+  try {
+    diff = await diffFiles(oldPath, newPath)
+  } catch (err) {
+    die(err && err.message ? err.message : String(err))
+  }
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify(diff.toJSON(), null, 2) + '\n')
+  } else {
+    log(
+      styles.cyan('→') +
+        ` Diffing ${styles.bold(oldPath)} → ${styles.bold(newPath)}…`
+    )
+    log('')
+    log(diff.print())
+  }
+
+  // Exit non-zero when breaking changes (removed / value-changed) are present.
+  process.exit(diff.exitCode)
+}
+
 async function main() {
   const argv = process.argv.slice(2)
   if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help') {
@@ -601,6 +640,7 @@ async function main() {
     if (cmd === 'audit') await cmdAudit(rest)
     else if (cmd === 'export') await cmdExport(rest)
     else if (cmd === 'validate') await cmdValidate(rest)
+    else if (cmd === 'diff') await cmdDiff(rest)
     else if (cmd === 'cache') await cmdCache(rest)
     else if (cmd === 'compat') await cmdCompat(rest)
     else if (cmd === 'lint') await cmdLint(rest)

--- a/lib/__tests__/token-diff.test.mjs
+++ b/lib/__tests__/token-diff.test.mjs
@@ -1,0 +1,368 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { diffTokens, diffFiles, TokenDiff } from '../token-diff.mjs'
+
+// Minimal helpers to build tokens objects that match the mint-ds schema.
+function color(name, value, scale) {
+  return { name, value, ...(scale ? { scale } : {}) }
+}
+
+function tokens(overrides = {}) {
+  return {
+    brand: 'acme',
+    colors: [],
+    typography: {
+      fontFamilies: {},
+      fontSizes: {},
+      fontWeights: {},
+      lineHeights: {},
+    },
+    spacing: {},
+    borderRadius: {},
+    shadows: {},
+    ...overrides,
+  }
+}
+
+describe('diffTokens', () => {
+  describe('no changes', () => {
+    it('reports no changes for identical token sets', () => {
+      const a = tokens({ colors: [color('primary', '#1976d2')] })
+      const b = tokens({ colors: [color('primary', '#1976d2')] })
+      const diff = diffTokens(a, b)
+      expect(diff.hasChanges).toBe(false)
+      expect(diff.hasBreakingChanges).toBe(false)
+      expect(diff.exitCode).toBe(0)
+      expect(diff.changes).toEqual([])
+    })
+  })
+
+  describe('colors', () => {
+    it('detects an added color as non-breaking', () => {
+      const a = tokens({ colors: [color('primary', '#1976d2')] })
+      const b = tokens({
+        colors: [color('primary', '#1976d2'), color('accent', '#f59e0b')],
+      })
+      const diff = diffTokens(a, b)
+      expect(diff.added).toHaveLength(1)
+      expect(diff.added[0]).toMatchObject({
+        category: 'colors',
+        type: 'added',
+        name: 'accent',
+        value: '#f59e0b',
+      })
+      expect(diff.hasBreakingChanges).toBe(false)
+      expect(diff.exitCode).toBe(0)
+    })
+
+    it('detects a removed color as breaking', () => {
+      const a = tokens({ colors: [color('legacy-blue', '#1a73e8')] })
+      const b = tokens({ colors: [] })
+      const diff = diffTokens(a, b)
+      expect(diff.removed).toHaveLength(1)
+      expect(diff.removed[0]).toMatchObject({
+        category: 'colors',
+        type: 'removed',
+        name: 'legacy-blue',
+        value: '#1a73e8',
+      })
+      expect(diff.hasBreakingChanges).toBe(true)
+      expect(diff.exitCode).toBe(1)
+    })
+
+    it('detects a base value change as breaking', () => {
+      const a = tokens({ colors: [color('primary', '#1976d2')] })
+      const b = tokens({ colors: [color('primary', '#1f77d8')] })
+      const diff = diffTokens(a, b)
+      expect(diff.valueChanged).toHaveLength(1)
+      expect(diff.valueChanged[0]).toMatchObject({
+        category: 'colors',
+        type: 'value-changed',
+        name: 'primary',
+        oldValue: '#1976d2',
+        newValue: '#1f77d8',
+      })
+      expect(diff.exitCode).toBe(1)
+    })
+
+    it('detects a renamed color (same value, different name) as non-breaking', () => {
+      const a = tokens({ colors: [color('primary', '#1976d2')] })
+      const b = tokens({ colors: [color('brand', '#1976d2')] })
+      const diff = diffTokens(a, b)
+      expect(diff.renamed).toHaveLength(1)
+      expect(diff.renamed[0]).toMatchObject({
+        category: 'colors',
+        type: 'renamed',
+        from: 'primary',
+        to: 'brand',
+        value: '#1976d2',
+      })
+      expect(diff.removed).toHaveLength(0)
+      expect(diff.added).toHaveLength(0)
+      expect(diff.hasBreakingChanges).toBe(false)
+    })
+
+    it('detects a scale stop value change as breaking', () => {
+      const a = tokens({
+        colors: [
+          color('primary', '#1976d2', { 500: '#1976d2', 700: '#0d47a1' }),
+        ],
+      })
+      const b = tokens({
+        colors: [
+          color('primary', '#1976d2', { 500: '#1f77d8', 700: '#0d47a1' }),
+        ],
+      })
+      const diff = diffTokens(a, b)
+      expect(diff.scaleChanged).toHaveLength(1)
+      const change = diff.scaleChanged[0]
+      expect(change).toMatchObject({ category: 'colors', name: 'primary' })
+      expect(change.stops).toEqual([
+        {
+          stop: '500',
+          type: 'value-changed',
+          oldValue: '#1976d2',
+          newValue: '#1f77d8',
+        },
+      ])
+      expect(diff.exitCode).toBe(1)
+    })
+
+    it('detects added and removed scale stops', () => {
+      const a = tokens({
+        colors: [color('primary', '#1976d2', { 500: '#1976d2' })],
+      })
+      const b = tokens({
+        colors: [
+          color('primary', '#1976d2', { 500: '#1976d2', 600: '#1565c0' }),
+        ],
+      })
+      const diff = diffTokens(a, b)
+      expect(diff.scaleChanged[0].stops).toEqual([
+        { stop: '600', type: 'added', newValue: '#1565c0' },
+      ])
+    })
+
+    it('does not report scale change when scales are identical', () => {
+      const scale = { 500: '#1976d2', 700: '#0d47a1' }
+      const a = tokens({ colors: [color('primary', '#1976d2', { ...scale })] })
+      const b = tokens({ colors: [color('primary', '#1976d2', { ...scale })] })
+      const diff = diffTokens(a, b)
+      expect(diff.scaleChanged).toHaveLength(0)
+      expect(diff.hasChanges).toBe(false)
+    })
+  })
+
+  describe('record categories', () => {
+    it('detects added/removed/value-changed spacing tokens', () => {
+      const a = tokens({ spacing: { 1: '4px', 2: '8px' } })
+      const b = tokens({ spacing: { 1: '4px', 2: '10px', 3: '12px' } })
+      const diff = diffTokens(a, b)
+      expect(diff.added.map((c) => c.name)).toEqual(['3'])
+      expect(diff.valueChanged).toHaveLength(1)
+      expect(diff.valueChanged[0]).toMatchObject({
+        category: 'spacing',
+        name: '2',
+        oldValue: '8px',
+        newValue: '10px',
+      })
+    })
+
+    it('detects a renamed spacing key (same value, different key)', () => {
+      const a = tokens({ spacing: { 4: '20px' } })
+      const b = tokens({ spacing: { 5: '20px' } })
+      const diff = diffTokens(a, b)
+      expect(diff.renamed).toHaveLength(1)
+      expect(diff.renamed[0]).toMatchObject({
+        category: 'spacing',
+        from: '4',
+        to: '5',
+        value: '20px',
+      })
+    })
+
+    it('diffs typography sub-records including numeric fontWeights', () => {
+      const a = tokens({
+        typography: {
+          fontFamilies: { body: 'Arial' },
+          fontSizes: {},
+          fontWeights: { bold: 700 },
+          lineHeights: {},
+        },
+      })
+      const b = tokens({
+        typography: {
+          fontFamilies: { body: 'Inter' },
+          fontSizes: {},
+          fontWeights: { bold: 800 },
+          lineHeights: {},
+        },
+      })
+      const diff = diffTokens(a, b)
+      const cats = diff.valueChanged.map((c) => c.category).sort()
+      expect(cats).toEqual(['fontFamilies', 'fontWeights'])
+      const weight = diff.valueChanged.find((c) => c.category === 'fontWeights')
+      expect(weight).toMatchObject({ oldValue: 700, newValue: 800 })
+    })
+
+    it('diffs borderRadius and shadows records', () => {
+      const a = tokens({
+        borderRadius: { sm: '4px' },
+        shadows: { sm: '0 2px 4px rgba(0,0,0,0.1)' },
+      })
+      const b = tokens({
+        borderRadius: { sm: '6px' },
+        shadows: {},
+      })
+      const diff = diffTokens(a, b)
+      expect(diff.valueChanged.some((c) => c.category === 'borderRadius')).toBe(
+        true
+      )
+      expect(diff.removed.some((c) => c.category === 'shadows')).toBe(true)
+    })
+  })
+
+  describe('brand', () => {
+    it('reports a brand value change', () => {
+      const diff = diffTokens(
+        tokens({ brand: 'old' }),
+        tokens({ brand: 'new' })
+      )
+      expect(diff.valueChanged).toHaveLength(1)
+      expect(diff.valueChanged[0]).toMatchObject({
+        category: 'brand',
+        name: 'brand',
+        oldValue: 'old',
+        newValue: 'new',
+      })
+    })
+
+    it('reports a brand addition and removal', () => {
+      const added = diffTokens(
+        tokens({ brand: undefined }),
+        tokens({ brand: 'acme' })
+      )
+      expect(added.added.some((c) => c.category === 'brand')).toBe(true)
+      const removed = diffTokens(
+        tokens({ brand: 'acme' }),
+        tokens({ brand: undefined })
+      )
+      expect(removed.removed.some((c) => c.category === 'brand')).toBe(true)
+    })
+  })
+
+  describe('robustness', () => {
+    it('handles partial/empty token objects without throwing', () => {
+      const diff = diffTokens({}, { colors: [color('primary', '#000')] })
+      expect(diff.added).toHaveLength(1)
+    })
+
+    it('handles null/undefined inputs', () => {
+      expect(() => diffTokens(null, undefined)).not.toThrow()
+      expect(diffTokens(null, undefined).hasChanges).toBe(false)
+    })
+
+    it('pairs renames greedily when multiple candidates share a value', () => {
+      const a = tokens({ spacing: { a: '4px', b: '4px' } })
+      const b = tokens({ spacing: { c: '4px' } })
+      const diff = diffTokens(a, b)
+      expect(diff.renamed).toHaveLength(1)
+      expect(diff.removed).toHaveLength(1)
+    })
+  })
+})
+
+describe('TokenDiff output', () => {
+  it('prints a clean message when there are no changes', () => {
+    const diff = diffTokens(tokens(), tokens())
+    expect(diff.print()).toBe('✓ No changes between token files')
+  })
+
+  it('groups changes by category with symbols in the human report', () => {
+    const a = tokens({
+      colors: [color('primary', '#1976d2'), color('legacy-blue', '#1a73e8')],
+      spacing: { 4: '20px' },
+    })
+    const b = tokens({
+      colors: [color('primary', '#1f77d8'), color('accent', '#f59e0b')],
+      spacing: { 5: '20px' },
+    })
+    const out = diffTokens(a, b).print()
+    expect(out).toContain('colors')
+    expect(out).toContain('+ accent (#f59e0b)')
+    expect(out).toContain('~ primary: #1976d2 → #1f77d8')
+    expect(out).toContain('– legacy-blue (was #1a73e8)')
+    expect(out).toContain('↻ renamed "4" → "5" (value 20px)')
+  })
+
+  it('renders scale stop changes as name.stop lines', () => {
+    const a = tokens({
+      colors: [color('primary', '#1976d2', { 500: '#1976d2' })],
+    })
+    const b = tokens({
+      colors: [color('primary', '#1976d2', { 500: '#1f77d8' })],
+    })
+    const out = diffTokens(a, b).print()
+    expect(out).toContain('~ primary.500: #1976d2 → #1f77d8')
+  })
+
+  it('produces machine-readable JSON via toJSON', () => {
+    const a = tokens({ colors: [color('primary', '#1976d2')] })
+    const b = tokens({ colors: [] })
+    const json = diffTokens(a, b).toJSON()
+    expect(json).toMatchObject({
+      changed: true,
+      breaking: true,
+      summary: { removed: 1 },
+    })
+    expect(Array.isArray(json.changes)).toBe(true)
+    expect(json.changes[0]).toMatchObject({ type: 'removed', name: 'primary' })
+  })
+
+  it('exposes a TokenDiff instance', () => {
+    expect(diffTokens(tokens(), tokens())).toBeInstanceOf(TokenDiff)
+  })
+})
+
+describe('diffFiles', () => {
+  let dir
+  beforeAll(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mint-diff-'))
+  })
+  afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+
+  it('reads two files and returns a diff', async () => {
+    const oldPath = path.join(dir, 'old.json')
+    const newPath = path.join(dir, 'new.json')
+    await fs.writeFile(
+      oldPath,
+      JSON.stringify(tokens({ colors: [color('primary', '#1976d2')] }))
+    )
+    await fs.writeFile(
+      newPath,
+      JSON.stringify(tokens({ colors: [color('primary', '#1f77d8')] }))
+    )
+    const diff = await diffFiles(oldPath, newPath)
+    expect(diff.valueChanged).toHaveLength(1)
+  })
+
+  it('throws a clear error when a file is missing', async () => {
+    await expect(
+      diffFiles(path.join(dir, 'nope.json'), path.join(dir, 'nope2.json'))
+    ).rejects.toThrow(/not found/i)
+  })
+
+  it('throws a clear error on invalid JSON', async () => {
+    const badPath = path.join(dir, 'bad.json')
+    const goodPath = path.join(dir, 'good.json')
+    await fs.writeFile(badPath, '{ not json')
+    await fs.writeFile(goodPath, JSON.stringify(tokens()))
+    await expect(diffFiles(badPath, goodPath)).rejects.toThrow(
+      /not valid JSON/i
+    )
+  })
+})

--- a/lib/token-diff.mjs
+++ b/lib/token-diff.mjs
@@ -1,0 +1,495 @@
+/**
+ * Token Diff — compare two mint-ds tokens.json files and classify what changed.
+ *
+ * Categories of change:
+ *   - added         a token present in the new file but not the old one
+ *   - removed       a token present in the old file but not the new one
+ *   - renamed       same value under a different name (heuristic)
+ *   - value-changed same name, different value
+ *   - scale-changed a color scale whose stops differ (added/removed/changed)
+ *
+ * Breaking changes (removed, value-changed, scale-changed) drive a non-zero
+ * exit code so CI can gate on them. Additions and renames preserve existing
+ * values and are non-breaking.
+ */
+
+export const ChangeType = {
+  ADDED: 'added',
+  REMOVED: 'removed',
+  RENAMED: 'renamed',
+  VALUE_CHANGED: 'value-changed',
+  SCALE_CHANGED: 'scale-changed',
+}
+
+const BREAKING_TYPES = new Set([
+  ChangeType.REMOVED,
+  ChangeType.VALUE_CHANGED,
+  ChangeType.SCALE_CHANGED,
+])
+
+// Display order + labels. Typography sub-records surface under their leaf name.
+const CATEGORY_ORDER = [
+  'brand',
+  'colors',
+  'fontFamilies',
+  'fontSizes',
+  'fontWeights',
+  'lineHeights',
+  'spacing',
+  'borderRadius',
+  'shadows',
+]
+
+const TYPE_PRIORITY = {
+  [ChangeType.ADDED]: 0,
+  [ChangeType.VALUE_CHANGED]: 1,
+  [ChangeType.SCALE_CHANGED]: 2,
+  [ChangeType.RENAMED]: 3,
+  [ChangeType.REMOVED]: 4,
+}
+
+export class TokenDiff {
+  constructor() {
+    this.changes = []
+  }
+
+  add(change) {
+    this.changes.push(change)
+  }
+
+  get added() {
+    return this.changes.filter((c) => c.type === ChangeType.ADDED)
+  }
+
+  get removed() {
+    return this.changes.filter((c) => c.type === ChangeType.REMOVED)
+  }
+
+  get renamed() {
+    return this.changes.filter((c) => c.type === ChangeType.RENAMED)
+  }
+
+  get valueChanged() {
+    return this.changes.filter((c) => c.type === ChangeType.VALUE_CHANGED)
+  }
+
+  get scaleChanged() {
+    return this.changes.filter((c) => c.type === ChangeType.SCALE_CHANGED)
+  }
+
+  get breaking() {
+    return this.changes.filter((c) => BREAKING_TYPES.has(c.type))
+  }
+
+  get hasChanges() {
+    return this.changes.length > 0
+  }
+
+  get hasBreakingChanges() {
+    return this.breaking.length > 0
+  }
+
+  // 0 = no breaking changes, 1 = breaking changes present.
+  get exitCode() {
+    return this.hasBreakingChanges ? 1 : 0
+  }
+
+  toJSON() {
+    return {
+      changed: this.hasChanges,
+      breaking: this.hasBreakingChanges,
+      summary: {
+        added: this.added.length,
+        removed: this.removed.length,
+        renamed: this.renamed.length,
+        valueChanged: this.valueChanged.length,
+        scaleChanged: this.scaleChanged.length,
+      },
+      changes: this.changes,
+    }
+  }
+
+  print() {
+    if (!this.hasChanges) return '✓ No changes between token files'
+
+    const byCategory = new Map()
+    for (const change of this.changes) {
+      if (!byCategory.has(change.category)) byCategory.set(change.category, [])
+      byCategory.get(change.category).push(change)
+    }
+
+    const seen = new Set()
+    const orderedCategories = [
+      ...CATEGORY_ORDER.filter((c) => byCategory.has(c)),
+      ...[...byCategory.keys()].filter((c) => !CATEGORY_ORDER.includes(c)),
+    ]
+
+    const lines = []
+    for (const category of orderedCategories) {
+      if (seen.has(category)) continue
+      seen.add(category)
+      const changes = byCategory.get(category)
+      lines.push(category)
+      const sorted = [...changes].sort((a, b) => {
+        const pa = TYPE_PRIORITY[a.type] ?? 9
+        const pb = TYPE_PRIORITY[b.type] ?? 9
+        if (pa !== pb) return pa - pb
+        return keyOf(a).localeCompare(keyOf(b))
+      })
+      for (const change of sorted) {
+        for (const line of renderChange(change)) lines.push(line)
+      }
+    }
+
+    lines.push('')
+    lines.push(this.summaryLine())
+    return lines.join('\n')
+  }
+
+  summaryLine() {
+    const counts = [
+      ['added', this.added.length],
+      ['removed', this.removed.length],
+      ['renamed', this.renamed.length],
+      ['value-changed', this.valueChanged.length],
+      ['scale-changed', this.scaleChanged.length],
+    ]
+      .filter(([, n]) => n > 0)
+      .map(([label, n]) => `${n} ${label}`)
+    const breaking = this.hasBreakingChanges ? ' — breaking' : ''
+    return `Summary: ${this.changes.length} change(s) — ${counts.join(', ')}${breaking}`
+  }
+}
+
+function keyOf(change) {
+  return String(change.name ?? change.from ?? '')
+}
+
+function fmt(value) {
+  if (value === null || value === undefined) return String(value)
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+function renderChange(change) {
+  switch (change.type) {
+    case ChangeType.ADDED:
+      return [`  + ${change.name} (${fmt(change.value)})`]
+    case ChangeType.REMOVED:
+      return [`  – ${change.name} (was ${fmt(change.value)})`]
+    case ChangeType.RENAMED:
+      return [
+        `  ↻ renamed "${change.from}" → "${change.to}" (value ${fmt(change.value)})`,
+      ]
+    case ChangeType.VALUE_CHANGED:
+      return [
+        `  ~ ${change.name}: ${fmt(change.oldValue)} → ${fmt(change.newValue)}`,
+      ]
+    case ChangeType.SCALE_CHANGED:
+      return change.stops.map((stop) => renderStop(change.name, stop))
+    default:
+      return []
+  }
+}
+
+function renderStop(name, stop) {
+  if (stop.type === ChangeType.ADDED) {
+    return `  + ${name}.${stop.stop} (${fmt(stop.newValue)})`
+  }
+  if (stop.type === ChangeType.REMOVED) {
+    return `  – ${name}.${stop.stop} (was ${fmt(stop.oldValue)})`
+  }
+  return `  ~ ${name}.${stop.stop}: ${fmt(stop.oldValue)} → ${fmt(stop.newValue)}`
+}
+
+// ─── Comparison helpers ─────────────────────────────────────────────────────
+
+function valuesEqual(a, b) {
+  if (a === b) return true
+  if (a && b && typeof a === 'object' && typeof b === 'object') {
+    return JSON.stringify(a) === JSON.stringify(b)
+  }
+  return false
+}
+
+function asObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : {}
+}
+
+function colorMap(colors) {
+  const map = new Map()
+  if (Array.isArray(colors)) {
+    for (const c of colors) {
+      if (c && typeof c.name === 'string') map.set(c.name, c)
+    }
+  }
+  return map
+}
+
+function sortStops(keys) {
+  return [...keys].sort((a, b) => {
+    const na = Number(a)
+    const nb = Number(b)
+    if (Number.isFinite(na) && Number.isFinite(nb)) return na - nb
+    return String(a).localeCompare(String(b))
+  })
+}
+
+/**
+ * Greedy 1:1 rename pairing: an old name and a new name that share the same
+ * value are treated as a rename. Returns the pairing plus the leftovers.
+ */
+function pairRenames(onlyOld, onlyNew, oldValueOf, newValueOf) {
+  const renames = []
+  const usedNew = new Set()
+  const removed = []
+  for (const oldName of onlyOld) {
+    const oldValue = oldValueOf(oldName)
+    let match = null
+    for (const newName of onlyNew) {
+      if (usedNew.has(newName)) continue
+      if (valuesEqual(oldValue, newValueOf(newName))) {
+        match = newName
+        break
+      }
+    }
+    if (match !== null) {
+      renames.push({ from: oldName, to: match, value: oldValue })
+      usedNew.add(match)
+    } else {
+      removed.push(oldName)
+    }
+  }
+  const added = onlyNew.filter((n) => !usedNew.has(n))
+  return { renames, removed, added }
+}
+
+// ─── Category diffs ─────────────────────────────────────────────────────────
+
+function diffBrand(oldTokens, newTokens, diff) {
+  const oldBrand = oldTokens.brand
+  const newBrand = newTokens.brand
+  if (oldBrand === newBrand) return
+  if (oldBrand == null && newBrand != null) {
+    diff.add({
+      category: 'brand',
+      type: ChangeType.ADDED,
+      name: 'brand',
+      value: newBrand,
+    })
+  } else if (oldBrand != null && newBrand == null) {
+    diff.add({
+      category: 'brand',
+      type: ChangeType.REMOVED,
+      name: 'brand',
+      value: oldBrand,
+    })
+  } else {
+    diff.add({
+      category: 'brand',
+      type: ChangeType.VALUE_CHANGED,
+      name: 'brand',
+      oldValue: oldBrand,
+      newValue: newBrand,
+    })
+  }
+}
+
+function diffScale(oldScaleRaw, newScaleRaw) {
+  const oldScale = asObject(oldScaleRaw)
+  const newScale = asObject(newScaleRaw)
+  const stops = []
+  const keys = new Set([...Object.keys(oldScale), ...Object.keys(newScale)])
+  for (const stop of sortStops(keys)) {
+    const inOld = stop in oldScale
+    const inNew = stop in newScale
+    if (inOld && inNew) {
+      if (!valuesEqual(oldScale[stop], newScale[stop])) {
+        stops.push({
+          stop,
+          type: ChangeType.VALUE_CHANGED,
+          oldValue: oldScale[stop],
+          newValue: newScale[stop],
+        })
+      }
+    } else if (inNew) {
+      stops.push({ stop, type: ChangeType.ADDED, newValue: newScale[stop] })
+    } else {
+      stops.push({ stop, type: ChangeType.REMOVED, oldValue: oldScale[stop] })
+    }
+  }
+  return stops
+}
+
+function diffColors(oldColors, newColors, diff) {
+  const oldMap = colorMap(oldColors)
+  const newMap = colorMap(newColors)
+  const oldNames = [...oldMap.keys()]
+  const onlyOld = oldNames.filter((n) => !newMap.has(n))
+  const onlyNew = [...newMap.keys()].filter((n) => !oldMap.has(n))
+  const common = oldNames.filter((n) => newMap.has(n))
+
+  const { renames, removed, added } = pairRenames(
+    onlyOld,
+    onlyNew,
+    (n) => oldMap.get(n).value,
+    (n) => newMap.get(n).value
+  )
+
+  for (const name of added) {
+    diff.add({
+      category: 'colors',
+      type: ChangeType.ADDED,
+      name,
+      value: newMap.get(name).value,
+    })
+  }
+  for (const r of renames) {
+    diff.add({
+      category: 'colors',
+      type: ChangeType.RENAMED,
+      from: r.from,
+      to: r.to,
+      value: r.value,
+    })
+  }
+  for (const name of removed) {
+    diff.add({
+      category: 'colors',
+      type: ChangeType.REMOVED,
+      name,
+      value: oldMap.get(name).value,
+    })
+  }
+  for (const name of common) {
+    const oldColor = oldMap.get(name)
+    const newColor = newMap.get(name)
+    if (!valuesEqual(oldColor.value, newColor.value)) {
+      diff.add({
+        category: 'colors',
+        type: ChangeType.VALUE_CHANGED,
+        name,
+        oldValue: oldColor.value,
+        newValue: newColor.value,
+      })
+    }
+    const stops = diffScale(oldColor.scale, newColor.scale)
+    if (stops.length > 0) {
+      diff.add({
+        category: 'colors',
+        type: ChangeType.SCALE_CHANGED,
+        name,
+        stops,
+      })
+    }
+  }
+}
+
+function diffRecord(category, oldRaw, newRaw, diff) {
+  const oldObj = asObject(oldRaw)
+  const newObj = asObject(newRaw)
+  const oldKeys = Object.keys(oldObj)
+  const onlyOld = oldKeys.filter((k) => !(k in newObj))
+  const onlyNew = Object.keys(newObj).filter((k) => !(k in oldObj))
+  const common = oldKeys.filter((k) => k in newObj)
+
+  const { renames, removed, added } = pairRenames(
+    onlyOld,
+    onlyNew,
+    (k) => oldObj[k],
+    (k) => newObj[k]
+  )
+
+  for (const name of added) {
+    diff.add({ category, type: ChangeType.ADDED, name, value: newObj[name] })
+  }
+  for (const r of renames) {
+    diff.add({
+      category,
+      type: ChangeType.RENAMED,
+      from: r.from,
+      to: r.to,
+      value: r.value,
+    })
+  }
+  for (const name of removed) {
+    diff.add({ category, type: ChangeType.REMOVED, name, value: oldObj[name] })
+  }
+  for (const name of common) {
+    if (!valuesEqual(oldObj[name], newObj[name])) {
+      diff.add({
+        category,
+        type: ChangeType.VALUE_CHANGED,
+        name,
+        oldValue: oldObj[name],
+        newValue: newObj[name],
+      })
+    }
+  }
+}
+
+/**
+ * Compare two parsed mint-ds tokens objects.
+ * @param {object} oldTokens
+ * @param {object} newTokens
+ * @returns {TokenDiff}
+ */
+export function diffTokens(oldTokens, newTokens) {
+  const diff = new TokenDiff()
+  const oldT = oldTokens && typeof oldTokens === 'object' ? oldTokens : {}
+  const newT = newTokens && typeof newTokens === 'object' ? newTokens : {}
+
+  diffBrand(oldT, newT, diff)
+  diffColors(oldT.colors, newT.colors, diff)
+
+  const oldTypo = asObject(oldT.typography)
+  const newTypo = asObject(newT.typography)
+  for (const sub of [
+    'fontFamilies',
+    'fontSizes',
+    'fontWeights',
+    'lineHeights',
+  ]) {
+    diffRecord(sub, oldTypo[sub], newTypo[sub], diff)
+  }
+
+  diffRecord('spacing', oldT.spacing, newT.spacing, diff)
+  diffRecord('borderRadius', oldT.borderRadius, newT.borderRadius, diff)
+  diffRecord('shadows', oldT.shadows, newT.shadows, diff)
+
+  return diff
+}
+
+async function loadTokens(filePath) {
+  const { promises: fs } = await import('node:fs')
+  let content
+  try {
+    content = await fs.readFile(filePath, 'utf8')
+  } catch {
+    throw new Error(`Tokens file not found: ${filePath}`)
+  }
+  try {
+    return JSON.parse(content)
+  } catch (err) {
+    throw new Error(
+      `Tokens file is not valid JSON: ${filePath} (${err.message})`
+    )
+  }
+}
+
+/**
+ * Load two tokens.json files from disk and diff them.
+ * @param {string} oldPath
+ * @param {string} newPath
+ * @returns {Promise<TokenDiff>}
+ */
+export async function diffFiles(oldPath, newPath) {
+  const oldTokens = await loadTokens(oldPath)
+  const newTokens = await loadTokens(newPath)
+  return diffTokens(oldTokens, newTokens)
+}
+
+const TokenDiffer = { diffTokens, diffFiles, TokenDiff, ChangeType }
+export default TokenDiffer

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lib/audit-summary.mjs",
     "lib/css-compat-data.mjs",
     "lib/css-lint-rules.mjs",
+    "lib/token-diff.mjs",
     "lib/llm_providers/**/*.mjs",
     "README.md"
   ],


### PR DESCRIPTION
Closes #34

## What

Adds `mint-ds diff <old.tokens.json> <new.tokens.json>` — a semantic diff of two token files, so a PR reviewer can see *what* changed (a color shifted, a token got renamed, a scale stop moved) instead of hand-diffing JSON.

## How it works

Changes are grouped by category (`colors`, `spacing`, `fontFamilies`, `borderRadius`, `shadows`, `brand`, …) and classified:

| Symbol | Change | Meaning |
| --- | --- | --- |
| `+` | added | New file only |
| `–` | removed | Old file only |
| `↻` | renamed | Same value, different name (heuristic) |
| `~` | value-changed | Same name, different value |
| `~` | scale-changed | A color scale stop added / removed / re-valued |

The classifier maps onto the real (nested) mint-ds schema: `colors[]` with per-color `scale`, `typography.*` sub-records, and the `spacing`/`borderRadius`/`shadows` records.

```
colors
  + accent (#f59e0b)
  ~ primary.500: #1976d2 → #1f77d8
  – legacy-blue (was #1a73e8)
spacing
  ↻ renamed "4" → "5" (value 20px)

Summary: 3 change(s) — 1 added, 1 removed, 1 renamed — breaking
```

`--json` emits machine-readable output for CI / PR bots.

## Exit codes (CI gate)

`0` no breaking changes · `1` breaking changes. **Removed, value-changed and scale-changed** tokens are breaking (they alter what downstream exports emit); additions and renames preserve existing values and exit `0`.

> Design note: the issue defines breaking as "removed or value-changed". I also treat **scale-changed** as breaking, because the issue's own example renders a scale-stop change with the value-change symbol (`~ primary.500: … → …`) and a moved stop changes emitted output. Documented in the README so it's easy to revisit.

## Structure

- `lib/token-diff.mjs` — pure `diffTokens()` / `diffFiles()` + a `TokenDiff` result class with `toJSON()`, `print()`, `exitCode`, mirroring the existing `dtcg-validator.mjs` pattern.
- `bin/mint-ds.mjs` — `cmdDiff`, dispatch, help (COMMANDS + DIFF OPTIONS + example).
- `README.md` — commands table row + a `### Diff` section (symbols, example, exit codes).
- `package.json` — new module added to the `files` allowlist.

## Verification

- 360 tests pass (25 new); `lib/token-diff.mjs` at 96.8% line coverage (threshold 80%).
- `tsc --noEmit`, ESLint, and Prettier all clean.
- CLI exercised end-to-end: human report, `--json`, and every exit path (no-change → 0, additive → 0, breaking → 1, missing-file / invalid-JSON / missing-arg → 1).

## Note

Trivially overlaps with #89 (both add lines to `package.json` `files`); they touch different entries and merge cleanly in either order.