### PR TITLE
feat(mint): add logical properties analysis step to CSS audit prompt

### DIFF
--- a/BUILD-PLAN-issue-10.md
+++ b/BUILD-PLAN-issue-10.md
@@ -1,0 +1,12 @@
+# BUILD-PLAN-issue-10 — Stylelint 17.10: logical vs physical properties audit
+
+**Card:** https://github.com/nujovich/mint-radar/issues/10
+
+**Decision:** Planned (no Nadia override recorded — PLAN comment at 2026-06-16).
+
+## Milestones
+
+- [x] Milestone 1 — Extend audit prompt in lib/prompts.mjs with STEP 14: logical properties analysis (detect physical directional properties, suggest logical equivalents, compute logical-vs-physical ratio). Add LogicalPropertiesIssue + LogicalPropertiesAudit types to lib/types.ts and logicalProperties field to AuditReport.
+- [ ] Milestone 2 — Wire logicalProperties results in playground UI (AuditView component)
+- [ ] Milestone 3 — Wire logicalProperties in audit-summary.mjs (CLI summary line)
+- [ ] Milestone 4 — Add test fixture with mixed logical/physical properties and tests in lib/**tests**/

--- a/components/AuditView.tsx
+++ b/components/AuditView.tsx
@@ -801,6 +801,110 @@ export default function AuditView({ audit, onResolve }: Props) {
         </div>
       </section>
 
+      {/* Logical properties */}
+      {audit.logicalProperties && audit.logicalProperties.found.length > 0 && (
+        <section>
+          <SectionLabel>
+            Logical properties -- {audit.logicalProperties.found.length} issue
+            {audit.logicalProperties.found.length === 1 ? '' : 's'} ·{' '}
+            {Math.round(audit.logicalProperties.logicalVsPhysicalRatio * 100)}%
+            logical
+          </SectionLabel>
+
+          <div
+            style={{
+              padding: '10px 14px',
+              borderRadius: 8,
+              background: 'rgba(129,140,248,0.06)',
+              border: '1px solid rgba(129,140,248,0.15)',
+              fontSize: 11,
+              color: 'var(--text-muted)',
+              lineHeight: 1.65,
+              marginBottom: 12,
+            }}
+          >
+            <strong style={{ color: 'var(--text)', fontWeight: 500 }}>
+              Why logical properties?
+            </strong>{' '}
+            CSS logical properties (like{' '}
+            <code style={{ fontFamily: 'var(--mono)', fontSize: 10 }}>
+              margin-inline-start
+            </code>{' '}
+            instead of{' '}
+            <code style={{ fontFamily: 'var(--mono)', fontSize: 10 }}>
+              margin-left
+            </code>
+            ) adapt automatically to writing modes (LTR, RTL, vertical). This
+            stylesheet is{' '}
+            {Math.round(audit.logicalProperties.logicalVsPhysicalRatio * 100)}%
+            logical —
+            {audit.logicalProperties.logicalVsPhysicalRatio >= 0.7
+              ? ' solid i18n readiness.'
+              : audit.logicalProperties.logicalVsPhysicalRatio >= 0.4
+                ? ' moderate physical property usage remains.'
+                : ' significant physical property usage needs migration.'}
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {audit.logicalProperties.found.map((issue, i) => (
+              <div
+                key={`logical-${i}`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'baseline',
+                  gap: 8,
+                  padding: '8px 12px',
+                  borderRadius: 8,
+                  background: 'var(--surface)',
+                  border: '1px solid var(--border)',
+                }}
+              >
+                <span
+                  style={{
+                    flexShrink: 0,
+                    fontSize: 10,
+                    fontWeight: 600,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.04em',
+                    color: '#818cf8',
+                  }}
+                >
+                  suggestion
+                </span>
+                <div style={{ minWidth: 0 }}>
+                  <code
+                    style={{
+                      fontSize: 11,
+                      fontFamily: 'var(--mono)',
+                      color: 'var(--text)',
+                    }}
+                  >
+                    {issue.selector}
+                  </code>
+                  <div
+                    style={{
+                      fontSize: 11,
+                      color: 'var(--text-muted)',
+                      lineHeight: 1.55,
+                      marginTop: 2,
+                    }}
+                  >
+                    <code style={{ fontFamily: 'var(--mono)', fontSize: 10 }}>
+                      {issue.property}: {issue.value}
+                    </code>{' '}
+                    <span style={{ opacity: 0.6 }}>→</span>{' '}
+                    <code style={{ fontFamily: 'var(--mono)', fontSize: 10 }}>
+                      {issue.suggestion}
+                    </code>
+                    {issue.reason && <> -- {issue.reason}</>}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       {/* Layout linting */}
       {lintGroups.length > 0 && (
         <section>

--- a/lib/__tests__/css-auditor.test.mjs
+++ b/lib/__tests__/css-auditor.test.mjs
@@ -659,3 +659,68 @@ describe('CssAuditor propertyTypeIssues integration', () => {
     expect(result.propertyTypeIssues).toBeUndefined()
   })
 })
+
+describe('CssAuditor logicalProperties integration', () => {
+  const baseReport = {
+    brand: 'test',
+    chaosScore: 3,
+    summary: '',
+    colorClusters: [],
+    fonts: [],
+    spacing: { found: [], suggestedScale: {}, nonScaleValues: [] },
+    lineHeights: { found: [], suggestedScale: {}, unitlessMix: false },
+    layoutA11yIssues: [],
+    modernPracticeIssues: [],
+    adoptionSuggestions: [],
+    overflowSafetyIssues: [],
+    propertyTypeIssues: [],
+  }
+
+  const auditWith = async (report) => {
+    const sendPromptSpy = vi.fn().mockResolvedValue(JSON.stringify(report))
+    const auditor = new CssAuditor(
+      { sendPrompt: sendPromptSpy },
+      { maxTokens: { audit: 3000, parse: 4000, export: 6000 } }
+    )
+    return auditor.audit({ content: 'test', system: 'sys' })
+  }
+
+  it('audit parses response with logicalProperties', async () => {
+    const issue = {
+      selector: '.sidebar',
+      property: 'margin-left',
+      value: '16px',
+      suggestion: 'margin-inline-start: 16px',
+      reason:
+        'Use margin-inline-start instead of margin-left for automatic RTL/LTR and writing-mode support',
+      severity: 'suggestion',
+    }
+    const result = await auditWith({
+      ...baseReport,
+      logicalProperties: {
+        found: [issue],
+        logicalVsPhysicalRatio: 0.4,
+      },
+    })
+    expect(result.logicalProperties).toEqual({
+      found: [issue],
+      logicalVsPhysicalRatio: 0.4,
+    })
+  })
+
+  it('audit handles empty logicalProperties found array', async () => {
+    const result = await auditWith({
+      ...baseReport,
+      logicalProperties: { found: [], logicalVsPhysicalRatio: 1.0 },
+    })
+    expect(result.logicalProperties).toEqual({
+      found: [],
+      logicalVsPhysicalRatio: 1.0,
+    })
+  })
+
+  it('audit handles missing logicalProperties gracefully', async () => {
+    const result = await auditWith(baseReport)
+    expect(result.logicalProperties).toBeUndefined()
+  })
+})

--- a/lib/__tests__/helpers/logical-properties-fixture.css
+++ b/lib/__tests__/helpers/logical-properties-fixture.css
@@ -1,0 +1,53 @@
+/* Mixed logical and physical directional properties for testing STEP 14 */
+
+.sidebar {
+  margin-left: 16px;
+  padding-top: 8px;
+  left: 0;
+}
+
+.content {
+  margin-inline-start: 16px;
+  padding-block-end: 12px;
+  inset-inline-start: 240px;
+}
+
+.header {
+  border-bottom: 2px solid #ccc;
+  border-right-color: #999;
+}
+
+.footer-links {
+  padding-right: 24px;
+  margin-block: 16px;
+  text-align: right;
+}
+
+.card {
+  width: 300px;
+  height: auto;
+  max-width: 100%;
+  min-height: 100px;
+}
+
+.responsive {
+  inline-size: 100%;
+  block-size: auto;
+  max-inline-size: 1200px;
+  min-block-size: 0;
+}
+
+.text-block {
+  text-align: start;
+}
+
+.legacy-block {
+  text-align: left;
+}
+
+.actions {
+  border-left-style: solid;
+  border-bottom-width: 1px;
+  margin-top: 8px;
+  padding-inline: 16px;
+}

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -610,3 +610,60 @@ describe('buildAuditPrompt lint issue contract', () => {
     }
   )
 })
+
+describe('buildAuditPrompt logical properties', () => {
+  it('includes STEP 14 for logical properties analysis', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('STEP 14')
+    expect(prompt.content).toContain('LOGICAL PROPERTIES ANALYSIS')
+  })
+
+  it('instructs LLM to detect physical margin properties', () => {
+    const css = '.sidebar { margin-left: 16px; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('margin-inline-start')
+    expect(prompt.content).toContain('margin-left')
+  })
+
+  it('instructs LLM to detect physical padding properties', () => {
+    const css = '.footer { padding-right: 24px; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('padding-inline-end')
+  })
+
+  it('instructs LLM to detect physical positioning properties', () => {
+    const css = '.sidebar { left: 0; top: 0; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('inset-inline-start')
+    expect(prompt.content).toContain('inset-block-start')
+  })
+
+  it('instructs LLM to detect physical sizing properties', () => {
+    const css = '.card { width: 300px; height: auto; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('inline-size')
+    expect(prompt.content).toContain('block-size')
+  })
+
+  it('instructs LLM to compute logical-vs-physical ratio', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('logicalVsPhysicalRatio')
+    expect(prompt.content).toContain('logical declarations')
+  })
+
+  it('includes logicalProperties in the output example', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('logicalProperties')
+    expect(prompt.content).toContain('.sidebar')
+    expect(prompt.content).toContain('.footer-links')
+  })
+
+  it('caps the number of reported logicalProperties issues', () => {
+    const css = 'body { color: red; }'
+    const prompt = buildAuditPrompt(css)
+    expect(prompt.content).toContain('up to 12 logicalProperties issues')
+  })
+})

