### PR TITLE
feat(mint): add legacy pattern detection to CSS audit prompt

### DIFF
--- a/components/AuditView.tsx
+++ b/components/AuditView.tsx
@@ -13,7 +13,8 @@ interface LintIssue {
   selector?: string
   rule?: string
   severity: string
-  reason: string
+  reason?: string
+  suggestion?: string
 }
 
 function nearestScaleValue(
@@ -870,7 +871,7 @@ export default function AuditView({ audit, onResolve }: Props) {
                             marginTop: 2,
                           }}
                         >
-                          {issue.reason}
+                          {issue.reason || issue.suggestion || ''}
                         </div>
                       </div>
                     </div>

--- a/lib/__tests__/audit-summary.test.mjs
+++ b/lib/__tests__/audit-summary.test.mjs
@@ -45,6 +45,30 @@ describe('formatLintSummary', () => {
       '1 layout a11y · 1 modern-practice · 1 adoption · 1 overflow'
     )
   })
+
+  it('labels legacyPatterns with shortLabel legacy', () => {
+    const audit = {
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+      overflowSafetyIssues: [],
+      legacyPatterns: [{}, {}],
+    }
+    expect(formatLintSummary(audit)).toBe('2 legacy')
+  })
+
+  it('includes all five categories when all are non-empty', () => {
+    const audit = {
+      layoutA11yIssues: [{}],
+      modernPracticeIssues: [{}],
+      adoptionSuggestions: [{}],
+      overflowSafetyIssues: [{}],
+      legacyPatterns: [{}],
+    }
+    expect(formatLintSummary(audit)).toBe(
+      '1 layout a11y · 1 modern-practice · 1 adoption · 1 overflow · 1 legacy'
+    )
+  })
 })
 
 describe('collectLintGroups', () => {
@@ -93,6 +117,27 @@ describe('collectLintGroups', () => {
       'layoutA11yIssues',
       'adoptionSuggestions',
       'overflowSafetyIssues',
+    ])
+  })
+
+  it('includes legacyPatterns in collectLintGroups', () => {
+    const legacyIssue = {
+      selector: '.clearfix',
+      pattern: 'clearfix-hack',
+      severity: 'suggestion',
+      suggestion: 'Use display: flow-root instead',
+    }
+    const groups = collectLintGroups({
+      layoutA11yIssues: [],
+      overflowSafetyIssues: [],
+      legacyPatterns: [legacyIssue],
+    })
+    expect(groups).toEqual([
+      {
+        key: 'legacyPatterns',
+        label: 'Legacy CSS patterns',
+        issues: [legacyIssue],
+      },
     ])
   })
 })

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -549,3 +549,112 @@ describe('CssAuditor overflowSafetyIssues integration', () => {
     expect(result.overflowSafetyIssues).toBeUndefined()
   })
 })
+
+describe('CssAuditor legacyPatterns integration', () => {
+  it('audit parses response with legacyPatterns', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 4,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+      overflowSafetyIssues: [],
+      legacyPatterns: [
+        {
+          selector: '.vendor-prefix-demo',
+          pattern: 'obsolete-vendor-prefix',
+          severity: 'warning',
+          suggestion:
+            '-webkit-border-radius — remove -vendor- prefix, the unprefixed standard is Baseline Widely Available',
+        },
+        {
+          selector: '.clearfix',
+          pattern: 'clearfix-hack',
+          severity: 'suggestion',
+          suggestion:
+            'Replace the clearfix hack with display: flow-root on the container',
+        },
+        {
+          selector: '.ie-hacks',
+          pattern: 'ie-specific-hack',
+          severity: 'warning',
+          suggestion: 'IE-specific hack — remove entirely (IE is end-of-life)',
+        },
+      ],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.legacyPatterns).toHaveLength(3)
+    expect(result.legacyPatterns[0]).toEqual({
+      selector: '.vendor-prefix-demo',
+      pattern: 'obsolete-vendor-prefix',
+      severity: 'warning',
+      suggestion:
+        '-webkit-border-radius — remove -vendor- prefix, the unprefixed standard is Baseline Widely Available',
+    })
+    expect(result.legacyPatterns[1].pattern).toBe('clearfix-hack')
+    expect(result.legacyPatterns[2].pattern).toBe('ie-specific-hack')
+  })
+
+  it('audit handles empty legacyPatterns array', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+      overflowSafetyIssues: [],
+      legacyPatterns: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.legacyPatterns).toEqual([])
+  })
+
+  it('audit handles missing legacyPatterns gracefully', async () => {
+    const rawResponse = JSON.stringify({
+      brand: 'test',
+      chaosScore: 3,
+      summary: '',
+      colorClusters: [],
+      fonts: [],
+      spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+      lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+      layoutA11yIssues: [],
+      modernPracticeIssues: [],
+      adoptionSuggestions: [],
+      overflowSafetyIssues: [],
+    })
+
+    const sendPromptSpy = vi.fn().mockResolvedValue(rawResponse)
+    const mockClient = { sendPrompt: sendPromptSpy }
+    const auditor = new CssAuditor(mockClient, {
+      maxTokens: { audit: 3000, parse: 4000, export: 6000 },
+    })
+
+    const result = await auditor.audit({ content: 'test', system: 'sys' })
+    expect(result.legacyPatterns).toBeUndefined()
+  })
+})

