### PR TITLE
feat: add design-md export target (DESIGN.md generator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,16 +548,16 @@ Add `mint-ds.cache.json` to `.gitignore` if you don't want to commit it.
 
 ### Export options
 
-| Flag                | Description                                                                                                                                                                                                                                                                         |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--target <name>`   | **Required.** Accepts: `tailwind`, `unocss`, `react`, `vue`, `svelte`, `astro`, `css`, `scss`, `ts`, `css-modules`, `styled`, `emotion`, `vanilla-extract`, `angular`, `angular-legacy`, `solidjs`, `qwik`, `dtcg` (full names like `tailwind-config`, `react-component` also work) |
-| `--tokens <file>`   | Tokens input path (default: `mint-ds.tokens.json`)                                                                                                                                                                                                                                  |
-| `--out <file>`      | Override the default output filename                                                                                                                                                                                                                                                |
-| `--provider <name>` | LLM backend: `anthropic` (default), `ollama`, or `openrouter`                                                                                                                                                                                                                       |
-| `--api-key <value>` | LLM provider API key (overrides all API key env vars)                                                                                                                                                                                                                               |
-| `--model <name>`    | Model name (overrides all model env vars)                                                                                                                                                                                                                                           |
-| `--url <url>`       | API endpoint URL (overrides all URL env vars)                                                                                                                                                                                                                                       |
-| `--stdout`          | Print to stdout instead of writing a file                                                                                                                                                                                                                                           |
+| Flag                | Description                                                                                                                                                                                                                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--target <name>`   | **Required.** Accepts: `tailwind`, `unocss`, `react`, `vue`, `svelte`, `astro`, `css`, `scss`, `ts`, `css-modules`, `styled`, `emotion`, `vanilla-extract`, `angular`, `angular-legacy`, `solidjs`, `qwik`, `dtcg`, `design-md` (full names like `tailwind-config`, `react-component` also work) |
+| `--tokens <file>`   | Tokens input path (default: `mint-ds.tokens.json`)                                                                                                                                                                                                                                               |
+| `--out <file>`      | Override the default output filename                                                                                                                                                                                                                                                             |
+| `--provider <name>` | LLM backend: `anthropic` (default), `ollama`, or `openrouter`                                                                                                                                                                                                                                    |
+| `--api-key <value>` | LLM provider API key (overrides all API key env vars)                                                                                                                                                                                                                                            |
+| `--model <name>`    | Model name (overrides all model env vars)                                                                                                                                                                                                                                                        |
+| `--url <url>`       | API endpoint URL (overrides all URL env vars)                                                                                                                                                                                                                                                    |
+| `--stdout`          | Print to stdout instead of writing a file                                                                                                                                                                                                                                                        |
 
 ### Local development without publishing
 
@@ -581,6 +581,7 @@ node bin/mint-ds.mjs audit ./examples/site --provider ollama
 | Frameworks | Tailwind Config, Styled Components, Emotion Theme, CSS Modules, Vanilla Extract        |
 | Components | React + TypeScript, Vue 3 SFC, Svelte, Astro, Angular, Angular (Legacy), SolidJS, Qwik |
 | Interop    | DTCG (Design Tokens Format Module v1) — for Penpot & Tokens Studio                     |
+| Docs       | DESIGN.md — human-readable design system summary for AI-assisted workflows             |
 
 ## Penpot & DTCG interop
 

--- a/bin/__tests__/export-design-md.test.mjs
+++ b/bin/__tests__/export-design-md.test.mjs
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+
+// The design-md export is fully deterministic (no network, no LLM), so we can
+// drive the real CLI end-to-end and assert on stdout.
+const CLI = fileURLToPath(new URL('../mint-ds.mjs', import.meta.url))
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url))
+const TOKENS = resolve(REPO_ROOT, 'examples/frankenstein/mint-ds.tokens.json')
+
+function runExport(args) {
+  return spawnSync('node', [CLI, 'export', ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  })
+}
+
+describe('mint-ds export --target design-md', () => {
+  it('prints the generated DESIGN.md to stdout and exits 0', () => {
+    const result = runExport([
+      '--target',
+      'design-md',
+      '--tokens',
+      TOKENS,
+      '--stdout',
+    ])
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('# frankenstein Design System')
+    expect(result.stdout).toContain('## Colors')
+    expect(result.stdout).toContain('### primary')
+  })
+
+  it('resolves the "design" alias too', () => {
+    const result = runExport([
+      '--target',
+      'design',
+      '--tokens',
+      TOKENS,
+      '--stdout',
+    ])
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('# frankenstein Design System')
+  })
+})

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -20,6 +20,7 @@ import { getCssAuditor } from '../lib/css-auditor.mjs'
 import { validateFile } from '../lib/dtcg-validator.mjs'
 import { diffFiles } from '../lib/token-diff.mjs'
 import { convertTokensToDTCG, serializeDTCG } from '../lib/dtcg-exporter.mjs'
