### PR TITLE
feat(mint): add dtcg export prompt with structured dimension token {value, unit} format

### DIFF
--- a/BUILD-PLAN-issue-11.md
+++ b/BUILD-PLAN-issue-11.md
@@ -1,0 +1,11 @@
+# BUILD PLAN — Card #11: Style Dictionary v5.4.0 — DTCG dimension tokens
+
+- **Card:** https://github.com/nujovich/mint-radar/issues/11
+- **Decision:** Nadia chose Option B (code implementation as planned)
+
+## Milestones
+
+- [ ] Milestone 1 — Add dtcg export prompt to EXPORT_PROMPTS in lib/prompts.mjs with DTCG {value, unit} dimension token instructions
+- [ ] Milestone 2 — Add DTCG type definitions to lib/types.ts for dimension, typography, and shadow tokens
+- [ ] Milestone 3 — Update bin/mint-ds.mjs to support --format dtcg flag for token generation flow
+- [ ] Milestone 4 — Add test fixture and tests for DTCG output validation

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -126,6 +126,7 @@ ${styles.bold('INIT OPTIONS')}
 ${styles.bold('AUDIT OPTIONS')}
   --out <file>                 Tokens output path (default: ${DEFAULT_TOKENS_FILE})
   --report <file>              Also write the raw audit report to <file>
+  --format <name>              Token output format (default: mint). Values: mint, dtcg
   --quiet                      Suppress chaos summary
   --no-cache                   Skip cache lookup and overwrite any existing entry
 
@@ -182,6 +183,7 @@ ${styles.bold('EXAMPLES')}
   npx mint-ds init
   npx mint-ds audit ./src/styles
   npx mint-ds audit ./src/styles --provider openrouter
+  npx mint-ds audit ./src/styles --format dtcg
   npx mint-ds export --target tailwind
   npx mint-ds export --target react --out ui/Components.tsx
   npx mint-ds export --target css --stdout > variables.css
@@ -327,6 +329,11 @@ async function cmdAudit(argv) {
   })
   if (!target) die('Usage: mint-ds audit <directory>')
 
+  const format = flags.format ? String(flags.format).toLowerCase() : 'mint'
+  if (format !== 'mint' && format !== 'dtcg') {
+    die(`Unknown --format "${flags.format}". Supported: mint, dtcg`)
+  }
+
   const reportFile = flags.report ? String(flags.report) : null
   const quiet = Boolean(flags.quiet)
   const noCache = Boolean(flags['no-cache'])
@@ -391,6 +398,19 @@ async function cmdAudit(argv) {
   }
 
   await fs.writeFile(outFile, JSON.stringify(tokens, null, 2) + '\n', 'utf8')
+
+  // --format dtcg: produce DTCG v1 tokens alongside the mint-format file.
+  if (format === 'dtcg') {
+    log(styles.cyan('→') + ' Converting to DTCG format...')
+    const dtcgCode = await cssAuditor.export(buildExportPrompt(tokens, 'dtcg'))
+    const dtcgOut =
+      flags.out != null
+        ? String(flags.out).replace(/(\.json)?$/, '.dtcg.json')
+        : outFile.replace(/(\.json)?$/, '.dtcg.json')
+    await fs.mkdir(path.dirname(dtcgOut), { recursive: true })
+    await fs.writeFile(dtcgOut, dtcgCode + '\n', 'utf8')
+    log(styles.green('✓') + ` DTCG tokens written to ${styles.bold(dtcgOut)}`)
+  }
 
   if (!quiet) {
     log('')

--- a/lib/__tests__/dtcg-exporter.test.mjs
+++ b/lib/__tests__/dtcg-exporter.test.mjs
@@ -96,4 +96,129 @@ describe('DTCG Exporter', () => {
       expect(typeIdx).toBeLessThan(valueIdx)
     })
   })