--- a/lib/__tests__/helpers/legacy-css-fixture.css
+++ b/lib/__tests__/helpers/legacy-css-fixture.css
@@ -1,0 +1,45 @@
+/* Test fixture for legacy CSS pattern detection */
+
+/* Obsolete vendor prefixes */
+.vendor-prefix-demo {
+  -webkit-border-radius: 8px;
+  -moz-border-radius: 8px;
+  border-radius: 8px;
+  -webkit-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  -webkit-transition: all 0.3s ease;
+  -o-transition: all 0.3s ease;
+  transition: all 0.3s ease;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+/* Clearfix hack */
+.clearfix::after {
+  content: '';
+  display: table;
+  clear: both;
+}
+
+.container::after {
+  content: '';
+  display: block;
+  clear: both;
+}
+
+/* IE-specific hacks */
+.ie-hacks {
+  *zoom: 1;
+  _width: 100%;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#FF0000', endColorstr='#00FF00');
+}
+
+/* Valid modern CSS (should NOT be flagged) */
+.modern-container {
+  display: flow-root;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transform: none;
+}

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -144,7 +144,7 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('</example>')
   })
 
-  it('includes all twelve analysis steps', () => {
+  it('includes all thirteen analysis steps', () => {
     const content = buildAuditPrompt(css).content
     expect(content).toContain('STEP 1')
     expect(content).toContain('STEP 2')
@@ -158,6 +158,7 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('STEP 10')
     expect(content).toContain('STEP 11')
     expect(content).toContain('STEP 12')
+    expect(content).toContain('STEP 13')
   })
 
   it('covers all required JSON output fields in the example', () => {
@@ -251,6 +252,48 @@ describe('buildAuditPrompt', () => {
     expect(content).toContain('standard')
     expect(content).toContain('emphasized')
     expect(content).toContain('decelerate')
+  })
+})
+
+describe('buildAuditPrompt legacy patterns', () => {
+  it('includes STEP 13 for legacy pattern detection', () => {
+    const css =
+      '.clearfix::after { content: \"\"; display: table; clear: both; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('STEP 13')
+    expect(prompt.content).toContain('LEGACY PATTERN DETECTION')
+  })
+
+  it('instructs LLM to detect obsolete vendor prefixes', () => {
+    const css = '.demo { -webkit-border-radius: 8px; border-radius: 8px; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('OBSOLETE VENDOR PREFIXES')
+    expect(prompt.content).toContain('obsolete-vendor-prefix')
+    expect(prompt.content).toContain('-webkit-')
+  })
+
+  it('instructs LLM to detect clearfix hacks', () => {
+    const css =
+      '.clearfix::after { content: \"\"; display: table; clear: both; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('CLEARFIX HACKS')
+    expect(prompt.content).toContain('clearfix-hack')
+    expect(prompt.content).toContain('flow-root')
+  })
+
+  it('instructs LLM to detect IE-specific hacks', () => {
+    const css = '.old-ie { *zoom: 1; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('IE-SPECIFIC HACKS')
+    expect(prompt.content).toContain('ie-specific-hack')
+    expect(prompt.content).toContain('*property')
+  })
+
+  it('includes legacyPatterns in the output example', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('legacyPatterns')
+    expect(prompt.content).toContain('obsolete-vendor-prefix')
   })
 })
 

--- a/lib/audit-summary.mjs
+++ b/lib/audit-summary.mjs
@@ -22,6 +22,11 @@ const LINT_CATEGORIES = [
     shortLabel: 'overflow',
     label: 'Overflow & wrap safety',
   },
+  {
+    key: 'legacyPatterns',
+    shortLabel: 'legacy',
+    label: 'Legacy CSS patterns',
+  },
 ]
 
 /**

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -198,7 +198,49 @@ For each such case, record:
 - "severity": "suggestion"
 - "reason": a specific message identifying the overflow risk (e.g. "Grid container with fixed height but no overflow handling — content may be clipped if grid items exceed the container" or "Flex container with max-width and no overflow property — ensure overflow is handled explicitly")
 
-Only report up to 8 overflowSafetyIssues total. Prioritize flex-wrap-missing (warnings) first, then missing-overflow-wrap (suggestions).</instructions>
+Only report up to 8 overflowSafetyIssues total. Prioritize flex-wrap-missing (warnings) first, then missing-overflow-wrap (suggestions).
+
+STEP 13 — LEGACY PATTERN DETECTION
+Scan the CSS for legacy code patterns that have modern replacements. Focus on three categories:
+
+13a. OBSOLETE VENDOR PREFIXES
+Detect vendor-prefixed properties or values that are no longer necessary because the unprefixed version is Baseline Widely Available. Look for:
+- \`-webkit-border-radius\`, \`-webkit-box-shadow\`, \`-webkit-transform\`, \`-webkit-transition\` on properties where the unprefixed standard has been available for years
+- \`-moz-border-radius\`, \`-moz-box-shadow\` (Firefox dropped prefix requirements in Firefox 4, 2011)
+- \`-ms-transform\`, \`-ms-transition\` (IE-specific prefixes, IE is end-of-life)
+- \`-o-*\` (Opera Presto prefixes, obsolete since Opera 15 switched to Blink in 2013)
+- \`-webkit-appearance\` (unprefixed \`appearance\` is baseline since 2020)
+Do NOT flag \`-webkit-background-clip: text\` or \`-webkit-text-fill-color\` — these are still needed.
+For each found prefix pattern, record:
+- \"selector\": the CSS selector containing the obsolete prefix
+- \"pattern\": \"obsolete-vendor-prefix\"
+- \"severity\": \"warning\"
+- \"suggestion\": \"(Property) — remove -vendor- prefix, the unprefixed standard is Baseline Widely Available\"
+
+13b. CLEARFIX HACKS
+Look for the classic clearfix pattern used before \`display: flow-root\` existed:
+- A selector with \`::after\` pseudo-element that sets \`content: \"\"\` or \`content: ''\` combined with \`display: table\` or \`display: block\` and \`clear: both\`
+- Any rule containing the string \"clearfix\" in the selector name together with \`::after\` or \`::before\` pseudo-elements
+For each found clearfix, record:
+- \"selector\": the CSS selector (the container that needs clearing, not the ::after rule itself)
+- \"pattern\": \"clearfix-hack\"
+- \"severity\": \"suggestion\"
+- \"suggestion\": \"Replace the clearfix hack with \`display: flow-root\` on the container — it creates a new Block Formatting Context without extra pseudo-elements\"
+
+13c. IE-SPECIFIC HACKS
+Detect Internet Explorer-specific CSS hacks that have no purpose in modern browsers:
+- Properties starting with \`*property\` (IE6/7 hack — asterisk prefix, e.g. \`*zoom: 1\`)
+- Properties starting with \`_property\` (IE6 hack — underscore prefix)
+- \`filter: progid:DXImageTransform.Microsoft.*\` (legacy IE filters)
+- \`-ms-filter\` (IE8/9 filter syntax)
+- Expressions like \`expression(...)\` inside CSS values (IE5-7 proprietary)
+For each found IE hack, record:
+- \"selector\": the CSS selector containing the IE hack
+- \"pattern\": \"ie-specific-hack\"
+- \"severity\": \"warning\"
+- \"suggestion\": \"IE-specific hack — remove entirely (IE is end-of-life and CSS has native replacements for all of these)\"
+
+Only report up to 10 legacyPatterns total. Prioritize IE-specific hacks and obsolete prefixes (warnings) over clearfix hacks (suggestions).</instructions>
 
 <output_format>
 Return ONLY a valid JSON object matching the structure in the example below. No markdown fences, no backticks, no text before or after the JSON.
@@ -267,6 +309,11 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
   "overflowSafetyIssues": [
     { "selector": ".nav-list", "rule": "flex-wrap-missing", "severity": "warning", "reason": "Flex container without \`flex-wrap\` — items will not wrap and may overflow on narrow viewports" },
     { "selector": ".dashboard-grid", "rule": "missing-overflow-wrap", "severity": "suggestion", "reason": "Grid container with fixed height but no overflow handling — content may be clipped if grid items exceed the container" }
+  ],
+  "legacyPatterns": [
+    { "selector": ".old-button", "pattern": "obsolete-vendor-prefix", "severity": "warning", "suggestion": "-webkit-border-radius \u2014 remove -webkit- prefix, the unprefixed border-radius is Baseline Widely Available" },
+    { "selector": ".grid-container", "pattern": "clearfix-hack", "severity": "suggestion", "suggestion": "Replace the clearfix hack with display: flow-root on the container \u2014 it creates a new Block Formatting Context without extra pseudo-elements" },
+    { "selector": ".ie-fallback", "pattern": "ie-specific-hack", "severity": "warning", "suggestion": "IE-specific hack \u2014 remove entirely (IE is end-of-life and CSS has native replacements for all of these)" }
   ]
 }
 </example>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -159,6 +159,13 @@ export interface OverflowSafetyIssue {
   reason: string
 }
 
+export interface LegacyPatternIssue {
+  selector: string
+  pattern: 'obsolete-vendor-prefix' | 'clearfix-hack' | 'ie-specific-hack'
+  severity: 'warning' | 'suggestion'
+  suggestion: string
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -172,6 +179,7 @@ export interface AuditReport {
   modernPracticeIssues?: ModernPracticeIssue[]
   adoptionSuggestions?: AdoptionSuggestion[]
   overflowSafetyIssues?: OverflowSafetyIssue[]
+  legacyPatterns?: LegacyPatternIssue[]
 }
 
 export interface ColorDecision {


### PR DESCRIPTION
**Card:** https://github.com/nujovich/mint-radar/issues/9

**What:** Extends the CSS audit with legacy pattern detection. Milestone 1 adds a new audit step (STEP 13) to `lib/prompts.mjs` that detects obsolete vendor prefixes (-webkit-, -moz-, -ms-, -o-), classic clearfix hacks, and IE-specific CSS hacks (*property, _property, filter:progid, expression()), and suggests modern replacements for each.

**Why:** ReliCSS demonstrated strong demand for tools that identify CSS fossil patterns. Mint already performs semantic CSS auditing (colors, fonts, spacing, motion, layout a11y, modern practices, overflow safety) but has no awareness of legacy CSS artifacts that bloat stylesheets and complicate maintenance. Adding legacy pattern detection closes this gap, reinforcing Mint's positioning as a thorough CSS health auditor.

## Milestones

- [x] Milestone 1 — Extend audit prompt in lib/prompts.mjs with STEP 13: legacy pattern detection (obsolete vendor prefixes, clearfix hacks, IE-specific hacks), suggest modern alternatives
- [x] Milestone 2 — Add legacyPatterns field to AuditReport type in lib/types.ts
- [x] Milestone 3 — Wire legacy patterns results in playground UI as warning-level alerts
- [x] Milestone 4 — Add test fixture with CSS legacy patterns and test in lib/__tests__/

## Milestone 3 detail

Added `legacyPatterns` to the `LINT_CATEGORIES` registry in `lib/audit-summary.mjs`, making legacy pattern findings visible in both the CLI summary line (`formatLintSummary`) and the playground `AuditView` (`collectLintGroups`). The `AuditView` renderer was extended to fall back to `issue.suggestion` when `issue.reason` is not present (LegacyPatternIssue uses `suggestion` rather than `reason`).

Files changed:
- `lib/audit-summary.mjs` — added `legacyPatterns` entry to LINT_CATEGORIES (key, shortLabel: 'legacy', label: 'Legacy CSS patterns')
- `components/AuditView.tsx` — made `reason` optional, added `suggestion` to LintIssue interface, render uses `issue.reason || issue.suggestion`
- `lib/__tests__/audit-summary.test.mjs` — added tests for formatLintSummary (legacy shortLabel) and collectLintGroups (legacyPatterns included, raw issues preserved)

## Milestone 4 detail

Added a CSS test fixture containing legacy patterns and integration tests:

- `lib/__tests__/helpers/legacy-css-fixture.css` — test fixture with obsolete vendor prefixes, clearfix hacks, IE-specific hacks, and modern valid CSS
- `lib/__tests__/prompts.test.mjs` — updated to include STEP 13 in step count test, added `buildAuditPrompt legacy patterns` describe block with 5 tests
- `lib/__tests__/css-auditor.test.mjs` — added `CssAuditor legacyPatterns integration` describe block with 3 tests

## Tests

All 735 tests passing:
```
npm test
```

**How to test:**
```bash
npm test
```