--- a/lib/audit-summary.mjs
+++ b/lib/audit-summary.mjs
@@ -27,6 +27,12 @@ const LINT_CATEGORIES = [
     shortLabel: 'property types',
     label: '@property type safety',
   },
+  {
+    key: 'logicalProperties',
+    shortLabel: 'logical props',
+    label: 'Logical properties',
+    nestedKey: 'found',
+  },
 ]
 
 /**
@@ -35,8 +41,10 @@ const LINT_CATEGORIES = [
  */
 export function formatLintSummary(audit) {
   if (!audit) return ''
-  return LINT_CATEGORIES.map(({ key, shortLabel }) => {
-    const count = audit[key]?.length ?? 0
+  return LINT_CATEGORIES.map(({ key, shortLabel, nestedKey }) => {
+    const count = nestedKey
+      ? (audit[key]?.[nestedKey]?.length ?? 0)
+      : (audit[key]?.length ?? 0)
     return count > 0 ? `${count} ${shortLabel}` : null
   })
     .filter(Boolean)
@@ -50,8 +58,10 @@ export function formatLintSummary(audit) {
 export function collectLintGroups(audit) {
   if (!audit) return []
   const groups = []
-  for (const { key, label } of LINT_CATEGORIES) {
-    const issues = audit[key] ?? []
+  for (const { key, label, nestedKey } of LINT_CATEGORIES) {
+    const issues = nestedKey
+      ? (audit[key]?.[nestedKey] ?? [])
+      : (audit[key] ?? [])
     if (issues.length > 0) groups.push({ key, label, issues })
   }
   return groups

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -242,7 +242,64 @@ Scan every var() usage of a registered property for a fallback whose type contra
 13c. FOREIGN CONTEXT USAGE
 A registered property assigned to a CSS property its declared syntax cannot satisfy — a <length> property used in \`color\`, or a <color> property used in \`width\`. Report only when the mismatch is unambiguous from this stylesheet alone; skip any var() whose value may come from another stylesheet or from JavaScript. Record these with "rule": "property-type-mismatch" and "severity": "suggestion".
 
-Only report up to 8 propertyTypeIssues total. Prioritize invalid-initial-value, then fallback-type-mismatch, then property-type-mismatch. If the CSS contains no @property registrations, record an empty array.</instructions>
+Only report up to 8 propertyTypeIssues total. Prioritize invalid-initial-value, then fallback-type-mismatch, then property-type-mismatch. If the CSS contains no @property registrations, record an empty array.
+
+STEP 14 — LOGICAL PROPERTIES ANALYSIS
+Scan the CSS for the use of physical directional properties that have modern flow-relative (logical) equivalents. Logical properties adapt to writing mode and text direction, providing automatic RTL/LTR and vertical-writing-mode support. Physical properties are tied to a single axis and require manual overrides for internationalization.
+
+14a. DETECT PHYSICAL PROPERTIES
+For each CSS rule that uses a physical directional property from the list below, flag it with the physical property found, its value, and the suggested logical equivalent.
+
+Physical-to-logical mapping:
+- margin-left → margin-inline-start
+- margin-right → margin-inline-end
+- margin-top → margin-block-start
+- margin-bottom → margin-block-end
+- padding-left → padding-inline-start
+- padding-right → padding-inline-end
+- padding-top → padding-block-start
+- padding-bottom → padding-block-end
+- left → inset-inline-start
+- right → inset-inline-end
+- top → inset-block-start
+- bottom → inset-block-end
+- border-left → border-inline-start
+- border-right → border-inline-end
+- border-top → border-block-start
+- border-bottom → border-block-end
+- border-left-width → border-inline-start-width
+- border-right-width → border-inline-end-width
+- border-top-width → border-block-start-width
+- border-bottom-width → border-block-end-width
+- border-left-color → border-inline-start-color
+- border-right-color → border-inline-end-color
+- border-top-color → border-block-start-color
+- border-bottom-color → border-block-end-color
+- border-left-style → border-inline-start-style
+- border-right-style → border-inline-end-style
+- border-top-style → border-block-start-style
+- border-bottom-style → border-block-end-style
+- width → inline-size
+- height → block-size
+- min-width → min-inline-size
+- max-width → max-inline-size
+- min-height → min-block-size
+- max-height → max-block-size
+- text-align: left → text-align: start
+- text-align: right → text-align: end
+
+For each physical property found, record:
+- "selector": the CSS selector where the physical property is used
+- "property": the physical property name (e.g. "margin-left")
+- "value": the value assigned to the property (e.g. "16px")
+- "suggestion": the logical equivalent with the same value (e.g. "margin-inline-start: 16px")
+- "reason": "Use <logical-property> instead of <physical-property> for automatic RTL/LTR and writing-mode support"
+- "severity": "suggestion"
+
+14b. COMPUTE LOGICAL-VS-PHYSICAL RATIO
+Count total directional layout property declarations found in the CSS (both physical AND logical). Then compute logicalVsPhysicalRatio as: (logical declarations) / (total directional declarations). A ratio of 0 means all physical; 1.0 means all logical. Include logical property declarations (margin-inline, padding-block, etc.) in the count even though they are not flagged as issues — they contribute positively to the ratio.
+
+Only report up to 12 logicalProperties issues total. Prioritize margin/padding properties first (they are the most common source of i18n bugs), then border/positioning, then sizing/text-align.</instructions>
 
 <output_format>
 Return ONLY a valid JSON object matching the structure in the example below. No markdown fences, no backticks, no text before or after the JSON.
@@ -316,7 +373,15 @@ Return ONLY a valid JSON object matching the structure in the example below. No 
     { "selector": "@property --spacing-unit", "property": "initial-value", "rule": "invalid-initial-value", "severity": "warning", "reason": "Registered as \`<length>\` but \`initial-value: red\` is a \`<color>\` — the browser rejects this registration entirely", "propertyName": "--spacing-unit", "declaredSyntax": "<length>" },
     { "selector": ".button", "property": "background-color", "rule": "fallback-type-mismatch", "severity": "warning", "reason": "\`--my-color\` is registered as \`<color>\` but falls back to \`14px\` — the fallback can never apply", "propertyName": "--my-color", "declaredSyntax": "<color>" },
     { "selector": ".card", "property": "color", "rule": "property-type-mismatch", "severity": "suggestion", "reason": "\`--spacing-unit\` is registered as \`<length>\` but is used as a color value", "propertyName": "--spacing-unit", "declaredSyntax": "<length>" }
-  ]
+  ],
+  "logicalProperties": {
+    "logicalVsPhysicalRatio": 0.35,
+    "found": [
+      { "selector": ".sidebar", "property": "margin-left", "value": "16px", "suggestion": "margin-inline-start: 16px", "reason": "Use margin-inline-start instead of margin-left for automatic RTL/LTR and writing-mode support", "severity": "suggestion" },
+      { "selector": ".footer-links", "property": "padding-right", "value": "24px", "suggestion": "padding-inline-end: 24px", "reason": "Use padding-inline-end instead of padding-right for automatic RTL/LTR and writing-mode support", "severity": "suggestion" },
+      { "selector": ".nav", "property": "text-align", "value": "right", "suggestion": "text-align: end", "reason": "Use text-align: end instead of text-align: right for automatic RTL/LTR and writing-mode support", "severity": "suggestion" }
+    ]
+  }
 }
 </example>
 </output_format>`

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -169,6 +169,20 @@ export interface PropertyTypeIssue {
   declaredSyntax: string // the @property syntax descriptor, e.g. '<color>'
 }
 
+export interface LogicalPropertiesIssue {
+  selector: string
+  property: string // the physical property found, e.g. 'margin-left'
+  value: string // the original value, e.g. '16px'
+  suggestion: string // the logical equivalent, e.g. 'margin-inline-start: 16px'
+  reason: string
+  severity: 'suggestion'
+}
+
+export interface LogicalPropertiesAudit {
+  found: LogicalPropertiesIssue[]
+  logicalVsPhysicalRatio: number // 0-1, e.g. 0.65 means 65% logical
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -183,6 +197,7 @@ export interface AuditReport {
   adoptionSuggestions?: AdoptionSuggestion[]
   overflowSafetyIssues?: OverflowSafetyIssue[]
   propertyTypeIssues?: PropertyTypeIssue[]
+  logicalProperties?: LogicalPropertiesAudit
 }
 
 export interface ColorDecision {


### PR DESCRIPTION
**Card:** https://github.com/nujovich/mint-radar/issues/10

**What:** Adds STEP 14 (Logical Properties Analysis) to the CSS audit prompt in lib/prompts.mjs. This step scans CSS for physical directional properties (margin-left, padding-right, border-top, left, width, text-align: right, etc.) and suggests their modern flow-relative (logical) equivalents. It also computes a logical-vs-physical ratio to quantify the stylesheet's i18n readiness.

**Why:** Stylelint 17.10 added layout-mappings rules that enforce logical properties. Mint's CSS audit should detect physical properties and guide users toward logical equivalents for automatic RTL/LTR and writing-mode support, closing the gap between Mint and Stylelint's coverage.

## Milestones

- [x] Milestone 1 -- Add STEP 14 to audit prompt in lib/prompts.mjs: detect physical directional properties (30+ mappings), suggest logical equivalents (e.g. margin-left -> margin-inline-start), compute logical-vs-physical ratio. Add LogicalPropertiesIssue / LogicalPropertiesAudit types to lib/types.ts and logicalProperties field to AuditReport.
- [x] Milestone 2 -- Wire logicalProperties results in playground UI (AuditView component)
- [x] Milestone 3 -- Wire logicalProperties in audit-summary.mjs (CLI summary line)
- [x] Milestone 4 -- Add test fixture with mixed logical/physical properties and tests in lib/__tests__/

**How to test:**
```bash
npm test
```