+
+  describe('DTCG output validation (milestone 4)', () => {
+    const HELPERS_DIR = resolve(import.meta.dirname, 'helpers')
+
+    function readHelperJson(filename) {
+      return JSON.parse(readFileSync(resolve(HELPERS_DIR, filename), 'utf8'))
+    }
+
+    it('valid fixture passes DTCG validator with zero errors', () => {
+      const dtcg = readHelperJson('dtcg-valid-output.json')
+      const result = validateDTCG(dtcg)
+      expect(result.hasErrors).toBe(false)
+      expect(result.exitCode).toBe(0)
+    })
+
+    it('valid fixture has dimension tokens with {value, unit} objects', () => {
+      const dtcg = readHelperJson('dtcg-valid-output.json')
+      expect(dtcg.spacing.$type).toBe('dimension')
+      expect(dtcg.spacing['1'].$value).toEqual({ value: 4, unit: 'px' })
+      expect(dtcg.spacing.gutter.$value).toEqual({ value: 1.5, unit: 'rem' })
+      expect(dtcg['border-radius'].$type).toBe('dimension')
+      expect(dtcg['border-radius'].sm.$value).toEqual({ value: 4, unit: 'px' })
+    })
+
+    it('valid fixture has shadow arrays with dimension objects', () => {
+      const dtcg = readHelperJson('dtcg-valid-output.json')
+      expect(dtcg.shadow.$type).toBe('shadow')
+      expect(Array.isArray(dtcg.shadow.sm.$value)).toBe(true)
+      expect(dtcg.shadow.sm.$value[0].offsetX).toEqual({ value: 0, unit: 'px' })
+      expect(dtcg.shadow.sm.$value[0].offsetY).toEqual({ value: 2, unit: 'px' })
+      expect(dtcg.shadow.sm.$value[0].blur).toEqual({ value: 4, unit: 'px' })
+      expect(dtcg.shadow.md.$value[0].offsetY).toEqual({ value: 4, unit: 'px' })
+    })
+
+    it('valid fixture has typography sub-groups with correct types', () => {
+      const dtcg = readHelperJson('dtcg-valid-output.json')
+      expect(dtcg.typography['font-family'].$type).toBe('fontFamily')
+      expect(dtcg.typography['font-family'].body.$value).toBe('Inter')
+      expect(Array.isArray(dtcg.typography['font-family'].heading.$value)).toBe(
+        true
+      )
+      expect(dtcg.typography['font-weight'].$type).toBe('fontWeight')
+      expect(dtcg.typography['font-weight'].bold.$value).toBe(700)
+      expect(dtcg.typography['font-weight'].normal.$value).toBe(400)
+      expect(dtcg.typography['font-size'].$type).toBe('dimension')
+      expect(dtcg.typography['font-size'].md.$value).toEqual({
+        value: 16,
+        unit: 'px',
+      })
+      expect(dtcg.typography['line-height'].$type).toBe('number')
+      expect(dtcg.typography['line-height'].normal.$value).toBe(1.5)
+    })
+
+    it('valid fixture has color hex values', () => {
+      const dtcg = readHelperJson('dtcg-valid-output.json')
+      expect(dtcg.color.$type).toBe('color')
+      expect(dtcg.color.primary['500'].$value).toBe('#1976d2')
+      expect(dtcg.color.error.$value).toBe('#e53935')
+      expect(dtcg.color.background.$value).toBe('#f5f5f5')
+    })
+
+    it('valid fixture serializes and re-parses identically', () => {
+      const dtcg = readHelperJson('dtcg-valid-output.json')
+      const json = serializeDTCG(dtcg)
+      const reparsed = JSON.parse(json)
+      const result = validateDTCG(reparsed)
+      expect(result.hasErrors).toBe(false)
+      expect(reparsed.color.$type).toBe('color')
+      expect(reparsed.spacing.$type).toBe('dimension')
+    })
+
+    it('broken fixture reports the expected validation errors', () => {
+      const broken = readFileSync(
+        resolve(FIXTURE_DIR, 'mint-ds.tokens.dtcg.broken.json'),
+        'utf8'
+      )
+      const dtcg = JSON.parse(broken)
+      const result = validateDTCG(dtcg)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'BROKEN_REFERENCE')).toBe(
+        true
+      )
+      expect(result.errors.some((e) => e.code === 'CIRCULAR_REFERENCE')).toBe(
+        true
+      )
+    })
+
+    it('rejects DTCG output with string dimensions instead of objects', () => {
+      const bad = {
+        spacing: {
+          $type: 'dimension',
+          1: { $value: '4px' },
+        },
+      }
+      const result = validateDTCG(bad)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_DIMENSION')).toBe(
+        true
+      )
+    })
+
+    it('rejects DTCG output with non-array shadow value', () => {
+      const bad = {
+        shadow: {
+          $type: 'shadow',
+          sm: { $value: '0 2px 4px rgba(0,0,0,0.1)' },
+        },
+      }
+      const result = validateDTCG(bad)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'INVALID_SHADOW')).toBe(true)
+    })
+
+    it('rejects DTCG output missing $value on leaf token', () => {
+      const bad = {
+        color: {
+          $type: 'color',
+          primary: { $type: 'color' },
+        },
+      }
+      const result = validateDTCG(bad)
+      expect(result.hasErrors).toBe(true)
+      expect(result.errors.some((e) => e.code === 'MISSING_VALUE')).toBe(true)
+    })
+  })
 })