+import { convertTokensToDesignMd } from '../lib/design-md.mjs'
 import { formatLintSummary } from '../lib/audit-summary.mjs'
 import { checkCompat } from '../lib/css-compat-data.mjs'
 import { lintCss, lintGapDecorationAdoption } from '../lib/css-lint-rules.mjs'
@@ -592,6 +593,9 @@ async function cmdExport(argv) {
     // Deterministic conversion — no LLM
     const dtcg = convertTokensToDTCG(tokens)
     code = serializeDTCG(dtcg)
+  } else if (target === 'design-md') {
+    // Deterministic conversion — no LLM
+    code = convertTokensToDesignMd(tokens)
   } else {
     const cssAuditor = getCssAuditor(flags)
     code = await cssAuditor.export(buildExportPrompt(tokens, target))

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -174,6 +174,7 @@ ${styles.bold('EXAMPLES')}
   npx mint-ds export --target tailwind
   npx mint-ds export --target react --out ui/Components.tsx
   npx mint-ds export --target css --stdout > variables.css
+  npx mint-ds export --target design-md > DESIGN.md
   npx mint-ds validate tokens.json --spec dtcg
   npx mint-ds validate tokens.json --spec dtcg --json
   npx mint-ds diff old.tokens.json mint-ds.tokens.json

--- a/examples/frankenstein/DESIGN.md
+++ b/examples/frankenstein/DESIGN.md
@@ -1,0 +1,146 @@
+# frankenstein Design System
+
+## Colors
+
+### primary
+
+| Step | Value |
+|---|---|
+| 50 | #e3f2fd |
+| 100 | #bbdefb |
+| 200 | #90caf9 |
+| 300 | #64b5f6 |
+| 400 | #42a5f5 |
+| 500 | #1976d2 |
+| 600 | #1565c0 |
+| 700 | #0d47a1 |
+| 800 | #0a3f8f |
+| 900 | #08357d |
+
+### error
+
+| Step | Value |
+|---|---|
+| 50 | #ffebee |
+| 100 | #ffcdd2 |
+| 200 | #ef9a9a |
+| 300 | #e57373 |
+| 400 | #ef5350 |
+| 500 | #e53935 |
+| 600 | #d32f2f |
+| 700 | #c62828 |
+| 800 | #b71c1c |
+| 900 | #a01818 |
+
+### background
+
+| Step | Value |
+|---|---|
+| 50 | #fefefe |
+| 100 | #fdfdfd |
+| 200 | #fafafa |
+| 300 | #f7f7f7 |
+| 400 | #f6f6f6 |
+| 500 | #f5f5f5 |
+| 600 | #e8e8e8 |
+| 700 | #d4d4d4 |
+| 800 | #c0c0c0 |
+| 900 | #a8a8a8 |
+
+### text
+
+| Step | Value |
+|---|---|
+| 50 | #f5f5f5 |
+| 100 | #e0e0e0 |
+| 200 | #bdbdbd |
+| 300 | #9e9e9e |
+| 400 | #757575 |
+| 500 | #212121 |
+| 600 | #1e1e1e |
+| 700 | #1a1a1a |
+| 800 | #171717 |
+| 900 | #141414 |
+
+### border
+
+| Step | Value |
+|---|---|
+| 50 | #f9f9f9 |
+| 100 | #f4f4f4 |
+| 200 | #eeeeee |
+| 300 | #e7e7e7 |
+| 400 | #e2e2e2 |
+| 500 | #dddddd |
+| 600 | #c7c7c7 |
+| 700 | #a8a8a8 |
+| 800 | #8a8a8a |
+| 900 | #6c6c6c |
+
+### surface
+
+| Step | Value |
+|---|---|
+| 50 | #ffffff |
+| 100 | #ffffff |
+| 200 | #ffffff |
+| 300 | #ffffff |
+| 400 | #ffffff |
+| 500 | #ffffff |
+| 600 | #e6e6e6 |
+| 700 | #cccccc |
+| 800 | #b3b3b3 |
+| 900 | #999999 |
+
+### muted
+
+| Step | Value |
+|---|---|
+| 50 | #f2f2f2 |
+| 100 | #e0e0e0 |
+| 200 | #cccccc |
+| 300 | #b3b3b3 |
+| 400 | #8c8c8c |
+| 500 | #666666 |
+| 600 | #5c5c5c |
+| 700 | #4d4d4d |
+| 800 | #404040 |
+| 900 | #333333 |
+
+## Typography
+
+### Font families
+
+| Token | Value |
+|---|---|
+| body | Helvetica Neue |
+
+### Font weights
+
+| Token | Value |
+|---|---|
+| bold | 700 |
+| extrabold | 800 |
+
+## Spacing
+
+| Token | Value |
+|---|---|
+| 1 | 4px |
+| 2 | 8px |
+| 3 | 12px |
+| 5 | 20px |
+| 6 | 24px |
+
+## Border radius
+
+| Token | Value |
+|---|---|
+| sm | 4px |
+| md | 8px |
+
+## Shadows
+
+| Token | Value |
+|---|---|
+| sm | 0 2px 4px rgba(0,0,0,0.1) |

--- a/lib/__tests__/design-md.test.mjs
+++ b/lib/__tests__/design-md.test.mjs
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { convertTokensToDesignMd } from '../design-md.mjs'
 
 describe('convertTokensToDesignMd', () => {
@@ -134,5 +136,21 @@ describe('convertTokensToDesignMd', () => {
     expect(convertTokensToDesignMd(tokens)).toBe(
       convertTokensToDesignMd(tokens)
     )
+  })
+})
+
+describe('golden output', () => {
+  const FIXTURE_DIR = resolve(
+    import.meta.dirname,
+    '../../examples/frankenstein'
+  )
+
+  it('matches the committed frankenstein DESIGN.md exactly', () => {
+    const tokens = JSON.parse(
+      readFileSync(resolve(FIXTURE_DIR, 'mint-ds.tokens.json'), 'utf8')
+    )
+    const output = convertTokensToDesignMd(tokens)
+    const expected = readFileSync(resolve(FIXTURE_DIR, 'DESIGN.md'), 'utf8')
+    expect(output).toBe(expected.trimEnd())
   })
 })

--- a/lib/__tests__/design-md.test.mjs
+++ b/lib/__tests__/design-md.test.mjs
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { convertTokensToDesignMd } from '../design-md.mjs'
+
+describe('convertTokensToDesignMd', () => {
+  it('falls back to "Design System" title when brand is empty/missing', () => {
+    expect(convertTokensToDesignMd({})).toBe('# Design System')
+    expect(convertTokensToDesignMd({ brand: '' })).toBe('# Design System')
+    expect(convertTokensToDesignMd({ brand: '   ' })).toBe('# Design System')
+  })
+
+  it('uses the brand in the title when present', () => {
+    expect(convertTokensToDesignMd({ brand: 'Acme' })).toBe(
+      '# Acme Design System'
+    )
+  })
+
+  it('renders a per-color subsection with a Step | Value table', () => {
+    const md = convertTokensToDesignMd({
+      colors: [{ name: 'primary', scale: { 50: '#eef', 500: '#123456' } }],
+    })
+    expect(md).toContain('## Colors')
+    expect(md).toContain('### primary')
+    expect(md).toContain('| Step | Value |')
+    expect(md).toContain('| 50 | #eef |')
+    expect(md).toContain('| 500 | #123456 |')
+  })
+
+  it('renders a color description as an emphasized note only when non-empty', () => {
+    const withDesc = convertTokensToDesignMd({
+      colors: [
+        {
+          name: 'primary',
+          scale: { 500: '#123' },
+          description: 'Primary actions',
+        },
+      ],
+    })
+    expect(withDesc).toContain('_Primary actions_')
+
+    const withoutDesc = convertTokensToDesignMd({
+      colors: [{ name: 'primary', scale: { 500: '#123' }, description: '' }],
+    })
+    expect(withoutDesc).not.toContain('_')
+  })
+
+  it('skips colors that have no scale', () => {
+    const md = convertTokensToDesignMd({ colors: [{ name: 'ghost' }] })
+    expect(md).not.toContain('### ghost')
+    expect(md).not.toContain('## Colors')
+  })
+
+  it('renders typography sub-maps as Token | Value tables', () => {
+    const md = convertTokensToDesignMd({
+      typography: {
+        fontFamilies: { body: 'Inter' },
+        fontSizes: { base: '16px' },
+        fontWeights: { bold: 700 },
+        lineHeights: { tight: 1.2 },
+      },
+    })
+    expect(md).toContain('## Typography')
+    expect(md).toContain('### Font families')
+    expect(md).toContain('| body | Inter |')
+    expect(md).toContain('### Font sizes')
+    expect(md).toContain('| base | 16px |')
+    expect(md).toContain('### Font weights')
+    expect(md).toContain('| bold | 700 |')
+    expect(md).toContain('### Line heights')
+    expect(md).toContain('| tight | 1.2 |')
+  })
+
+  it('renders motion (from typography.motion) as its own section', () => {
+    const md = convertTokensToDesignMd({
+      typography: {
+        motion: {
+          durations: { fast: '150ms' },
+          easings: { standard: 'cubic-bezier(0.4, 0, 0.2, 1)' },
+        },
+      },
+    })
+    expect(md).toContain('## Motion')
+    expect(md).toContain('### Durations')
+    expect(md).toContain('| fast | 150ms |')
+    expect(md).toContain('### Easings')
+    expect(md).toContain('| standard | cubic-bezier(0.4, 0, 0.2, 1) |')
+  })
+
+  it('renders spacing, border radius and shadows as Token | Value tables', () => {
+    const md = convertTokensToDesignMd({
+      spacing: { 1: '4px' },
+      borderRadius: { sm: '4px' },
+      shadows: { sm: '0 1px 2px rgba(0,0,0,0.05)' },
+    })
+    expect(md).toContain('## Spacing')
+    expect(md).toContain('| 1 | 4px |')
+    expect(md).toContain('## Border radius')
+    expect(md).toContain('| sm | 4px |')
+    expect(md).toContain('## Shadows')
+    expect(md).toContain('| sm | 0 1px 2px rgba(0,0,0,0.05) |')
+  })
+
+  it('omits empty categories entirely (no heading, no empty table)', () => {
+    const md = convertTokensToDesignMd({
+      brand: 'Min',
+      typography: { fontSizes: {}, lineHeights: {} },
+      spacing: {},
+      shadows: {},
+    })
+    expect(md).toBe('# Min Design System')
+  })
+
+  it('is deterministic — identical input yields byte-identical output', () => {
+    const tokens = {
+      brand: 'Acme',
+      colors: [{ name: 'primary', scale: { 500: '#123' } }],
+      spacing: { 1: '4px', 2: '8px' },
+    }
+    expect(convertTokensToDesignMd(tokens)).toBe(
+      convertTokensToDesignMd(tokens)
+    )
+  })
+})

--- a/lib/__tests__/design-md.test.mjs
+++ b/lib/__tests__/design-md.test.mjs
@@ -109,6 +109,22 @@ describe('convertTokensToDesignMd', () => {
     expect(md).toBe('# Min Design System')
   })
 
+  it('escapes pipe characters in table cell values', () => {
+    const md = convertTokensToDesignMd({ spacing: { 1: '4 | 8px' } })
+    expect(md).toContain('| 1 | 4 \\| 8px |')
+  })
+
+  it('renders multiple color subsections', () => {
+    const md = convertTokensToDesignMd({
+      colors: [
+        { name: 'primary', scale: { 500: '#111' } },
+        { name: 'error', scale: { 500: '#222' } },
+      ],
+    })
+    expect(md).toContain('### primary')
+    expect(md).toContain('### error')
+  })
+
   it('is deterministic — identical input yields byte-identical output', () => {
     const tokens = {
       brand: 'Acme',

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -49,6 +49,14 @@ describe('resolveTarget', () => {
     expect(resolveTarget('ve')).toBe('vanilla-extract')
   })
 
+  it('resolves design-md target directly', () => {
+    expect(resolveTarget('design-md')).toBe('design-md')
+  })
+
+  it('resolves the "design" alias to design-md', () => {
+    expect(resolveTarget('design')).toBe('design-md')
+  })
+
   it('returns null for an unknown target', () => {
     expect(resolveTarget('unknown-xyz')).toBeNull()
   })

--- a/lib/design-md.mjs
+++ b/lib/design-md.mjs
@@ -1,0 +1,83 @@
+/**
+ * DESIGN.md generator — deterministic converter from mint-ds.tokens.json
+ * to a human-readable Markdown design-system summary.
+ *
+ * Consumed as context for AI-assisted design workflows (e.g. Claude Design).
+ * No LLM, no I/O. Same input → byte-identical output.
+ *
+ * Mirrors the deterministic approach of lib/dtcg-exporter.mjs.
+ */
+
+function isNonEmptyObject(v) {
+  return (
+    v && typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length > 0
+  )
+}
+
+/** Render a flat map as a `Token | Value` Markdown table. */
+function kvTable(map) {
+  const lines = ['| Token | Value |', '|---|---|']
+  for (const [k, v] of Object.entries(map)) {
+    lines.push(`| ${k} | ${v} |`)
+  }
+  return lines.join('\n')
+}
+
+export function convertTokensToDesignMd(tokens) {
+  const t = tokens && typeof tokens === 'object' ? tokens : {}
+  const out = []
+
+  // Title — brand from the resolved tokens; the schema allows an empty string.
+  const brand =
+    typeof t.brand === 'string' && t.brand.trim() !== '' ? t.brand.trim() : null
+  out.push(`# ${brand ? brand + ' ' : ''}Design System`)
+
+  // Colors — one subsection per color, Step | Value over the scale.
+  if (Array.isArray(t.colors) && t.colors.length > 0) {
+    const blocks = []
+    for (const c of t.colors) {
+      if (!c || typeof c !== 'object' || !isNonEmptyObject(c.scale)) continue
+      const block = [`### ${c.name}`, '', '| Step | Value |', '|---|---|']
+      for (const [step, hex] of Object.entries(c.scale)) {
+        block.push(`| ${step} | ${hex} |`)
+      }
+      if (typeof c.description === 'string' && c.description.trim() !== '') {
+        block.push('', `_${c.description.trim()}_`)
+      }
+      blocks.push(block.join('\n'))
+    }
+    if (blocks.length > 0) out.push('## Colors', blocks.join('\n\n'))
+  }
+
+  // Typography — one Token | Value table per present sub-map.
+  const typo = isNonEmptyObject(t.typography) ? t.typography : {}
+  const typoSections = []
+  if (isNonEmptyObject(typo.fontFamilies))
+    typoSections.push(`### Font families\n\n${kvTable(typo.fontFamilies)}`)
+  if (isNonEmptyObject(typo.fontSizes))
+    typoSections.push(`### Font sizes\n\n${kvTable(typo.fontSizes)}`)
+  if (isNonEmptyObject(typo.fontWeights))
+    typoSections.push(`### Font weights\n\n${kvTable(typo.fontWeights)}`)
+  if (isNonEmptyObject(typo.lineHeights))
+    typoSections.push(`### Line heights\n\n${kvTable(typo.lineHeights)}`)
+  if (typoSections.length > 0)
+    out.push('## Typography', typoSections.join('\n\n'))
+
+  // Motion — sourced from typography.motion, rendered as its own section.
+  const motion = isNonEmptyObject(typo.motion) ? typo.motion : {}
+  const motionSections = []
+  if (isNonEmptyObject(motion.durations))
+    motionSections.push(`### Durations\n\n${kvTable(motion.durations)}`)
+  if (isNonEmptyObject(motion.easings))
+    motionSections.push(`### Easings\n\n${kvTable(motion.easings)}`)
+  if (motionSections.length > 0)
+    out.push('## Motion', motionSections.join('\n\n'))
+
+  // Flat scales.
+  if (isNonEmptyObject(t.spacing)) out.push('## Spacing', kvTable(t.spacing))
+  if (isNonEmptyObject(t.borderRadius))
+    out.push('## Border radius', kvTable(t.borderRadius))
+  if (isNonEmptyObject(t.shadows)) out.push('## Shadows', kvTable(t.shadows))
+
+  return out.join('\n\n')
+}

--- a/lib/design-md.mjs
+++ b/lib/design-md.mjs
@@ -14,11 +14,16 @@ function isNonEmptyObject(v) {
   )
 }
 
+/** Escape `|` in a Markdown table cell so values don't break the table. */
+function cell(v) {
+  return String(v).replace(/\|/g, '\\|')
+}
+
 /** Render a flat map as a `Token | Value` Markdown table. */
 function kvTable(map) {
   const lines = ['| Token | Value |', '|---|---|']
   for (const [k, v] of Object.entries(map)) {
-    lines.push(`| ${k} | ${v} |`)
+    lines.push(`| ${cell(k)} | ${cell(v)} |`)
   }
   return lines.join('\n')
 }
@@ -39,7 +44,7 @@ export function convertTokensToDesignMd(tokens) {
       if (!c || typeof c !== 'object' || !isNonEmptyObject(c.scale)) continue
       const block = [`### ${c.name}`, '', '| Step | Value |', '|---|---|']
       for (const [step, hex] of Object.entries(c.scale)) {
-        block.push(`| ${step} | ${hex} |`)
+        block.push(`| ${cell(step)} | ${cell(hex)} |`)
       }
       if (typeof c.description === 'string' && c.description.trim() !== '') {
         block.push('', `_${c.description.trim()}_`)

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -694,6 +694,7 @@ export const EXPORT_OUTPUT = {
   'qwik-component': { filename: 'components', ext: 'tsx' },
   'vanilla-extract': { filename: 'theme.css', ext: 'ts' },
   dtcg: { filename: 'mint-ds.tokens', ext: 'dtcg.json' },
+  'design-md': { filename: 'DESIGN', ext: 'md' },
 }
 
 // Short aliases the CLI accepts for --target.
@@ -723,6 +724,7 @@ export const TARGET_ALIASES = {
   'vanilla-extract': 'vanilla-extract',
   ve: 'vanilla-extract',
   dtcg: 'dtcg',
+  design: 'design-md',
 }
 
 // Curated short list shown in --help and validation errors. Keeps the public
@@ -746,6 +748,7 @@ export const ADVERTISED_TARGETS = [
   'qwik',
   'vanilla-extract',
   'dtcg',
+  'design-md',
 ]
 
 export function resolveTarget(input) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lib/config.mjs",
     "lib/dtcg-validator.mjs",
     "lib/dtcg-exporter.mjs",
+    "lib/design-md.mjs",
     "lib/audit-summary.mjs",
     "lib/css-compat-data.mjs",
     "lib/css-lint-rules.mjs",


### PR DESCRIPTION
## Summary

Adds a new deterministic `design-md` export target that converts the resolved `mint-ds.tokens.json` into a human-readable `DESIGN.md` — a portable single source of truth for a project's design system, suitable as context for AI-assisted design workflows.

- `mint-ds export --target design-md` (alias `design`) → writes `DESIGN.md`
- Fully deterministic (no LLM / no network), mirroring the existing `dtcg` target
- Sections: Colors (per-color 50–900 scale tables), Typography (families / sizes / weights / line heights), Motion (durations / easings), Spacing, Border radius, Shadows
- Empty categories are omitted; brand falls back to `# Design System`; per-color `description` rendered only when present; table cell values escape `|`

Implemented as a new export target (not a new subcommand), reusing the existing `resolveTarget` / `EXPORT_OUTPUT` / `cmdExport` plumbing (`--out`, `--stdout`).

Closes #26.

## Changes

- `lib/design-md.mjs` — pure `convertTokensToDesignMd(tokens)` converter
- `lib/prompts.mjs` — register the `design-md` target + `design` alias
- `bin/mint-ds.mjs` — deterministic `cmdExport` branch + `--help` example
- `package.json` — add `lib/design-md.mjs` to the published `files`
- `examples/frankenstein/DESIGN.md` — golden snapshot
- `README.md` — document the target

## Test Plan

- [x] Unit tests for the converter (brand fallback, per-color tables, description note, pipe escaping, omit-empty, determinism)
- [x] Golden snapshot against the `frankenstein` fixture
- [x] End-to-end CLI test (`export --target design-md --stdout`, plus `design` alias)
- [x] Full suite green (534 tests)
- [x] `npm run check:pack` passes (new lib file in published tarball)