### PR TITLE
feat: add `mint-ds init` command to scaffold a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,9 @@ The committed artifacts ([`mint-ds.tokens.json`](examples/frankenstein/mint-ds.t
 ## CLI
 
 ```bash
+# Optional: scaffold a mint.config.mjs with project defaults
+npx mint-ds init
+
 # Analyze every CSS/SCSS/HTML file in a directory and write mint-ds.tokens.json
 npx mint-ds audit ./src/styles
 
@@ -321,6 +324,7 @@ npx mint-ds export --target tailwind --provider ollama
 
 | Command                          | Description                                                                                                                |
 | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `mint-ds init`                   | Scaffold a `mint.config.mjs` with project defaults (`--force` to overwrite an existing config)                             |
 | `mint-ds audit <dir>`            | Walk `<dir>` for `.css`, `.scss`, `.sass`, `.less`, `.html` files, audit them with Claude, and write `mint-ds.tokens.json` |
 | `mint-ds export --target <name>` | Read `mint-ds.tokens.json` and generate the chosen format                                                                  |
 | `mint-ds validate <file>`        | Validate `tokens.json` against DTCG v1 — structure, references, cycles, naming consistency                                 |
@@ -329,6 +333,34 @@ npx mint-ds export --target tailwind --provider ollama
 | `mint-ds compat <dir>`           | Flag CSS properties below Baseline / Interop 2026 for your browserslist target, with fallback suggestions (no LLM)         |
 | `mint-ds lint <dir>`             | Run static CSS lint rules (gap-decoration hacks) plus a modern-CSS adoption report — no LLM                                |
 | `mint-ds --help`                 | Show full usage                                                                                                            |
+
+### Configuration
+
+Repeating the same flags on every `audit` / `export` gets old. Run `mint-ds init` to scaffold a `mint.config.mjs` in the current directory:
+
+```js
+/** @type {import('mint-ds').MintConfig} */
+export default {
+  // Directory the audit walks by default
+  source: './src/styles',
+  // Default tokens file
+  tokens: 'mint-ds.tokens.json',
+  // Default export target
+  target: 'tailwind',
+  // Where exports are written
+  outDir: './design-system',
+  // Glob patterns excluded from the audit walk
+  ignore: ['**/node_modules/**', '**/dist/**'],
+}
+```
+
+With that file present, `mint-ds audit` (no directory) walks `source`, and `mint-ds export` (no `--target`) emits `tailwind` into `outDir`. **CLI flags always win over config**, which in turn wins over the built-in defaults:
+
+```
+CLI flag  >  mint.config.mjs  >  built-in default
+```
+
+The file is generated as `.mjs` so it loads regardless of whether your project is ESM or CommonJS; existing `mint.config.js` / `mint.config.cjs` are also picked up if you prefer to write your own. `init` refuses to clobber an existing config unless you pass `--force`. Every field is optional.
 
 ### Validate options
 

--- a/bin/__tests__/config-defaults.test.mjs
+++ b/bin/__tests__/config-defaults.test.mjs
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+// Integration tests that mint.config.mjs feeds the audit/export defaults and
+// that CLI flags override config. All assertions hit early validation/`die`
+// paths that run BEFORE any LLM call, so no network or API key is involved.
+const CLI = fileURLToPath(new URL('../mint-ds.mjs', import.meta.url))
+
+function run(cwd, args) {
+  return spawnSync('node', [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, API_KEY: '', ANTHROPIC_API_KEY: '' },
+  })
+}
+
+async function writeConfig(cwd, obj) {
+  const body = `export default ${JSON.stringify(obj, null, 2)}\n`
+  await fs.writeFile(path.join(cwd, 'mint.config.mjs'), body, 'utf8')
+}
+
+let dir
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mint-cfg-'))
+})
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+describe('audit reads config defaults', () => {
+  it('falls back to config.source when no directory is passed', async () => {
+    await writeConfig(dir, { source: './missing-src' })
+    const result = run(dir, ['audit'])
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toMatch(/Path not found: \.\/missing-src/)
+  })
+
+  it('lets a positional directory override config.source', async () => {
+    await writeConfig(dir, { source: './missing-src' })
+    const result = run(dir, ['audit', './other-missing'])
+    expect(result.stderr).toMatch(/Path not found: \.\/other-missing/)
+  })
+
+  it('applies config.ignore to the source walk', async () => {
+    await writeConfig(dir, { ignore: ['**/*.css'] })
+    await fs.mkdir(path.join(dir, 'styles'))
+    await fs.writeFile(path.join(dir, 'styles', 'a.css'), 'a{color:red}\n')
+    const result = run(dir, ['audit', './styles'])
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toMatch(/No CSS.*files found/)
+  })
+})
+
+describe('export reads config defaults', () => {
+  it('uses config.target when --target is absent', async () => {
+    await writeConfig(dir, { target: 'css' })
+    const result = run(dir, ['export'])
+    // Passed target validation using config.target, then failed on tokens.
+    expect(result.stderr).toMatch(/Tokens file not found/)
+    expect(result.stderr).not.toMatch(/--target/)
+  })
+
+  it('uses config.tokens for the input path', async () => {
+    await writeConfig(dir, { target: 'css', tokens: 'custom.tokens.json' })
+    const result = run(dir, ['export'])
+    expect(result.stderr).toMatch(/custom\.tokens\.json/)
+  })
+
+  it('lets --tokens override config.tokens', async () => {
+    await writeConfig(dir, { target: 'css', tokens: 'cfg.json' })
+    const result = run(dir, ['export', '--tokens', 'flag.json'])
+    expect(result.stderr).toMatch(/flag\.json/)
+    expect(result.stderr).not.toMatch(/cfg\.json/)
+  })
+})

--- a/bin/__tests__/init.test.mjs
+++ b/bin/__tests__/init.test.mjs
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs, existsSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+// Integration tests for `mint-ds init`. The CLI runs as a real child process
+// (no network, no LLM), so we can drive it end-to-end and assert on exit codes.
+const CLI = fileURLToPath(new URL('../mint-ds.mjs', import.meta.url))
+
+function runInit(cwd, args = []) {
+  return spawnSync('node', [CLI, 'init', ...args], { cwd, encoding: 'utf8' })
+}
+
+let dir
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mint-init-'))
+})
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+describe('mint-ds init', () => {
+  it('scaffolds mint.config.mjs and exits 0', () => {
+    const result = runInit(dir)
+    expect(result.status).toBe(0)
+    expect(existsSync(path.join(dir, 'mint.config.mjs'))).toBe(true)
+  })
+
+  it('refuses to overwrite an existing config and exits non-zero', () => {
+    runInit(dir)
+    const result = runInit(dir)
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toMatch(/already exists/i)
+  })
+
+  it('overwrites an existing config when --force is passed', () => {
+    runInit(dir)
+    const result = runInit(dir, ['--force'])
+    expect(result.status).toBe(0)
+  })
+})

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -22,6 +22,14 @@ import { diffFiles } from '../lib/token-diff.mjs'
 import { formatLintSummary } from '../lib/audit-summary.mjs'
 import { checkCompat } from '../lib/css-compat-data.mjs'
 import { lintCss, lintGapDecorationAdoption } from '../lib/css-lint-rules.mjs'
+import {
+  DEFAULT_TOKENS_FILE,
+  loadConfig,
+  scaffoldConfig,
+  matchesIgnore,
+  resolveAuditOptions,
+  resolveExportOptions,
+} from '../lib/mint-config.mjs'
 
 const require = createRequire(import.meta.url)
 const { version: VERSION } = require('../package.json')
@@ -33,7 +41,6 @@ const SOURCE_EXTS = new Set([
   '.html',
   '.htm',
 ])
-const DEFAULT_TOKENS_FILE = 'mint-ds.tokens.json'
 const CACHE_FILE = 'mint-ds.cache.json'
 const MAX_CSS_CHARS = 120_000
 
@@ -87,6 +94,7 @@ ${styles.bold('USAGE')}
   npx mint-ds <command> [options]
 
 ${styles.bold('COMMANDS')}
+  init                         Scaffold a mint.config.mjs with project defaults
   audit <dir>                  Analyze CSS/SCSS files in <dir> and write ${DEFAULT_TOKENS_FILE}
   export --target <name>       Generate exports from ${DEFAULT_TOKENS_FILE}
   validate <file> [options]    Validate tokens.json against a spec (e.g. dtcg)
@@ -94,6 +102,9 @@ ${styles.bold('COMMANDS')}
   cache --clear                Delete the local ${CACHE_FILE}
   compat <dir>                 Scan CSS for Interop 2026 browser-compat issues (warnings + suggestions)
   lint <dir>                   Run static CSS lint rules on files in <dir>
+
+${styles.bold('INIT OPTIONS')}
+  --force                      Overwrite an existing mint.config.{mjs,js,cjs}
 
 ${styles.bold('AUDIT OPTIONS')}
   --out <file>                 Tokens output path (default: ${DEFAULT_TOKENS_FILE})
@@ -144,6 +155,7 @@ ${styles.bold('ENVIRONMENT')}
   Precedence: --flag > {PROVIDER}_ENV > generic env > provider default
 
 ${styles.bold('EXAMPLES')}
+  npx mint-ds init
   npx mint-ds audit ./src/styles
   npx mint-ds audit ./src/styles --provider openrouter
   npx mint-ds export --target tailwind
@@ -177,7 +189,7 @@ function parseFlags(argv) {
   return { flags, rest }
 }
 
-async function* walk(dir) {
+async function* walk(dir, root, ignore = []) {
   let entries
   try {
     entries = await fs.readdir(dir, { withFileTypes: true })
@@ -196,8 +208,9 @@ async function* walk(dir) {
     )
       continue
     const full = path.join(dir, entry.name)
+    if (matchesIgnore(path.relative(root, full), ignore)) continue
     if (entry.isDirectory()) {
-      yield* walk(full)
+      yield* walk(full, root, ignore)
     } else if (
       entry.isFile() &&
       SOURCE_EXTS.has(path.extname(entry.name).toLowerCase())
@@ -207,7 +220,7 @@ async function* walk(dir) {
   }
 }
 
-async function collectSources(target) {
+async function collectSources(target, ignore = []) {
   const root = path.resolve(target)
   const stat = await fs.stat(root).catch(() => null)
   if (!stat) die(`Path not found: ${target}`)
@@ -221,7 +234,7 @@ async function collectSources(target) {
     }
     files.push(root)
   } else {
-    for await (const file of walk(root)) files.push(file)
+    for await (const file of walk(root, root, ignore)) files.push(file)
   }
 
   if (files.length === 0) die(`No CSS/SCSS/HTML files found in ${target}`)
@@ -273,16 +286,24 @@ function chaosBadge(score) {
 
 async function cmdAudit(argv) {
   const { flags, rest } = parseFlags(argv)
-  const target = rest[0]
+  const { config } = await loadConfig(process.cwd())
+  const {
+    dir: target,
+    outFile,
+    ignore,
+  } = resolveAuditOptions({
+    flags,
+    rest,
+    config,
+  })
   if (!target) die('Usage: mint-ds audit <directory>')
 
-  const outFile = String(flags.out || DEFAULT_TOKENS_FILE)
   const reportFile = flags.report ? String(flags.report) : null
   const quiet = Boolean(flags.quiet)
   const noCache = Boolean(flags['no-cache'])
 
   log(styles.cyan('→') + ` Reading sources from ${styles.bold(target)}…`)
-  const { files, css } = await collectSources(target)
+  const { files, css } = await collectSources(target, ignore)
   log(
     styles.dim(
       `  ${files.length} file(s), ${(css.length / 1000).toFixed(1)}k chars`
@@ -429,6 +450,17 @@ async function cmdCompat(argv) {
   }
 }
 
+async function cmdInit(argv) {
+  const { flags } = parseFlags(argv)
+  const { path: written } = await scaffoldConfig({
+    cwd: process.cwd(),
+    force: Boolean(flags.force),
+  })
+  const rel = path.relative(process.cwd(), written) || written
+  log(styles.green('✓') + ` Created ${styles.bold(rel)}`)
+  log(styles.dim('  next: npx mint-ds audit ./src/styles'))
+}
+
 async function cmdCache(argv) {
   const { flags } = parseFlags(argv)
   if (flags.clear) {
@@ -512,7 +544,8 @@ async function cmdLint(argv) {
 
 async function cmdExport(argv) {
   const { flags } = parseFlags(argv)
-  const targetInput = flags.target
+  const { config } = await loadConfig(process.cwd())
+  const { targetInput, tokensPath } = resolveExportOptions({ flags, config })
   if (!targetInput || targetInput === true)
     die('Usage: mint-ds export --target <name>  (e.g. tailwind, react, css)')
 
@@ -523,7 +556,6 @@ async function cmdExport(argv) {
     )
   }
 
-  const tokensPath = String(flags.tokens || DEFAULT_TOKENS_FILE)
   const tokensRaw = await fs.readFile(tokensPath, 'utf8').catch(() => null)
   if (tokensRaw === null) {
     die(
@@ -548,11 +580,13 @@ async function cmdExport(argv) {
   }
 
   const meta = EXPORT_OUTPUT[target]
-  const outFile = flags.out ? String(flags.out) : `${meta.filename}.${meta.ext}`
-  await fs.writeFile(outFile, code + '\n', 'utf8')
+  const defaultFilename = `${meta.filename}.${meta.ext}`
+  const { outPath } = resolveExportOptions({ flags, config, defaultFilename })
+  await fs.mkdir(path.dirname(outPath), { recursive: true })
+  await fs.writeFile(outPath, code + '\n', 'utf8')
   log(
     styles.green('✓') +
-      ` Wrote ${styles.bold(outFile)} (${(code.length / 1000).toFixed(1)}k chars)`
+      ` Wrote ${styles.bold(outPath)} (${(code.length / 1000).toFixed(1)}k chars)`
   )
 }
 
@@ -637,7 +671,8 @@ async function main() {
 
   const [cmd, ...rest] = argv
   try {
-    if (cmd === 'audit') await cmdAudit(rest)
+    if (cmd === 'init') await cmdInit(rest)
+    else if (cmd === 'audit') await cmdAudit(rest)
     else if (cmd === 'export') await cmdExport(rest)
     else if (cmd === 'validate') await cmdValidate(rest)
     else if (cmd === 'diff') await cmdDiff(rest)

--- a/lib/__tests__/mint-config.test.mjs
+++ b/lib/__tests__/mint-config.test.mjs
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import {
+  CONFIG_FILENAMES,
+  DEFAULT_CONFIG_FILE,
+  DEFAULT_TOKENS_FILE,
+  findConfigFile,
+  loadConfig,
+  scaffoldConfig,
+  CONFIG_TEMPLATE,
+  matchesIgnore,
+  resolveAuditOptions,
+  resolveExportOptions,
+} from '../mint-config.mjs'
+
+// Temp dirs live under node_modules (gitignored, and within Vite's fs allow
+// list) so loadConfig's dynamic import of a scaffolded config resolves under
+// the Vitest module runner, which will not serve files outside the project.
+const TMP_ROOT = path.join(process.cwd(), 'node_modules', '.tmp-mint-config')
+
+let dir
+beforeEach(async () => {
+  await fs.mkdir(TMP_ROOT, { recursive: true })
+  dir = await fs.mkdtemp(path.join(TMP_ROOT, 'case-'))
+})
+afterEach(async () => {
+  await fs.rm(TMP_ROOT, { recursive: true, force: true })
+})
+
+describe('CONFIG_FILENAMES', () => {
+  it('lists the three recognized filenames in precedence order', () => {
+    expect(CONFIG_FILENAMES).toEqual([
+      'mint.config.mjs',
+      'mint.config.js',
+      'mint.config.cjs',
+    ])
+  })
+})
+
+describe('findConfigFile', () => {
+  it('returns null when no config file is present', () => {
+    expect(findConfigFile(dir)).toBeNull()
+  })
+
+  it('finds mint.config.mjs', async () => {
+    await fs.writeFile(path.join(dir, 'mint.config.mjs'), 'export default {}\n')
+    const found = findConfigFile(dir)
+    expect(path.isAbsolute(found)).toBe(true)
+    expect(path.basename(found)).toBe('mint.config.mjs')
+  })
+
+  it('finds mint.config.js when it is the only variant', async () => {
+    await fs.writeFile(path.join(dir, 'mint.config.js'), 'export default {}\n')
+    expect(path.basename(findConfigFile(dir))).toBe('mint.config.js')
+  })
+
+  it('finds mint.config.cjs when it is the only variant', async () => {
+    await fs.writeFile(
+      path.join(dir, 'mint.config.cjs'),
+      'module.exports = {}\n'
+    )
+    expect(path.basename(findConfigFile(dir))).toBe('mint.config.cjs')
+  })
+
+  it('prefers .mjs over .js and .cjs when several exist', async () => {
+    await fs.writeFile(path.join(dir, 'mint.config.cjs'), 'module.exports={}\n')
+    await fs.writeFile(path.join(dir, 'mint.config.js'), 'export default {}\n')
+    await fs.writeFile(path.join(dir, 'mint.config.mjs'), 'export default {}\n')
+    expect(path.basename(findConfigFile(dir))).toBe('mint.config.mjs')
+  })
+})
+
+describe('loadConfig', () => {
+  it('returns an empty config and null path when no file exists', async () => {
+    const result = await loadConfig(dir)
+    expect(result).toEqual({ config: {}, path: null })
+  })
+
+  it('loads the default export of a valid .mjs config', async () => {
+    await fs.writeFile(
+      path.join(dir, 'mint.config.mjs'),
+      `export default { source: './s', target: 'tailwind' }\n`
+    )
+    const { config, path: p } = await loadConfig(dir)
+    expect(config).toEqual({ source: './s', target: 'tailwind' })
+    expect(path.basename(p)).toBe('mint.config.mjs')
+  })
+
+  it('treats a config without an object default export as empty', async () => {
+    await fs.writeFile(
+      path.join(dir, 'mint.config.mjs'),
+      `export const something = 1\n`
+    )
+    const { config } = await loadConfig(dir)
+    expect(config).toEqual({})
+  })
+
+  it('throws a contextual error when the config file is malformed', async () => {
+    await fs.writeFile(
+      path.join(dir, 'mint.config.mjs'),
+      `export default { oops \n`
+    )
+    await expect(loadConfig(dir)).rejects.toThrow(/mint\.config\.mjs/)
+  })
+})
+
+describe('scaffoldConfig', () => {
+  it('writes mint.config.mjs with the template contents', async () => {
+    const { path: written } = await scaffoldConfig({ cwd: dir })
+    expect(path.basename(written)).toBe(DEFAULT_CONFIG_FILE)
+    const body = await fs.readFile(written, 'utf8')
+    expect(body).toBe(CONFIG_TEMPLATE)
+  })
+
+  it('produces a file that loads into a config with the documented defaults', async () => {
+    await scaffoldConfig({ cwd: dir })
+    const { config } = await loadConfig(dir)
+    expect(config).toMatchObject({
+      source: expect.any(String),
+      tokens: expect.any(String),
+      target: expect.any(String),
+      outDir: expect.any(String),
+      ignore: expect.arrayContaining(['**/node_modules/**']),
+    })
+  })
+
+  it('refuses to overwrite an existing config file without force', async () => {
+    await fs.writeFile(path.join(dir, 'mint.config.js'), 'export default {}\n')
+    await expect(scaffoldConfig({ cwd: dir })).rejects.toThrow(
+      /already exists/i
+    )
+  })
+
+  it('overwrites an existing config when force is true', async () => {
+    await fs.writeFile(path.join(dir, 'mint.config.mjs'), '// stale sentinel\n')
+    await scaffoldConfig({ cwd: dir, force: true })
+    const body = await fs.readFile(path.join(dir, 'mint.config.mjs'), 'utf8')
+    expect(body).toBe(CONFIG_TEMPLATE)
+  })
+})
+
+describe('matchesIgnore', () => {
+  it('matches a top-level and nested node_modules glob', () => {
+    expect(matchesIgnore('node_modules/foo.css', ['**/node_modules/**'])).toBe(
+      true
+    )
+    expect(
+      matchesIgnore('packages/a/node_modules/b.css', ['**/node_modules/**'])
+    ).toBe(true)
+  })
+
+  it('matches a dist glob', () => {
+    expect(matchesIgnore('dist/bundle.css', ['**/dist/**'])).toBe(true)
+  })
+
+  it('treats * as a single path segment wildcard', () => {
+    expect(matchesIgnore('foo.css', ['*.css'])).toBe(true)
+    expect(matchesIgnore('a/foo.css', ['*.css'])).toBe(false)
+  })
+
+  it('treats ? as a single character wildcard', () => {
+    expect(matchesIgnore('a.css', ['?.css'])).toBe(true)
+    expect(matchesIgnore('ab.css', ['?.css'])).toBe(false)
+  })
+
+  it('returns false when nothing matches or there are no patterns', () => {
+    expect(matchesIgnore('src/app.css', ['**/dist/**'])).toBe(false)
+    expect(matchesIgnore('src/app.css', [])).toBe(false)
+    expect(matchesIgnore('src/app.css')).toBe(false)
+  })
+
+  it('normalizes backslash paths before matching', () => {
+    expect(matchesIgnore('dist\\bundle.css', ['**/dist/**'])).toBe(true)
+  })
+})
+
+describe('resolveAuditOptions', () => {
+  it('prefers the positional dir over config.source', () => {
+    const { dir: d } = resolveAuditOptions({
+      rest: ['./cli'],
+      config: { source: './cfg' },
+    })
+    expect(d).toBe('./cli')
+  })
+
+  it('falls back to config.source when no positional dir', () => {
+    const { dir: d } = resolveAuditOptions({
+      rest: [],
+      config: { source: './cfg' },
+    })
+    expect(d).toBe('./cfg')
+  })
+
+  it('prefers --out over config.tokens over the built-in default', () => {
+    expect(
+      resolveAuditOptions({
+        flags: { out: 'a.json' },
+        config: { tokens: 'b.json' },
+      }).outFile
+    ).toBe('a.json')
+    expect(resolveAuditOptions({ config: { tokens: 'b.json' } }).outFile).toBe(
+      'b.json'
+    )
+    expect(resolveAuditOptions({}).outFile).toBe(DEFAULT_TOKENS_FILE)
+  })
+
+  it('returns config.ignore as an array, defaulting to empty', () => {
+    expect(
+      resolveAuditOptions({ config: { ignore: ['**/x/**'] } }).ignore
+    ).toEqual(['**/x/**'])
+    expect(resolveAuditOptions({}).ignore).toEqual([])
+  })
+})
+
+describe('resolveExportOptions', () => {
+  it('prefers --target over config.target', () => {
+    expect(
+      resolveExportOptions({
+        flags: { target: 'react' },
+        config: { target: 'vue' },
+      }).targetInput
+    ).toBe('react')
+    expect(
+      resolveExportOptions({ config: { target: 'vue' } }).targetInput
+    ).toBe('vue')
+  })
+
+  it('prefers --tokens over config.tokens over the default for the input path', () => {
+    expect(
+      resolveExportOptions({
+        flags: { tokens: 'in.json' },
+        config: { tokens: 'c.json' },
+      }).tokensPath
+    ).toBe('in.json')
+    expect(
+      resolveExportOptions({ config: { tokens: 'c.json' } }).tokensPath
+    ).toBe('c.json')
+    expect(resolveExportOptions({}).tokensPath).toBe(DEFAULT_TOKENS_FILE)
+  })
+
+  it('uses --out verbatim for the output path when given', () => {
+    expect(
+      resolveExportOptions({
+        flags: { out: 'ui/Comp.tsx' },
+        config: { outDir: './ds' },
+        defaultFilename: 'tailwind.config.js',
+      }).outPath
+    ).toBe('ui/Comp.tsx')
+  })
+
+  it('joins config.outDir with the default filename when --out is absent', () => {
+    expect(
+      resolveExportOptions({
+        config: { outDir: './ds' },
+        defaultFilename: 'tailwind.config.js',
+      }).outPath
+    ).toBe(path.join('./ds', 'tailwind.config.js'))
+  })
+
+  it('writes to the current directory when neither --out nor outDir is set', () => {
+    expect(
+      resolveExportOptions({ defaultFilename: 'variables.css' }).outPath
+    ).toBe(path.join('.', 'variables.css'))
+  })
+})

--- a/lib/mint-config.mjs
+++ b/lib/mint-config.mjs
@@ -1,0 +1,193 @@
+// Mint config loading and scaffolding.
+//
+// `mint-ds init` writes a `mint.config.mjs` (see CONFIG_TEMPLATE), and the
+// audit/export commands load it as a source of defaults. CLI flags always win
+// over config values; config values win over the built-in defaults.
+//
+// The scaffolded file uses `.mjs` on purpose: the package is not `type:module`
+// and most consumer projects are CommonJS, so a `mint.config.js` with
+// `export default` would throw when loaded via dynamic import. `.mjs` always
+// loads as ESM regardless of the host project. An existing `.js`/`.cjs` is
+// still recognized by findConfigFile/loadConfig if the user creates one.
+
+import { existsSync, promises as fs } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
+
+/** Tokens filename used when neither a flag nor config supplies one. */
+export const DEFAULT_TOKENS_FILE = 'mint-ds.tokens.json'
+
+/** Recognized config filenames, in resolution precedence order. */
+export const CONFIG_FILENAMES = [
+  'mint.config.mjs',
+  'mint.config.js',
+  'mint.config.cjs',
+]
+
+/** Filename `mint-ds init` scaffolds. */
+export const DEFAULT_CONFIG_FILE = 'mint.config.mjs'
+
+/** Contents written by `mint-ds init`. */
+export const CONFIG_TEMPLATE = `/** @type {import('mint-ds').MintConfig} */
+export default {
+  // Directory the audit walks by default
+  source: './src/styles',
+  // Default tokens file
+  tokens: '${DEFAULT_TOKENS_FILE}',
+  // Default export target
+  target: 'tailwind',
+  // Where exports are written
+  outDir: './design-system',
+  // Glob patterns excluded from the audit walk
+  ignore: ['**/node_modules/**', '**/dist/**'],
+}
+`
+
+/**
+ * Resolve the first existing config file in `cwd`, honoring CONFIG_FILENAMES
+ * precedence. Returns an absolute path, or null when none exists.
+ * @param {string} [cwd]
+ * @returns {string | null}
+ */
+export function findConfigFile(cwd = process.cwd()) {
+  for (const name of CONFIG_FILENAMES) {
+    const candidate = path.join(cwd, name)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+/**
+ * Load the mint config from `cwd`. Returns the parsed default export (or an
+ * empty object when there is no default object export) along with the resolved
+ * path. When no config file exists, returns `{ config: {}, path: null }`.
+ * Throws a contextual error when the config file fails to load.
+ * @param {string} [cwd]
+ * @returns {Promise<{ config: object, path: string | null }>}
+ */
+export async function loadConfig(cwd = process.cwd()) {
+  const configPath = findConfigFile(cwd)
+  if (!configPath) return { config: {}, path: null }
+
+  let mod
+  try {
+    mod = await import(pathToFileURL(configPath).href)
+  } catch (err) {
+    const detail = err && err.message ? err.message : String(err)
+    throw new Error(
+      `Failed to load config ${path.basename(configPath)}: ${detail}`
+    )
+  }
+
+  const value = mod?.default
+  const config = value && typeof value === 'object' ? value : {}
+  return { config, path: configPath }
+}
+
+/**
+ * Write CONFIG_TEMPLATE to `mint.config.mjs` in `cwd`. Refuses to overwrite any
+ * existing config variant unless `force` is set.
+ * @param {{ cwd?: string, force?: boolean }} [opts]
+ * @returns {Promise<{ path: string }>}
+ */
+export async function scaffoldConfig({
+  cwd = process.cwd(),
+  force = false,
+} = {}) {
+  const existing = findConfigFile(cwd)
+  if (existing && !force) {
+    throw new Error(
+      `${path.basename(existing)} already exists. Re-run with --force to overwrite it.`
+    )
+  }
+  const target = path.join(cwd, DEFAULT_CONFIG_FILE)
+  await fs.writeFile(target, CONFIG_TEMPLATE, 'utf8')
+  return { path: target }
+}
+
+/**
+ * Convert a glob pattern (`**`, `*`, `?`) to an anchored RegExp. `**` matches
+ * across path separators (including zero leading segments); `*` and `?` stay
+ * within a single segment.
+ * @param {string} glob
+ * @returns {RegExp}
+ */
+function globToRegExp(glob) {
+  let re = ''
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        re += '.*'
+        i++
+        if (glob[i + 1] === '/') i++ // let **/ match zero directories too
+      } else {
+        re += '[^/]*'
+      }
+    } else if (c === '?') {
+      re += '[^/]'
+    } else if ('.+^${}()|[]\\/'.includes(c)) {
+      re += '\\' + c
+    } else {
+      re += c
+    }
+  }
+  return new RegExp(`^${re}$`)
+}
+
+/**
+ * Test a repo-relative path against a list of ignore globs. Paths are
+ * normalized to posix separators before matching.
+ * @param {string} relPath
+ * @param {string[]} [patterns]
+ * @returns {boolean}
+ */
+export function matchesIgnore(relPath, patterns = []) {
+  if (!patterns || patterns.length === 0) return false
+  const normalized = relPath.split('\\').join('/')
+  return patterns.some((pattern) => globToRegExp(pattern).test(normalized))
+}
+
+/**
+ * Resolve audit options from CLI flags/positional args and config, with the
+ * precedence: flag > config > built-in default.
+ * @param {{ flags?: object, rest?: string[], config?: object }} [input]
+ */
+export function resolveAuditOptions({
+  flags = {},
+  rest = [],
+  config = {},
+} = {}) {
+  return {
+    dir: rest[0] ?? config.source,
+    outFile: flags.out
+      ? String(flags.out)
+      : (config.tokens ?? DEFAULT_TOKENS_FILE),
+    ignore: Array.isArray(config.ignore) ? config.ignore : [],
+  }
+}
+
+/**
+ * Resolve export options from CLI flags and config, with the precedence:
+ * flag > config > built-in default. `defaultFilename` is the export target's
+ * natural output filename (e.g. `tailwind.config.js`).
+ * @param {{ flags?: object, config?: object, defaultFilename?: string }} [input]
+ */
+export function resolveExportOptions({
+  flags = {},
+  config = {},
+  defaultFilename,
+} = {}) {
+  return {
+    targetInput: flags.target ?? config.target,
+    tokensPath: flags.tokens
+      ? String(flags.tokens)
+      : (config.tokens ?? DEFAULT_TOKENS_FILE),
+    outPath: flags.out
+      ? String(flags.out)
+      : defaultFilename != null
+        ? path.join(config.outDir ?? '.', defaultFilename)
+        : undefined,
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -53,6 +53,24 @@ export interface ExportConfig {
   description: string
 }
 
+/**
+ * Project configuration read from `mint.config.{mjs,js,cjs}`. Every field is
+ * optional; CLI flags always take precedence over these values, which in turn
+ * take precedence over the built-in defaults. Scaffold one with `mint-ds init`.
+ */
+export interface MintConfig {
+  /** Directory the audit walks when no `<dir>` argument is given. */
+  source?: string
+  /** Tokens file path — the audit output and the export input default. */
+  tokens?: string
+  /** Default export target (a CLI alias such as `tailwind`, or a full name). */
+  target?: string
+  /** Directory exports are written to when `--out` is not passed. */
+  outDir?: string
+  /** Glob patterns excluded from the audit walk (e.g. `dist/**`). */
+  ignore?: string[]
+}
+
 // ─── CSS Audit Wizard ─────────────────────────────────────────────────────────
 
 export interface ColorSample {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lib/css-compat-data.mjs",
     "lib/css-lint-rules.mjs",
     "lib/token-diff.mjs",
+    "lib/mint-config.mjs",
     "lib/llm_providers/**/*.mjs",
     "README.md"
   ],


### PR DESCRIPTION
## What & why

Closes #13. Repeating `--out` / `--target` / `--tokens` on every `audit` / `export` gets old, and there was no canonical place for project-level defaults. This adds a `mint-ds init` command (in the spirit of `eslint --init` / `tsc --init`) plus a config file that supplies those defaults.

## Changes

- **`lib/mint-config.mjs` (new)** — config discovery/loading and scaffolding:
  - `findConfigFile` / `loadConfig` resolve `mint.config.{mjs,js,cjs}` (in that precedence order)
  - `scaffoldConfig` writes a documented `mint.config.mjs`, refusing to overwrite an existing config without `--force`
  - `matchesIgnore` — a minimal glob matcher (`**`, `*`, `?`) for the `ignore` walk
  - `resolveAuditOptions` / `resolveExportOptions` implement **flag > config > built-in default**
- **`bin/mint-ds.mjs`** — `cmdInit`, wired into `main()` and `printHelp()` (COMMANDS, INIT OPTIONS, example). `audit` and `export` now read the config: `audit` honors `source` / `tokens` / `ignore`, `export` honors `target` / `tokens` / `outDir` (and creates `outDir` when missing). CLI flags always win.
- **`lib/types.ts`** — `MintConfig` interface for editor autocomplete.
- **`README.md`** — new **Configuration** section + `init` command row.
- **`package.json`** — ship `lib/mint-config.mjs` (enforced by `check:pack`).

## Design note

The scaffolded file is `.mjs`, not `.js`: the package isn't `type: module` and most consumer projects are CommonJS, so a `mint.config.js` with `export default` would throw when loaded via dynamic `import()`. `.mjs` always loads as ESM regardless of the host project. Existing `.js` / `.cjs` are still picked up if a user writes their own.

## Follow-up (out of scope)

The scaffold's `@type {import('mint-ds').MintConfig}` JSDoc only yields autocomplete for published consumers once the package ships `.d.ts` declarations (a `types` field). Not wired here — kept as the issue specified.

## Verification

- **409 tests pass** (38 new): unit tests for the config module (find/load/scaffold/glob/resolvers) and integration tests spawning the CLI for `init` and config-driven defaults. `mint-config.mjs` at 100% line coverage.
- `typecheck`, `lint`, `prettier --check`, and `check:pack` all green.
- Manual CLI smoke: `init` creates `mint.config.mjs`, a second run refuses (exit 1), and `--force` overwrites.
