### PR TITLE
ci: guard that bin-reachable lib files ship in the npm tarball

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,6 @@ jobs:
 
       - run: npm run test:coverage
 
+      - run: npm run check:pack
+
       - run: npm run build

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "vitest run",
+    "check:pack": "node scripts/check-pack.mjs",
+    "prepublishOnly": "vitest run && npm run check:pack",
     "prepare": "husky",
     "release": "GITHUB_TOKEN=$(gh auth token) release-it",
     "release:dry": "GITHUB_TOKEN=$(gh auth token) release-it --dry-run"

--- a/scripts/__tests__/check-pack.test.mjs
+++ b/scripts/__tests__/check-pack.test.mjs
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { parseLocalDeps, collectReachableFiles } from '../check-pack.mjs'
+
+describe('parseLocalDeps', () => {
+  it('extracts relative specifiers from import/export/require/dynamic-import forms', () => {
+    const source = `
+      import { a } from '../lib/foo.mjs'
+      import '../lib/side-effect.mjs'
+      export { b } from './bar.mjs'
+      const pkg = require('../package.json')
+      const mod = await import('./dyn.mjs')
+    `
+    expect(parseLocalDeps(source).sort()).toEqual(
+      [
+        '../lib/foo.mjs',
+        '../lib/side-effect.mjs',
+        './bar.mjs',
+        '../package.json',
+        './dyn.mjs',
+      ].sort()
+    )
+  })
+
+  it('ignores bare specifiers and node: builtins', () => {
+    const source = `
+      import { features } from 'web-features'
+      import { promises as fs } from 'node:fs'
+      const bl = require('browserslist')
+      import x from '@scope/pkg'
+    `
+    expect(parseLocalDeps(source)).toEqual([])
+  })
+
+  it('deduplicates repeated specifiers', () => {
+    const source = `
+      import { a } from './x.mjs'
+      import { b } from './x.mjs'
+    `
+    expect(parseLocalDeps(source)).toEqual(['./x.mjs'])
+  })
+})
+
+describe('collectReachableFiles', () => {
+  let root
+  beforeAll(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'pack-check-'))
+    await fs.mkdir(path.join(root, 'bin'))
+    await fs.mkdir(path.join(root, 'lib'))
+    await fs.writeFile(
+      path.join(root, 'bin/entry.mjs'),
+      `import { a } from '../lib/a.mjs'\nimport { features } from 'web-features'\n`
+    )
+    await fs.writeFile(
+      path.join(root, 'lib/a.mjs'),
+      `import { b } from './b.mjs'\nconst pkg = require('../package.json')\n`
+    )
+    await fs.writeFile(path.join(root, 'lib/b.mjs'), `export const b = 1\n`)
+    await fs.writeFile(path.join(root, 'package.json'), `{"name":"fixture"}\n`)
+  })
+  afterAll(async () => {
+    await fs.rm(root, { recursive: true, force: true })
+  })
+
+  it('returns the transitive set of local files reachable from the entry (incl. the entry)', async () => {
+    const reachable = await collectReachableFiles(
+      path.join(root, 'bin/entry.mjs'),
+      root
+    )
+    expect([...reachable].sort()).toEqual(
+      ['bin/entry.mjs', 'lib/a.mjs', 'lib/b.mjs', 'package.json'].sort()
+    )
+  })
+
+  it('does not include bare npm dependencies', async () => {
+    const reachable = await collectReachableFiles(
+      path.join(root, 'bin/entry.mjs'),
+      root
+    )
+    expect([...reachable].some((f) => f.includes('web-features'))).toBe(false)
+  })
+
+  it('skips relative specifiers that do not resolve to an existing file', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pack-check-missing-'))
+    await fs.writeFile(
+      path.join(dir, 'entry.mjs'),
+      `import { x } from './does-not-exist.mjs'\n`
+    )
+    const reachable = await collectReachableFiles(
+      path.join(dir, 'entry.mjs'),
+      dir
+    )
+    expect([...reachable]).toEqual(['entry.mjs'])
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+})

