### PR TITLE
feat(mint): add logical properties migration audit types and mapping

### DIFF
--- a/BUILD-PLAN-issue-19.md
+++ b/BUILD-PLAN-issue-19.md
@@ -1,0 +1,14 @@
+# BUILD-PLAN-issue-19.md
+
+**Card:** https://github.com/nujovich/mint-radar/issues/19
+
+**Title:** Logical properties migration: Stylelint 17.10 estandariza el enforcement de flow-relative CSS
+
+**Plan reference:** 2026-07-10 PLAN comment (planned)
+
+## Milestones
+
+- [ ] Milestone 1 — Add `LogicalPropertyIssue`, `LogicalPropertyAudit`, and `PHYSICAL_TO_LOGICAL` mapping to `lib/types.ts`; add `logicalProperties` field to `AuditReport`
+- [ ] Milestone 2 — Implement `lintLogicalProperties()` in `lib/css-lint-rules.mjs`: parse CSS, detect physical properties where flow-relative equivalents exist, emit issues with selectors and suggestions
+- [ ] Milestone 3 — Wire `logicalProperties` into `bin/mint-ds.mjs` CLI output and `audit-summary.mjs` as a lint category with migration ratio display
+- [ ] Milestone 4 — Add test fixture with mixed logical/physical CSS and tests referencing Stylelint 17.10 logical-properties rules

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -23,7 +23,7 @@ import { convertTokensToDTCG, serializeDTCG } from '../lib/dtcg-exporter.mjs'
 import { convertTokensToDesignMd } from '../lib/design-md.mjs'
 import { formatLintSummary } from '../lib/audit-summary.mjs'
 import { checkCompat } from '../lib/css-compat-data.mjs'
-import { lintCss, lintGapDecorationAdoption } from '../lib/css-lint-rules.mjs'
+import { lintCss, lintGapDecorationAdoption, lintLogicalProperties } from '../lib/css-lint-rules.mjs'
 import { applyWsl2DnsWorkaround } from '../lib/net-utils.mjs'
 import { buildTokenIndex } from '../lib/token-index.mjs'
 import { applyCodemod } from '../lib/css-codemod.mjs'