--- a/lib/__tests__/helpers/dtcg-valid-output.json
+++ b/lib/__tests__/helpers/dtcg-valid-output.json
@@ -1,0 +1,148 @@
+{
+  "color": {
+    "$type": "color",
+    "primary": {
+      "500": {
+        "$value": "#1976d2"
+      },
+      "700": {
+        "$value": "#0d47a1"
+      }
+    },
+    "error": {
+      "$value": "#e53935"
+    },
+    "background": {
+      "$value": "#f5f5f5"
+    }
+  },
+  "spacing": {
+    "$type": "dimension",
+    "1": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      }
+    },
+    "2": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      }
+    },
+    "gutter": {
+      "$value": {
+        "value": 1.5,
+        "unit": "rem"
+      }
+    }
+  },
+  "border-radius": {
+    "$type": "dimension",
+    "sm": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      }
+    },
+    "md": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      }
+    }
+  },
+  "shadow": {
+    "$type": "shadow",
+    "sm": {
+      "$value": [
+        {
+          "offsetX": {
+            "value": 0,
+            "unit": "px"
+          },
+          "offsetY": {
+            "value": 2,
+            "unit": "px"
+          },
+          "blur": {
+            "value": 4,
+            "unit": "px"
+          },
+          "spread": {
+            "value": 0,
+            "unit": "px"
+          },
+          "color": "#0000001a"
+        }
+      ]
+    },
+    "md": {
+      "$value": [
+        {
+          "offsetX": {
+            "value": 0,
+            "unit": "px"
+          },
+          "offsetY": {
+            "value": 4,
+            "unit": "px"
+          },
+          "blur": {
+            "value": 8,
+            "unit": "px"
+          },
+          "spread": {
+            "value": 0,
+            "unit": "px"
+          },
+          "color": "#00000026"
+        }
+      ]
+    }
+  },
+  "typography": {
+    "font-family": {
+      "$type": "fontFamily",
+      "body": {
+        "$value": "Inter"
+      },
+      "heading": {
+        "$value": ["Roboto", "sans-serif"]
+      }
+    },
+    "font-weight": {
+      "$type": "fontWeight",
+      "normal": {
+        "$value": 400
+      },
+      "bold": {
+        "$value": 700
+      }
+    },
+    "font-size": {
+      "$type": "dimension",
+      "sm": {
+        "$value": {
+          "value": 14,
+          "unit": "px"
+        }
+      },
+      "md": {
+        "$value": {
+          "value": 16,
+          "unit": "px"
+        }
+      }
+    },
+    "line-height": {
+      "$type": "number",
+      "tight": {
+        "$value": 1.25
+      },
+      "normal": {
+        "$value": 1.5
+      }
+    }
+  }
+}

--- a/lib/__tests__/prompts.test.mjs
+++ b/lib/__tests__/prompts.test.mjs
@@ -530,6 +530,31 @@ describe('buildExportPrompt', () => {
     expect(content).toContain('150ms')
     expect(content).toContain('cubic-bezier')
   })