--- a/scripts/check-pack.mjs
+++ b/scripts/check-pack.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * check-pack — guardrail against the "lib file left out of package.json `files`"
+ * publish bug (see #79, #89).
+ *
+ * Walks the static import graph from every `bin` entry, collecting the local
+ * modules the CLI needs at runtime, then compares that against the files npm
+ * would actually publish (`npm pack --dry-run`). Any reachable local file that
+ * would NOT ship fails the check with a non-zero exit code.
+ *
+ * Run via `npm run check:pack` (also wired into `prepublishOnly` and CI).
+ */
+
+import { promises as fs } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import process from 'node:process'
+
+const SOURCE_EXTS = new Set(['.mjs', '.js', '.cjs', '.ts', '.tsx', '.jsx'])
+// Extension candidates tried when a relative specifier has no usable extension.
+const RESOLVE_EXTS = ['.mjs', '.js', '.cjs', '.ts', '.tsx', '.jsx', '.json']
+
+/**
+ * Extract relative module specifiers (starting with '.') from source code.
+ * Covers `import ... from`, side-effect `import`, `export ... from`,
+ * `require(...)`, and dynamic `import(...)`. Bare specifiers (npm packages,
+ * `node:` builtins) are ignored.
+ * @param {string} source
+ * @returns {string[]} unique relative specifiers, in first-seen order
+ */
+export function parseLocalDeps(source) {
+  const patterns = [
+    /(?:^|[^.\w])(?:import|export)\s[^;'"]*?\sfrom\s*['"]([^'"]+)['"]/g,
+    /(?:^|[^.\w])import\s*['"]([^'"]+)['"]/g,
+    /(?:^|[^.\w])import\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+    /(?:^|[^.\w])require\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ]
+  const found = []
+  const seen = new Set()
+  for (const re of patterns) {
+    let match
+    while ((match = re.exec(source)) !== null) {
+      const spec = match[1]
+      if (spec.startsWith('.') && !seen.has(spec)) {
+        seen.add(spec)
+        found.push(spec)
+      }
+    }
+  }
+  return found
+}
+
+async function fileExists(p) {
+  try {
+    const stat = await fs.stat(p)
+    return stat.isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve a relative specifier from an importer file to an existing file path,
+ * or null if it does not resolve. Tries the literal path, common extensions,
+ * and `<spec>/index.*`.
+ */
+async function resolveLocalSpecifier(importerFile, spec) {
+  const base = path.resolve(path.dirname(importerFile), spec)
+  if (await fileExists(base)) return base
+  for (const ext of RESOLVE_EXTS) {
+    if (await fileExists(base + ext)) return base + ext
+  }
+  for (const ext of RESOLVE_EXTS) {
+    const indexed = path.join(base, 'index' + ext)
+    if (await fileExists(indexed)) return indexed
+  }
+  return null
+}
+
+function toPosixRelative(repoRoot, absPath) {
+  return path.relative(repoRoot, absPath).split(path.sep).join('/')
+}
+
+/**
+ * Breadth-first walk of the import graph starting at `entryFile`. Returns the
+ * set of repo-relative (posix) paths of every local file reachable from the
+ * entry, including the entry itself. Relative specifiers that do not resolve to
+ * an existing file, and files outside `repoRoot`, are skipped.
+ * @param {string} entryFile absolute path to the entry module
+ * @param {string} repoRoot absolute path to the repo root
+ * @returns {Promise<Set<string>>}
+ */
+export async function collectReachableFiles(entryFile, repoRoot) {
+  const reachable = new Set()
+  const visited = new Set()
+  const queue = [path.resolve(entryFile)]
+
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (visited.has(current)) continue
+    visited.add(current)
+
+    const rel = toPosixRelative(repoRoot, current)
+    if (rel.startsWith('..')) continue // outside the repo — ignore
+    reachable.add(rel)
+
+    if (!SOURCE_EXTS.has(path.extname(current))) continue // e.g. .json — no deps to parse
+
+    let source
+    try {
+      source = await fs.readFile(current, 'utf8')
+    } catch {
+      continue
+    }
+
+    for (const spec of parseLocalDeps(source)) {
+      const resolved = await resolveLocalSpecifier(current, spec)
+      if (resolved && !visited.has(resolved)) queue.push(resolved)
+    }
+  }
+
+  return reachable
+}
+
+/** Read the `bin` entry paths (absolute) from package.json. */
+async function getBinEntries(repoRoot) {
+  const pkg = JSON.parse(
+    await fs.readFile(path.join(repoRoot, 'package.json'), 'utf8')
+  )
+  const bin = pkg.bin
+  const entries =
+    typeof bin === 'string'
+      ? [bin]
+      : bin && typeof bin === 'object'
+        ? Object.values(bin)
+        : []
+  return entries.map((e) => path.resolve(repoRoot, e))
+}
+
+/** The set of repo-relative (posix) paths npm would publish. */
+function getPackedFiles(repoRoot) {
+  const out = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  })
+  const parsed = JSON.parse(out)
+  const files = parsed?.[0]?.files ?? []
+  return new Set(files.map((f) => f.path.split(path.sep).join('/')))
+}
+
+/**
+ * Verify every local file reachable from the bin entries would be published.
+ * @returns {Promise<{ ok: boolean, missing: string[], reachable: string[] }>}
+ */
+export async function verifyPackCompleteness(repoRoot = process.cwd()) {
+  const entries = await getBinEntries(repoRoot)
+  const reachable = new Set()
+  for (const entry of entries) {
+    for (const f of await collectReachableFiles(entry, repoRoot)) {
+      reachable.add(f)
+    }
+  }
+  const packed = getPackedFiles(repoRoot)
+  const missing = [...reachable].filter((f) => !packed.has(f)).sort()
+  return { ok: missing.length === 0, missing, reachable: [...reachable].sort() }
+}
+
+async function main() {
+  const repoRoot = process.cwd()
+  let result
+  try {
+    result = await verifyPackCompleteness(repoRoot)
+  } catch (err) {
+    console.error(`✗ check-pack failed to run: ${err.message}`)
+    process.exit(2)
+  }
+
+  if (result.ok) {
+    console.log(
+      `✓ check-pack: all ${result.reachable.length} file(s) reachable from bin are in the published tarball`
+    )
+    process.exit(0)
+  }
+
+  console.error(
+    `✗ check-pack: ${result.missing.length} file(s) imported by the CLI are missing from package.json "files":`
+  )
+  for (const f of result.missing) console.error(`    - ${f}`)
+  console.error(
+    '\n  Add them to the "files" allowlist so they ship in the npm tarball.'
+  )
+  process.exit(1)
+}
+
+// Run only when executed directly, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}