@@ -365,6 +365,9 @@ async function cmdAudit(argv) {
   log(styles.cyan('→') + ' Auditing CSS...')
   const audit = await cssAuditor.audit(buildAuditPrompt(css))
 
+  // Merge deterministic logical properties lint into audit for summary display.
+  audit.logicalProperties = lintLogicalProperties(css)
+
   if (reportFile) {
     await fs.writeFile(
       reportFile,
@@ -544,6 +547,41 @@ async function cmdLint(argv) {
       log(`  ${badge}  ${finding.selector}`)
       log(styles.dim(`       ${finding.message}`))
       log('')
+    }
+  }
+
+  // Logical Properties: migration audit.
+  const logicalResult = lintLogicalProperties(css)
+  if (logicalResult.totalPhysicalProperties > 0) {
+    const pct = Math.round(logicalResult.migrationRatio * 100)
+    log('')
+    log(styles.bold('Logical Properties'))
+    const ratioColor =
+      logicalResult.migrationRatio >= 0.75
+        ? styles.green
+        : logicalResult.migrationRatio >= 0.4
+        ? styles.yellow
+        : styles.red
+    log(
+      styles.dim(
+        `  ${logicalResult.migratableProperties}/${logicalResult.totalPhysicalProperties} migratable (${ratioColor(pct + '%')})`
+      )
+    )
+    if (logicalResult.issues.length > 0) {
+      log('')
+      for (const issue of logicalResult.issues) {
+        const badge =
+          issue.severity === 'warning'
+            ? styles.yellow('WARN')
+            : styles.dim('INFO')
+        log(`  ${badge}  ${issue.selector}`)
+        log(
+          styles.dim(
+            `       ${issue.property}: ${issue.value} → ${issue.logicalEquivalent}`
+          )
+        )
+        log('')
+      }
     }
   }
 

--- a/lib/__fixtures__/logical-properties.css
+++ b/lib/__fixtures__/logical-properties.css
@@ -1,0 +1,67 @@
+/*
+ * Mixed logical/physical CSS fixture for the logical-properties audit.
+ * Exercises the Stylelint 17.10 layout-mappings rule families:
+ *   - property-layout-mappings  (physical property -> logical property)
+ *   - value-keyword-layout-mappings (physical value -> logical value)
+ *
+ * .card        physical-only directional properties (all migratable)
+ * .toolbar     already flow-relative (logical) properties (no findings)
+ * .direction-sensitive  physical value keywords on direction-aware properties
+ * .neutral     direction-agnostic declarations (no findings)
+ */
+
+.card {
+  margin-left: 20px;
+  margin-right: 12px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  border-left: 1px solid #ccc;
+  border-right-color: #999;
+  border-top-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 100%;
+  height: 50vh;
+  min-width: 240px;
+  max-height: 400px;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.toolbar {
+  margin-inline-start: 16px;
+  margin-inline-end: 12px;
+  padding-block-start: 8px;
+  padding-block-end: 8px;
+  border-inline-start: 1px solid #eee;
+  border-inline-end-color: #ddd;
+  border-start-start-radius: 4px;
+  border-end-end-radius: 4px;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  inset-block-start: 0;
+  inset-block-end: 0;
+  inline-size: 100%;
+  block-size: auto;
+  min-inline-size: 200px;
+  max-block-size: 300px;
+  overflow-inline: hidden;
+  overflow-block: auto;
+}
+
+.direction-sensitive {
+  text-align: left;
+  float: right;
+  clear: left;
+  resize: horizontal;
+}
+
+.neutral {
+  color: red;
+  font-size: 16px;
+  display: flex;
+  gap: 8px;
+}

--- a/lib/__tests__/audit-summary.test.mjs
+++ b/lib/__tests__/audit-summary.test.mjs
@@ -23,6 +23,34 @@ describe('formatLintSummary', () => {
     expect(formatLintSummary(audit)).toBe('3 property types')
   })
 
+  it('renders logical properties with migration ratio when issues are present', () => {
+    const audit = {
+      logicalProperties: {
+        issues: [{ selector: '.a', property: 'left', logicalEquivalent: 'inset-inline-start' }],
+        totalPhysicalProperties: 4,
+        migratableProperties: 3,
+        migrationRatio: 0.75,
+      },
+    }
+    expect(formatLintSummary(audit)).toBe('3/4 logical (75%)')
+  })
+
+  it('returns empty for logicalProperties with no issues', () => {
+    const audit = {
+      logicalProperties: {
+        issues: [],
+        totalPhysicalProperties: 2,
+        migratableProperties: 0,
+        migrationRatio: 0,
+      },
+    }
+    expect(formatLintSummary(audit)).toBe('')
+  })
+
+  it('returns empty when logicalProperties field is absent', () => {
+    expect(formatLintSummary({ brand: 'x' })).toBe('')
+  })
+
   it('includes the layout a11y count when issues are present', () => {
     const audit = { layoutA11yIssues: [{}, {}] }
     expect(formatLintSummary(audit)).toBe('2 layout a11y')
@@ -120,6 +148,30 @@ describe('collectLintGroups', () => {
       {
         key: 'propertyTypeIssues',
         label: '@property type safety',
+        issues: [issue],
+      },
+    ])
+  })
+
+  it('extracts issues from logicalProperties ratio-shaped audit field', () => {
+    const issue = {
+      selector: '.card',
+      property: 'left',
+      value: '0',
+      logicalEquivalent: 'inset-inline-start',
+    }
+    const audit = {
+      logicalProperties: {
+        issues: [issue],
+        totalPhysicalProperties: 3,
+        migratableProperties: 2,
+        migrationRatio: 0.67,
+      },
+    }
+    expect(collectLintGroups(audit)).toEqual([
+      {
+        key: 'logicalProperties',
+        label: 'Logical properties',
         issues: [issue],
       },
     ])

--- a/lib/__tests__/css-lint-rules.test.mjs
+++ b/lib/__tests__/css-lint-rules.test.mjs
@@ -7,6 +7,7 @@ import {
   lintGapDecorationAdoption,
   lintCss,
 } from '../css-lint-rules.mjs'
+import { PHYSICAL_TO_LOGICAL, PHYSICAL_VALUE_TO_LOGICAL } from '../types.ts'
 
 describe('parseCssRules', () => {
   it('parses a simple rule', () => {
@@ -358,5 +359,64 @@ describe('lintGapDecorationAdoption', () => {
     const { adoption } = lintGapDecorationAdoption(css, { stylesheetCount: 5 })
     expect(adoption.stylesheetsScanned).toBe(5)
     expect(adoption.stylesheetsWithHacks).toBe(1)
+  })
+})
+
+describe('PHYSICAL_TO_LOGICAL mapping', () => {
+  it('maps margin physical properties to logical equivalents', () => {
+    expect(PHYSICAL_TO_LOGICAL['margin-left']).toBe('margin-inline-start')
+    expect(PHYSICAL_TO_LOGICAL['margin-right']).toBe('margin-inline-end')
+    expect(PHYSICAL_TO_LOGICAL['margin-top']).toBe('margin-block-start')
+    expect(PHYSICAL_TO_LOGICAL['margin-bottom']).toBe('margin-block-end')
+  })
+
+  it('maps padding physical properties to logical equivalents', () => {
+    expect(PHYSICAL_TO_LOGICAL['padding-left']).toBe('padding-inline-start')
+    expect(PHYSICAL_TO_LOGICAL['padding-right']).toBe('padding-inline-end')
+  })
+
+  it('maps inset/position properties', () => {
+    expect(PHYSICAL_TO_LOGICAL['left']).toBe('inset-inline-start')
+    expect(PHYSICAL_TO_LOGICAL['right']).toBe('inset-inline-end')
+    expect(PHYSICAL_TO_LOGICAL['top']).toBe('inset-block-start')
+    expect(PHYSICAL_TO_LOGICAL['bottom']).toBe('inset-block-end')
+  })
+
+  it('maps size properties', () => {
+    expect(PHYSICAL_TO_LOGICAL['width']).toBe('inline-size')
+    expect(PHYSICAL_TO_LOGICAL['height']).toBe('block-size')
+    expect(PHYSICAL_TO_LOGICAL['min-width']).toBe('min-inline-size')
+    expect(PHYSICAL_TO_LOGICAL['max-height']).toBe('max-block-size')
+  })
+
+  it('maps border-radius corners', () => {
+    expect(PHYSICAL_TO_LOGICAL['border-top-left-radius']).toBe('border-start-start-radius')
+    expect(PHYSICAL_TO_LOGICAL['border-bottom-right-radius']).toBe('border-end-end-radius')
+  })
+
+  it('maps overflow properties', () => {
+    expect(PHYSICAL_TO_LOGICAL['overflow-x']).toBe('overflow-inline')
+    expect(PHYSICAL_TO_LOGICAL['overflow-y']).toBe('overflow-block')
+  })
+
+  it('maps text-align value keywords', () => {
+    expect(PHYSICAL_VALUE_TO_LOGICAL['text-align']['left']).toBe('start')
+    expect(PHYSICAL_VALUE_TO_LOGICAL['text-align']['right']).toBe('end')
+  })
+
+  it('maps float value keywords', () => {
+    expect(PHYSICAL_VALUE_TO_LOGICAL['float']['left']).toBe('inline-start')
+    expect(PHYSICAL_VALUE_TO_LOGICAL['float']['right']).toBe('inline-end')
+  })
+
+  it('has no mapping for already-logical properties', () => {
+    expect(PHYSICAL_TO_LOGICAL['margin-inline-start']).toBeUndefined()
+    expect(PHYSICAL_TO_LOGICAL['padding-block-end']).toBeUndefined()
+    expect(PHYSICAL_TO_LOGICAL['inset-inline-start']).toBeUndefined()
+  })
+
+  it('covers 30+ physical property mappings', () => {
+    const count = Object.keys(PHYSICAL_TO_LOGICAL).length
+    expect(count).toBeGreaterThanOrEqual(30)
   })
 })

--- a/lib/__tests__/css-lint-rules.test.mjs
+++ b/lib/__tests__/css-lint-rules.test.mjs
@@ -6,6 +6,9 @@ import {
   lintGapDecorationsCompat,
   lintGapDecorationAdoption,
   lintCss,
+  lintLogicalProperties,
+  PHYSICAL_TO_LOGICAL as RUNTIME_PHYSICAL_TO_LOGICAL,
+  PHYSICAL_VALUE_TO_LOGICAL as RUNTIME_PHYSICAL_VALUE_TO_LOGICAL,
 } from '../css-lint-rules.mjs'
 import { PHYSICAL_TO_LOGICAL, PHYSICAL_VALUE_TO_LOGICAL } from '../types.ts'
 
@@ -418,5 +421,106 @@ describe('PHYSICAL_TO_LOGICAL mapping', () => {
   it('covers 30+ physical property mappings', () => {
     const count = Object.keys(PHYSICAL_TO_LOGICAL).length
     expect(count).toBeGreaterThanOrEqual(30)
+  })
+})
+
+describe('lintLogicalProperties', () => {
+  it('detects a physical margin property and suggests its logical equivalent', () => {
+    const css = '.card { margin-left: 20px; }'
+    const { issues } = lintLogicalProperties(css)
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({
+      selector: '.card',
+      property: 'margin-left',
+      value: '20px',
+      logicalEquivalent: 'margin-inline-start',
+      severity: 'suggestion',
+    })
+  })
+
+  it('detects physical padding properties', () => {
+    const css = '.card { padding-right: 1rem; }'
+    const { issues } = lintLogicalProperties(css)
+    expect(issues).toHaveLength(1)
+    expect(issues[0].logicalEquivalent).toBe('padding-inline-end')
+  })
+
+  it('detects positioning/inset physical properties', () => {
+    const css = '.sticky { left: 0; right: 0; }'
+    const { issues } = lintLogicalProperties(css)
+    expect(issues.map((i) => i.logicalEquivalent)).toEqual([
+      'inset-inline-start',
+      'inset-inline-end',
+    ])
+  })
+
+  it('detects size properties', () => {
+    const css = '.box { width: 100px; max-height: 50px; }'
+    const { issues } = lintLogicalProperties(css)
+    expect(issues.map((i) => i.logicalEquivalent)).toEqual([
+      'inline-size',
+      'max-block-size',
+    ])
+  })
+
+  it('detects physical value keywords', () => {
+    const css = '.rtl { text-align: left; float: right; }'
+    const { issues } = lintLogicalProperties(css)
+    expect(issues).toHaveLength(2)
+    expect(issues[0].logicalEquivalent).toBe('text-align: start')
+    expect(issues[1].logicalEquivalent).toBe('float: inline-end')
+  })
+
+  it('does not flag already-logical properties', () => {
+    const css = '.card { margin-inline-start: 20px; padding-block-end: 1rem; }'
+    const { issues } = lintLogicalProperties(css)
+    expect(issues).toEqual([])
+  })
+
+  it('does not flag direction-neutral properties', () => {
+    const css = '.text { color: red; font-size: 16px; }'
+    const { issues } = lintLogicalProperties(css)
+    expect(issues).toEqual([])
+  })
+
+  it('returns empty results and zero ratio for clean CSS', () => {
+    const { issues, totalPhysicalProperties, migratableProperties, migrationRatio } =
+      lintLogicalProperties('.text { color: red; }')
+    expect(issues).toEqual([])
+    expect(totalPhysicalProperties).toBe(0)
+    expect(migratableProperties).toBe(0)
+    expect(migrationRatio).toBe(0)
+  })
+
+  it('computes total, migratable, and ratio across mixed CSS', () => {
+    const css = `
+      .a { margin-left: 1rem; }
+      .b { border-top-color: red; }
+      .c { width: 50%; }
+    `
+    const { issues, totalPhysicalProperties, migratableProperties, migrationRatio } =
+      lintLogicalProperties(css)
+    // margin-left and width are migratable; border-top-color is physical but
+    // has no logical equivalent, so it is counted but not migratable.
+    expect(totalPhysicalProperties).toBe(3)
+    expect(migratableProperties).toBe(2)
+    expect(issues).toHaveLength(2)
+    expect(migrationRatio).toBeCloseTo(2 / 3)
+  })
+
+  it('includes a reason with the suggested equivalent', () => {
+    const css = '.card { margin-left: 20px; }'
+    const { issues } = lintLogicalProperties(css)
+    expect(issues[0].reason).toContain('margin-inline-start')
+  })
+})
+
+describe('logical property mapping parity (types.ts vs runtime)', () => {
+  it('keeps the runtime property map in sync with types.ts', () => {
+    expect(RUNTIME_PHYSICAL_TO_LOGICAL).toEqual(PHYSICAL_TO_LOGICAL)
+  })
+
+  it('keeps the runtime value map in sync with types.ts', () => {
+    expect(RUNTIME_PHYSICAL_VALUE_TO_LOGICAL).toEqual(PHYSICAL_VALUE_TO_LOGICAL)
   })
 })

--- a/lib/__tests__/css-lint-rules.test.mjs
+++ b/lib/__tests__/css-lint-rules.test.mjs
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
 import {
   parseCssRules,
   parseDeclarations,
@@ -512,6 +513,72 @@ describe('lintLogicalProperties', () => {
     const css = '.card { margin-left: 20px; }'
     const { issues } = lintLogicalProperties(css)
     expect(issues[0].reason).toContain('margin-inline-start')
+  })
+})
+
+describe('lintLogicalProperties with the logical-properties fixture (Stylelint 17.10)', () => {
+  // Stylelint 17.10 shipped three layout-mappings rules to enforce flow-relative
+  // CSS: property-layout-mappings, unit-layout-mappings, and
+  // value-keyword-layout-mappings. This fixture exercises the deterministic
+  // audit's coverage of the property- and value-keyword-level mappings.
+  const fixture = readFileSync(
+    new URL('../__fixtures__/logical-properties.css', import.meta.url),
+    'utf8'
+  )
+
+  it('flags every physical property in the .card rule with a logical equivalent (property-layout-mappings)', () => {
+    const { issues } = lintLogicalProperties(fixture)
+    const cardIssues = issues.filter((i) => i.selector === '.card')
+
+    // All 18 physical declarations in .card have a logical equivalent.
+    expect(cardIssues).toHaveLength(18)
+    // Spot-check a representative subset across margin/padding/border/inset/size/overflow.
+    const mapped = Object.fromEntries(
+      cardIssues.map((i) => [i.property, i.logicalEquivalent])
+    )
+    expect(mapped['margin-left']).toBe('margin-inline-start')
+    expect(mapped['padding-top']).toBe('padding-block-start')
+    expect(mapped['border-right-color']).toBe('border-inline-end-color')
+    expect(mapped['left']).toBe('inset-inline-start')
+    expect(mapped['width']).toBe('inline-size')
+    expect(mapped['overflow-y']).toBe('overflow-block')
+  })
+
+  it('leaves already-logical .toolbar properties untouched', () => {
+    const { issues } = lintLogicalProperties(fixture)
+    const toolbarIssues = issues.filter((i) => i.selector === '.toolbar')
+    expect(toolbarIssues).toEqual([])
+  })
+
+  it('flags physical value keywords on direction-sensitive properties (value-keyword-layout-mappings)', () => {
+    const { issues } = lintLogicalProperties(fixture)
+    const dirIssues = issues.filter((i) => i.selector === '.direction-sensitive')
+
+    expect(dirIssues).toHaveLength(4)
+    const mapped = Object.fromEntries(
+      dirIssues.map((i) => [i.property, i.logicalEquivalent])
+    )
+    expect(mapped['text-align']).toBe('text-align: start')
+    expect(mapped['float']).toBe('float: inline-end')
+    expect(mapped['clear']).toBe('clear: inline-start')
+    expect(mapped['resize']).toBe('resize: inline')
+  })
+
+  it('leaves direction-neutral .neutral declarations untouched', () => {
+    const { issues } = lintLogicalProperties(fixture)
+    const neutralIssues = issues.filter((i) => i.selector === '.neutral')
+    expect(neutralIssues).toEqual([])
+  })
+
+  it('computes the migration ratio across the whole mixed fixture', () => {
+    const { totalPhysicalProperties, migratableProperties, migrationRatio } =
+      lintLogicalProperties(fixture)
+
+    // 18 physical properties in .card + 4 physical value keywords in
+    // .direction-sensitive, all migratable.
+    expect(totalPhysicalProperties).toBe(22)
+    expect(migratableProperties).toBe(22)
+    expect(migrationRatio).toBe(1)
   })
 })
 

--- a/lib/audit-summary.mjs
+++ b/lib/audit-summary.mjs
@@ -27,6 +27,12 @@ const LINT_CATEGORIES = [
     shortLabel: 'property types',
     label: '@property type safety',
   },
+  {
+    key: 'logicalProperties',
+    shortLabel: 'logical',
+    label: 'Logical properties',
+    ratio: true,
+  },
 ]
 
 /**
@@ -35,7 +41,13 @@ const LINT_CATEGORIES = [
  */
 export function formatLintSummary(audit) {
   if (!audit) return ''
-  return LINT_CATEGORIES.map(({ key, shortLabel }) => {
+  return LINT_CATEGORIES.map(({ key, shortLabel, ratio }) => {
+    if (ratio) {
+      const val = audit[key]
+      if (!val || !val.issues || val.issues.length === 0) return null
+      const pct = Math.round(val.migrationRatio * 100)
+      return `${val.migratableProperties}/${val.totalPhysicalProperties} ${shortLabel} (${pct}%)`
+    }
     const count = audit[key]?.length ?? 0
     return count > 0 ? `${count} ${shortLabel}` : null
   })
@@ -50,8 +62,10 @@ export function formatLintSummary(audit) {
 export function collectLintGroups(audit) {
   if (!audit) return []
   const groups = []
-  for (const { key, label } of LINT_CATEGORIES) {
-    const issues = audit[key] ?? []
+  for (const { key, label, ratio } of LINT_CATEGORIES) {
+    const val = audit[key]
+    if (!val) continue
+    const issues = ratio ? (val.issues ?? []) : (val ?? [])
     if (issues.length > 0) groups.push({ key, label, issues })
   }
   return groups

--- a/lib/css-lint-rules.mjs
+++ b/lib/css-lint-rules.mjs
@@ -382,3 +382,159 @@ export function lintCss(css, projectDir) {
     findings: [...gapResult.findings, ...compatResult.findings],
   }
 }
+
+/**
+ * Physical -> logical property mapping used by `lintLogicalProperties`.
+ *
+ * This is the runtime mirror of `PHYSICAL_TO_LOGICAL` in `lib/types.ts`.
+ * The copy lives here because this module is plain Node ESM (published to npm
+ * and executed directly via `node bin/mint-ds.mjs`) and cannot import
+ * TypeScript sources. The test suite asserts the two copies stay in sync.
+ */
+export const PHYSICAL_TO_LOGICAL = {
+  // Margin
+  'margin-left': 'margin-inline-start',
+  'margin-right': 'margin-inline-end',
+  'margin-top': 'margin-block-start',
+  'margin-bottom': 'margin-block-end',
+  // Padding
+  'padding-left': 'padding-inline-start',
+  'padding-right': 'padding-inline-end',
+  'padding-top': 'padding-block-start',
+  'padding-bottom': 'padding-block-end',
+  // Border
+  'border-left': 'border-inline-start',
+  'border-right': 'border-inline-end',
+  'border-top': 'border-block-start',
+  'border-bottom': 'border-block-end',
+  'border-left-color': 'border-inline-start-color',
+  'border-right-color': 'border-inline-end-color',
+  'border-left-style': 'border-inline-start-style',
+  'border-right-style': 'border-inline-end-style',
+  'border-left-width': 'border-inline-start-width',
+  'border-right-width': 'border-inline-end-width',
+  // Border radius
+  'border-top-left-radius': 'border-start-start-radius',
+  'border-top-right-radius': 'border-start-end-radius',
+  'border-bottom-left-radius': 'border-end-start-radius',
+  'border-bottom-right-radius': 'border-end-end-radius',
+  // Inset / positioning
+  left: 'inset-inline-start',
+  right: 'inset-inline-end',
+  top: 'inset-block-start',
+  bottom: 'inset-block-end',
+  // Size
+  width: 'inline-size',
+  height: 'block-size',
+  'min-width': 'min-inline-size',
+  'min-height': 'min-block-size',
+  'max-width': 'max-inline-size',
+  'max-height': 'max-block-size',
+  // Overflow
+  'overflow-x': 'overflow-inline',
+  'overflow-y': 'overflow-block',
+}
+
+/**
+ * Physical value -> logical value mapping for direction-sensitive properties.
+ * Runtime mirror of `PHYSICAL_VALUE_TO_LOGICAL` in `lib/types.ts`.
+ */
+export const PHYSICAL_VALUE_TO_LOGICAL = {
+  'text-align': { left: 'start', right: 'end' },
+  float: { left: 'inline-start', right: 'inline-end' },
+  clear: { left: 'inline-start', right: 'inline-end' },
+  resize: { horizontal: 'inline', vertical: 'block' },
+}
+
+/**
+ * True when a property name contains a physical direction keyword
+ * (left / right / top / bottom) as a whole word segment. Used to count
+ * physical properties that have no logical equivalent yet (e.g.
+ * `border-top-color`), so the migration ratio stays honest rather than 1.0.
+ */
+function isPhysicalProperty(property) {
+  return /(^|-)(left|right|top|bottom)(-|$)/.test(property)
+}
+
+/**
+ * True when a CSS value contains `keyword` as a whitespace-delimited token.
+ */
+function valueHasKeyword(value, keyword) {
+  return String(value).split(/\s+/).includes(keyword)
+}
+
+/**
+ * Detect physical-directional CSS properties and suggest flow-relative
+ * (logical) equivalents for automatic RTL/LTR and writing-mode support.
+ *
+ * Emits one issue per physical declaration that has a logical equivalent,
+ * carrying the selector, the physical property (or value), and the suggested
+ * flow-relative replacement. Aggregate counts (`totalPhysicalProperties`,
+ * `migratableProperties`, `migrationRatio`) quantify the migration surface.
+ *
+ * @param {string} css - Raw CSS source
+ * @returns {{ issues: Array<{selector, property, value, logicalEquivalent, reason, severity}>, totalPhysicalProperties: number, migratableProperties: number, migrationRatio: number }}
+ */
+export function lintLogicalProperties(css) {
+  const issues = []
+  const rules = parseCssRules(css)
+
+  let totalPhysicalProperties = 0
+
+  for (const rule of rules) {
+    const decls = parseDeclarations(rule.body)
+
+    for (const [property, value] of decls) {
+      // 1. Physical property with a direct logical property equivalent.
+      if (PHYSICAL_TO_LOGICAL[property]) {
+        totalPhysicalProperties += 1
+        const logicalEquivalent = PHYSICAL_TO_LOGICAL[property]
+        issues.push({
+          selector: rule.selector,
+          property,
+          value,
+          logicalEquivalent,
+          reason: `'${property}' is a physical property. Use '${logicalEquivalent}' for flow-relative layout that adapts to writing mode and direction.`,
+          severity: 'suggestion',
+        })
+        continue
+      }
+
+      // 2. Physical property without a logical equivalent (still counted so
+      //    the migration ratio reflects the full physical surface).
+      if (isPhysicalProperty(property)) {
+        totalPhysicalProperties += 1
+        continue
+      }
+
+      // 3. Direction-sensitive property with a physical value keyword.
+      const valueMap = PHYSICAL_VALUE_TO_LOGICAL[property]
+      if (valueMap) {
+        for (const [physicalKeyword, logicalKeyword] of Object.entries(valueMap)) {
+          if (valueHasKeyword(value, physicalKeyword)) {
+            totalPhysicalProperties += 1
+            issues.push({
+              selector: rule.selector,
+              property,
+              value,
+              logicalEquivalent: `${property}: ${logicalKeyword}`,
+              reason: `'${physicalKeyword}' is a physical value for '${property}'. Use '${logicalKeyword}' for flow-relative layout.`,
+              severity: 'suggestion',
+            })
+          }
+        }
+      }
+    }
+  }
+
+  const migratableProperties = issues.length
+  const migrationRatio =
+    totalPhysicalProperties > 0 ? migratableProperties / totalPhysicalProperties : 0
+
+  return {
+    issues,
+    totalPhysicalProperties,
+    migratableProperties,
+    migrationRatio,
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -169,6 +169,73 @@ export interface PropertyTypeIssue {
   declaredSyntax: string // the @property syntax descriptor, e.g. '<color>'
 }
 
+export interface LogicalPropertyIssue {
+  selector: string
+  property: string // the physical property, e.g. 'margin-left'
+  value: string // the property value, e.g. '20px'
+  logicalEquivalent: string // the suggested flow-relative property, e.g. 'margin-inline-start'
+  reason: string
+  severity: 'suggestion' | 'warning'
+}
+
+export interface LogicalPropertyAudit {
+  issues: LogicalPropertyIssue[]
+  totalPhysicalProperties: number
+  migratableProperties: number
+  migrationRatio: number // 0.0-1.0, fraction that can be migrated
+}
+
+export const PHYSICAL_TO_LOGICAL: Record<string, string> = {
+  // Margin
+  'margin-left': 'margin-inline-start',
+  'margin-right': 'margin-inline-end',
+  'margin-top': 'margin-block-start',
+  'margin-bottom': 'margin-block-end',
+  // Padding
+  'padding-left': 'padding-inline-start',
+  'padding-right': 'padding-inline-end',
+  'padding-top': 'padding-block-start',
+  'padding-bottom': 'padding-block-end',
+  // Border
+  'border-left': 'border-inline-start',
+  'border-right': 'border-inline-end',
+  'border-top': 'border-block-start',
+  'border-bottom': 'border-block-end',
+  'border-left-color': 'border-inline-start-color',
+  'border-right-color': 'border-inline-end-color',
+  'border-left-style': 'border-inline-start-style',
+  'border-right-style': 'border-inline-end-style',
+  'border-left-width': 'border-inline-start-width',
+  'border-right-width': 'border-inline-end-width',
+  // Border radius
+  'border-top-left-radius': 'border-start-start-radius',
+  'border-top-right-radius': 'border-start-end-radius',
+  'border-bottom-left-radius': 'border-end-start-radius',
+  'border-bottom-right-radius': 'border-end-end-radius',
+  // Inset / positioning
+  'left': 'inset-inline-start',
+  'right': 'inset-inline-end',
+  'top': 'inset-block-start',
+  'bottom': 'inset-block-end',
+  // Size
+  'width': 'inline-size',
+  'height': 'block-size',
+  'min-width': 'min-inline-size',
+  'min-height': 'min-block-size',
+  'max-width': 'max-inline-size',
+  'max-height': 'max-block-size',
+  // Overflow
+  'overflow-x': 'overflow-inline',
+  'overflow-y': 'overflow-block',
+}
+
+export const PHYSICAL_VALUE_TO_LOGICAL: Record<string, Record<string, string>> = {
+  'text-align': { 'left': 'start', 'right': 'end' },
+  'float': { 'left': 'inline-start', 'right': 'inline-end' },
+  'clear': { 'left': 'inline-start', 'right': 'inline-end' },
+  'resize': { 'horizontal': 'inline', 'vertical': 'block' },
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -183,6 +250,7 @@ export interface AuditReport {
   adoptionSuggestions?: AdoptionSuggestion[]
   overflowSafetyIssues?: OverflowSafetyIssue[]
   propertyTypeIssues?: PropertyTypeIssue[]
+  logicalProperties?: LogicalPropertyAudit
 }
 
 export interface ColorDecision {


### PR DESCRIPTION
**Card:** https://github.com/nujovich/mint-radar/issues/19

**What:** Adds a deterministic logical properties migration audit to Mint. Milestone 1 introduces the `LogicalPropertyIssue`, `LogicalPropertyAudit`, and `PHYSICAL_TO_LOGICAL` mapping types in `lib/types.ts`, plus the `logicalProperties` field on `AuditReport`. The mapping covers 30+ physical CSS properties and their flow-relative equivalents (e.g. `margin-left` -> `margin-inline-start`, `padding-right` -> `padding-inline-end`, `left` -> `inset-inline-start`), plus directional keyword mappings (`text-align: left` -> `text-align: start`). Future milestones will implement the parser, wire CLI output, and add Stylelint 17.10-aligned tests.

**Why:** Stylelint 17.10 standardized logical property enforcement with three new rules (`property-layout-mappings`, `unit-layout-mappings`, `value-keyword-layout-mappings`). Mint's CSS audit needs a deterministic analyzer that detects physical directional properties and guides users toward flow-relative equivalents for automatic RTL/LTR and writing-mode support. The deterministic approach complements the existing LLM-based STEP 14 analysis (from card #10) by providing instant, syntax-level detection without LLM latency or cost.

## Milestones

- [x] Milestone 1 -- Add `LogicalPropertyIssue`, `LogicalPropertyAudit`, and `PHYSICAL_TO_LOGICAL` mapping to `lib/types.ts`; add `logicalProperties` field to `AuditReport`
- [x] Milestone 2 -- Implement `lintLogicalProperties()` in `lib/css-lint-rules.mjs`: parse CSS, detect physical properties where flow-relative equivalents exist, emit issues with selectors and suggestions
- [x] Milestone 3 -- Wire `logicalProperties` into `bin/mint-ds.mjs` CLI output and `audit-summary.mjs` as a lint category with migration ratio display
- [x] Milestone 4 -- Add test fixture with mixed logical/physical CSS and tests referencing Stylelint 17.10 logical-properties rules

**How to test:**
```bash
npx vitest run lib/__tests__/css-lint-rules.test.mjs
# After milestone 3:
node bin/mint-ds.mjs lint <directory-with-physical-css>
```