+
+  it('returns an object with content and null system for dtcg target', () => {
+    const result = buildExportPrompt(tokens, 'dtcg')
+    expect(typeof result).toBe('object')
+    expect(result.content.length).toBeGreaterThan(0)
+    expect(result.system).toBeNull()
+  })
+
+  it('builds a DTCG prompt with dimension object instructions for dtcg target', () => {
+    const content = buildExportPrompt(tokens, 'dtcg').content
+    expect(content).toContain('DTCG')
+    expect(content).toContain('$type')
+    expect(content).toContain('$value')
+    expect(content).toContain('{ value:')
+    expect(content).toContain('unit:')
+    expect(content).toContain('dimension')
+  })
+
+  it('builds a DTCG prompt with shadow array instructions for dtcg target', () => {
+    const content = buildExportPrompt(tokens, 'dtcg').content
+    expect(content).toContain('offsetX')
+    expect(content).toContain('offsetY')
+    expect(content).toContain('blur')
+    expect(content).toContain('spread')
+  })
 })
 
 describe('buildAuditPrompt with the @property fixture', () => {

--- a/lib/prompts.mjs
+++ b/lib/prompts.mjs
@@ -713,6 +713,29 @@ Requirements:
 - Apply dark mode with createGlobalTheme('[data-theme="dark"]', vars, { ... }) overriding the background, surface, text, and muted color roles (reuse the light values for everything else)
 - Add a short usage comment at the top showing how to consume vars from a separate .css.ts style file, e.g. import { style } from '@vanilla-extract/css' and style({ color: vars.colors.primary['500'], padding: vars.space['4'] })
 - Do not emit any runtime CSS-in-JS beyond the theme wiring; keep it zero-runtime and type-safe`,
+
+  dtcg: (
+    shared
+  ) => `Generate a complete DTCG v1 (Design Tokens Community Group Format Module) JSON file for these design tokens.${shared}
+
+The DTCG Format Module v1 spec: https://www.designtokens.org/TR/2025.10/format/
+
+Requirements:
+- Top-level groups with $type on every group that has tokens
+- Groups: color ($type: color), spacing ($type: dimension), "border-radius" ($type: dimension), shadow ($type: shadow), typography sub-groups
+- Under typography: "font-family" ($type: fontFamily), "font-weight" ($type: fontWeight), "font-size" ($type: dimension), "line-height" ($type: number)
+- Color tokens use #RRGGBB hex strings as $value
+- Dimension tokens ($type: dimension) MUST use the structured object format { value: number, unit: string } — e.g. { value: 4, unit: "px" }, { value: 1.5, unit: "rem" }. NEVER use flat strings like "4px"
+- Shadow tokens ($type: shadow) use arrays of { offsetX, offsetY, blur, spread, color } objects where offsetX/offsetY/blur/spread are dimension objects and color is a hex string
+- Font family tokens use the font name string as $value
+- Font weight tokens use numeric values (100-900) as $value
+- Font size tokens use dimension objects { value, unit }
+- Line-height tokens use unitless numbers as $value
+- All $ prefixed properties ($type, $value) must appear as the first keys in every object
+- Every leaf token object must have exactly one $value key
+- Use valid JSON — no trailing commas, no comments, no markdown fences
+- Only include token groups that have data (no empty groups)
+- Return ONLY the JSON, no explanation, no markdown fences`,
 }
 
 export function buildExportPrompt(tokens, target) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -365,3 +365,30 @@ export const EXPORT_TARGETS: ExportConfig[] = [
     description: 'Resumable component$ with typed props and Slot',
   },
 ]
+
+// ─── DTCG v1 Format Types ────────────────────────────────────────────────────
+// Based on https://www.designtokens.org/TR/2025.10/format/
+// Used by the dtcg-exporter, dtcg-validator, and the LLM-based dtcg export prompt.
+
+/** DTCG dimension token value: { value: number, unit: string }. */
+export interface DTCGDimension {
+  value: number
+  unit: string
+}
+
+/** A single shadow entry within a DTCG shadow array ($type: shadow). */
+export interface DTCGShadowEntry {
+  offsetX: DTCGDimension
+  offsetY: DTCGDimension
+  blur: DTCGDimension
+  spread: DTCGDimension
+  color: string
+}
+
+/** DTCG typography sub-group with $type inheritance from the parent. */
+export interface DTCGTypographyGroup {
+  'font-family'?: Record<string, { $type: 'fontFamily'; $value: string }>
+  'font-size'?: Record<string, { $type: 'dimension'; $value: DTCGDimension }>
+  'font-weight'?: Record<string, { $type: 'fontWeight'; $value: number }>
+  'line-height'?: Record<string, { $type: 'number'; $value: number }>
+}


### PR DESCRIPTION
**Card:** https://github.com/nujovich/mint-radar/issues/11

**What:** Adds an LLM-based `dtcg` export prompt to EXPORT_PROMPTS in lib/prompts.mjs. This prompt instructs the LLM to generate DTCG v1 Format Module JSON with structured dimension tokens ({value, unit} objects instead of flat strings), proper $type/$value organization, shadow arrays, and typography sub-groups. The deterministic dtcg-exporter.mjs path is unchanged — this adds a complementary LLM-driven code path for richer DTCG generation.

**Why:** Style Dictionary v5.4.0 adopted DTCG v2025.10 dimension tokens as {value, unit} objects. Mint's deterministic DTCG exporter already handles this format, but the LLM-based export pipeline (used for all targets via buildExportPrompt) had no dtcg prompt builder. This closes the gap so that `dtcg` can function as a proper export target in both deterministic and LLM modes.

**Decision:** Nadia chose Option B (differentiation approach — implement code plan as described).

## Milestones

- [x] Milestone 1 — Add dtcg export prompt to EXPORT_PROMPTS in lib/prompts.mjs with DTCG {value, unit} dimension token instructions
- [x] Milestone 2 — Add DTCG type definitions to lib/types.ts for dimension, typography, and shadow tokens
- [x] Milestone 3 — Update bin/mint-ds.mjs to support --format dtcg flag for token generation flow
- [x] Milestone 4 — Add test fixture and tests for DTCG output validation

**How to test:**
```bash
npm test
```