### PR DESCRIPTION
## Why

Twice now a `lib/*.mjs` module imported by the CLI was left out of `package.json` `files`, so the published tarball omitted it and the command crashed with `ERR_MODULE_NOT_FOUND` on an npm-installed copy:

- #79 — `lib/dtcg-validator.mjs` (the `validate` command)
- #89 — `lib/audit-summary.mjs`, `lib/css-compat-data.mjs`, `lib/css-lint-rules.mjs` (`audit` summary, `compat`, `lint`)

Both slipped through because nothing checks that what the CLI imports is actually what gets published. This adds that check.

## What

`scripts/check-pack.mjs`:

1. Reads the `bin` entries from `package.json` and walks the **static import graph** from each (following relative `import` / `export … from` / `require()` / dynamic `import()`, ignoring bare npm and `node:` specifiers).
2. Runs `npm pack --dry-run --json` to get the exact set of files npm would publish.
3. Fails (exit `1`) listing any reachable local module that would **not** ship; otherwise prints a one-line ✓.

Wiring:
- `npm run check:pack` — run it anywhere.
- `prepublishOnly` — `vitest run && npm run check:pack` (blocks a bad publish).
- CI — a `check:pack` step after `test:coverage` (early signal on every PR).

The script lives in `scripts/` (not in `files`), so it is not itself published.

## Verification

- Unit tests for the import-graph parser and walker (`parseLocalDeps`, `collectReachableFiles`) — 6 tests, TDD.
- Against this repo: `✓ all 19 file(s) reachable from bin are in the published tarball` (exit 0).
- Simulated regression: temporarily dropping `lib/css-lint-rules.mjs` from `files` makes it fail with exit 1, naming the missing file — i.e. it would have caught #79 and #89.
- `test:coverage`, `tsc --noEmit`, ESLint, and Prettier all clean; full suite 346 tests.

## Note

Static-graph based: it verifies **local files** ship, not that npm **dependencies** resolve (npm install handles those). That's the exact bug class from #79/#89.