### PR TITLE
feat(mint): add CSS nesting depth audit

### DIFF
--- a/BUILD-PLAN-issue-23.md
+++ b/BUILD-PLAN-issue-23.md
@@ -1,0 +1,12 @@
+# BUILD-PLAN-issue-23 — CSS nesting depth and specificity anti-pattern audit
+
+**Card:** https://github.com/nujovich/mint-radar/issues/23
+
+**Decision:** PLAN defined 4 concrete code milestones.
+
+## Milestones
+
+- [ ] Milestone 1 — Add `NestingAudit` type to `lib/types.ts` with `maxDepth`, `specificityGrowth`, and `unnecessaryAmpersand` fields, plus a `nesting` field on `AuditReport`
+- [ ] Milestone 2 — Implement a parser that walks nested selectors with `&`, measuring maximum depth and flagging unnecessary `&` (when the nested selector is already specific)
+- [ ] Milestone 3 — Add a nesting complexity heatmap to the audit output with a configurable `--max-nesting-depth` threshold
+- [ ] Milestone 4 — Add test fixtures and tests based on Piccalilli and Kilian Valkhof nesting pitfalls

--- a/bin/mint-ds.mjs
+++ b/bin/mint-ds.mjs
@@ -23,7 +23,11 @@ import { convertTokensToDTCG, serializeDTCG } from '../lib/dtcg-exporter.mjs'
 import { convertTokensToDesignMd } from '../lib/design-md.mjs'
 import { formatLintSummary } from '../lib/audit-summary.mjs'
 import { checkCompat } from '../lib/css-compat-data.mjs'
-import { lintCss, lintGapDecorationAdoption } from '../lib/css-lint-rules.mjs'
+import {
+  lintCss,
+  lintGapDecorationAdoption,
+  nestingDepthHeatmap,
+} from '../lib/css-lint-rules.mjs'
 import { applyWsl2DnsWorkaround } from '../lib/net-utils.mjs'
 import { buildTokenIndex } from '../lib/token-index.mjs'
 import { applyCodemod } from '../lib/css-codemod.mjs'
@@ -153,6 +157,10 @@ ${styles.bold('DIFF OPTIONS')}
   --json                       Output the diff as JSON (for CI / PR bots)
                                  Exits non-zero on breaking changes (removed / value-changed)
 
+${styles.bold('LINT OPTIONS')}
+  --max-nesting-depth <n>      Max allowed CSS nesting depth before a rule is flagged
+                                 in the nesting heatmap (default: 3)
+
 ${styles.bold('AUTH (any command)')}
   --api-key <value>            LLM provider API key (overrides API_KEY env var)
 
@@ -216,6 +224,13 @@ function parseFlags(argv) {
     }
   }
   return { flags, rest }
+}
+
+function parseMaxNestingDepth(flags) {
+  const raw = flags['max-nesting-depth']
+  if (raw === undefined || raw === true) return 3
+  const n = Number.parseInt(String(raw), 10)
+  return Number.isFinite(n) && n >= 0 ? n : 3
 }
 
 async function* walk(dir, root, ignore = []) {
@@ -514,7 +529,7 @@ async function cmdCache(argv) {
 }
 
 async function cmdLint(argv) {
-  const { rest } = parseFlags(argv)
+  const { flags, rest } = parseFlags(argv)
   const target = rest[0]
   if (!target) die('Usage: mint-ds lint <directory>')
 
@@ -568,6 +583,44 @@ async function cmdLint(argv) {
       log(styles.dim(`    - ${pattern}: ${count}`))
     }
     log('')
+  }
+
+  // Nesting complexity heatmap with a configurable depth threshold.
+  const maxNestingDepth = parseMaxNestingDepth(flags)
+  const heatmap = nestingDepthHeatmap(css, { maxDepth: maxNestingDepth })
+
+  if (heatmap.totalRules > 0) {
+    log('')
+    log(
+      styles.bold(
+        `Nesting Complexity Heatmap (max depth threshold ${maxNestingDepth})`
+      )
+    )
+
+    const maxCount = Math.max(1, ...heatmap.counts.map((c) => c.count))
+    const barWidth = 40
+    for (const { depth, count } of heatmap.counts) {
+      const over = depth > maxNestingDepth
+      const barLen = Math.max(1, Math.round((count / maxCount) * barWidth))
+      const bar = '#'.repeat(barLen)
+      const coloredBar = over
+        ? styles.red(bar)
+        : depth === maxNestingDepth
+          ? styles.yellow(bar)
+          : styles.green(bar)
+      const suffix = over ? '  over threshold' : ''
+      log(
+        `  depth ${String(depth).padEnd(2)}  ${String(count).padStart(4)} rule(s)  ${coloredBar}${suffix}`
+      )
+    }
+
+    for (const ex of heatmap.excessive) {
+      log(
+        styles.yellow(
+          `  WARN  ${ex.selector}  nested ${ex.depth} level(s) deep (threshold ${maxNestingDepth})`
+        )
+      )
+    }
   }
 }
 

--- a/lib/__fixtures__/nesting-pitfalls.css
+++ b/lib/__fixtures__/nesting-pitfalls.css
@@ -1,0 +1,157 @@
+/* CSS nesting pitfalls — test fixture for Milestone 4.
+   Covers patterns flagged by Piccalilli (Andy Bell) and Kilian Valkhof
+   as common sources of confusion with native CSS nesting. */
+
+/* === KILIAN VALKHOF PITFALLS === */
+
+/* Pitfall 1: :is() specificity compounding (Kilian Valkhof, 2023-06-13).
+   `#page, .content { & p { ... } }` becomes `:is(#page, .content) p`
+   with specificity 1,0,1 (from #page), not 0,0,2. The ID bleeds through. */
+#page,
+.content {
+  & p {
+    margin-block: 1rem;
+    color: var(--text);
+  }
+}
+
+/* Pitfall 2: Media query interleaving reorders property priority.
+   `body { @media all { background: red; } background: blue; }`
+   The browser splits this: body{background:blue} then @media{:is(body){background:red}}
+   so red wins even though blue appears later in source order. */
+body {
+  @media all {
+    background: red;
+  }
+  background: blue;
+
+  @media all {
+    color: deeppink;
+  }
+
+  rotate: 20deg;
+}
+
+/* Pitfall 3: Nested @media with parent wrappers.
+   Both nested rules inside the body block should have depth 1 with
+   parentSelector 'body'. The @media block is transparent. */
+body {
+  @media (min-width: 600px) {
+    & .sidebar {
+      display: none;
+    }
+  }
+
+  @media (max-width: 599px) {
+    & .sidebar {
+      display: block;
+    }
+  }
+}
+
+/* === PICCALILLI (ANDY BELL) PITFALLS === */
+
+/* Pitfall 4: BEM modifier with nested child (Piccalilli, 2025-01-30).
+   `.component { &--reversed { &__child { ... } } }`
+   The inner `&` resolves to `.component--reversed`, so the compiled selector
+   becomes `.component--reversed__child-element` instead of the intended
+   `.component--reversed .component__child-element`.
+   This fixture has both the problematic deep &__ nesting AND a correct
+   flat alternative so the auditor can measure depth and flag deep nesting. */
+.component {
+  display: block;
+
+  &--reversed {
+    background: white;
+
+    &__child-element {
+      background: rebeccapurple;
+    }
+  }
+}
+
+/* Correct alternative: flat BEM with no deep nesting. */
+.component--correct {
+  background: white;
+
+  & .component__child-element {
+    background: rebeccapurple;
+  }
+}
+
+/* Pitfall 5: Deep nesting (4+ levels) that mirrors DOM structure (Piccalilli).
+   Nesting should be kept shallow (max 1-2 levels). This exercises the
+   maxDepth and heatmap threshold (default 3). */
+.page {
+  & .section {
+    & .card {
+      & .card-body {
+        & .card-text {
+          color: var(--text-secondary);
+          font-size: 0.875rem;
+        }
+      }
+    }
+  }
+}
+
+/* Pitfall 6: Redundant & before combinators (both authors).
+   `& .title`, `& > .item`, `& + .sibling`, `& ~ .next` all have
+   unnecessary `&` — the relative selector form already works. */
+.card {
+  padding: 1rem;
+
+  & .title {
+    font-weight: 700;
+  }
+
+  & > .body {
+    margin-top: 0.5rem;
+  }
+
+  & + .card {
+    margin-top: 1rem;
+  }
+
+  & ~ .divider {
+    border-top: 1px solid #eee;
+  }
+}
+
+/* Pitfall 7: Legitimate compound & (should NOT be flagged).
+   These `&` uses are necessary: pseudo-classes, class concatenation,
+   attribute selectors, pseudo-elements. */
+.button {
+  display: inline-flex;
+
+  &:hover {
+    background: var(--hover-bg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--focus-ring);
+  }
+
+  &.primary {
+    background: var(--primary);
+  }
+
+  &[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &::after {
+    content: '';
+    display: block;
+  }
+}
+
+/* Pitfall 8: Non-leading & (should NOT be flagged).
+   `&` in the middle of a selector is a valid BEM/suffix pattern
+   and is not a redundant combinator. */
+.theme-dark {
+  & .button {
+    color: white;
+  }
+}

--- a/lib/__tests__/css-lint-rules.test.mjs
+++ b/lib/__tests__/css-lint-rules.test.mjs
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
 import {
   parseCssRules,
   parseDeclarations,
@@ -523,5 +524,126 @@ describe('nestingDepthHeatmap', () => {
     expect(result.maxDepth).toBe(0)
     expect(result.counts).toEqual([])
     expect(result.excessive).toEqual([])
+  })
+})
+
+/* ── Milestone 4: Piccalilli & Kilian Valkhof nesting pitfalls ── */
+
+const nestingFixture = readFileSync(
+  new URL('../__fixtures__/nesting-pitfalls.css', import.meta.url),
+  'utf-8'
+)
+
+describe('parseNestedRules with nesting-pitfalls fixture', () => {
+  it('detects :is() specificity compounding depth (Kilian)', () => {
+    const rules = parseNestedRules(nestingFixture)
+    const pageRules = rules.filter((r) => r.selector === '& p')
+    expect(pageRules.length).toBeGreaterThanOrEqual(1)
+    for (const r of pageRules) {
+      expect(r.depth).toBe(1)
+      expect(r.parentSelector).toMatch(/#page, .content/)
+    }
+  })
+
+  it('parses media-query-interleaved body rules (Kilian)', () => {
+    const rules = parseNestedRules(nestingFixture)
+    const sidebarRules = rules.filter((r) => r.selector === '& .sidebar')
+    expect(sidebarRules.length).toBeGreaterThanOrEqual(2)
+    for (const r of sidebarRules) {
+      expect(r.depth).toBe(1)
+      expect(r.parentSelector).toBe('body')
+    }
+  })
+
+  it('detects deep BEM nesting with depth 2 (Piccalilli)', () => {
+    const rules = parseNestedRules(nestingFixture)
+    const childRules = rules.filter((r) => r.selector === '&__child-element')
+    expect(childRules.length).toBeGreaterThanOrEqual(1)
+    for (const r of childRules) {
+      expect(r.depth).toBe(2)
+      expect(r.parentSelector).toBe('&--reversed')
+    }
+  })
+
+  it('measures maxDepth 4+ for deep DOM-mirror nesting (Piccalilli)', () => {
+    const rules = parseNestedRules(nestingFixture)
+    const cardText = rules.filter((r) => r.selector === '& .card-text')
+    expect(cardText.length).toBeGreaterThanOrEqual(1)
+    for (const r of cardText) {
+      expect(r.depth).toBeGreaterThanOrEqual(4)
+    }
+  })
+})
+
+describe('lintNesting with nesting-pitfalls fixture', () => {
+  it('flags redundant & before combinators in .card block', () => {
+    const result = lintNesting(nestingFixture)
+    const cardAmpersands = result.unnecessaryAmpersand.filter(
+      (f) =>
+        f.selector.startsWith('& ') ||
+        f.selector.startsWith('& >') ||
+        f.selector.startsWith('& +') ||
+        f.selector.startsWith('& ~')
+    )
+    expect(cardAmpersands.length).toBeGreaterThanOrEqual(4)
+    for (const issue of cardAmpersands) {
+      expect(issue.severity).toBe('suggestion')
+    }
+  })
+
+  it('does NOT flag compound & pseudo-classes in .button block', () => {
+    const result = lintNesting(nestingFixture)
+    const buttonIssues = result.unnecessaryAmpersand.filter(
+      (f) =>
+        f.selector.startsWith('&:') ||
+        f.selector.startsWith('&.') ||
+        f.selector.startsWith('&[') ||
+        f.selector.startsWith('&::')
+    )
+    expect(buttonIssues).toEqual([])
+  })
+
+  it('reports maxDepth reflecting the deepest rule', () => {
+    const result = lintNesting(nestingFixture)
+    // The .card-text rule is depth 4+
+    expect(result.maxDepth).toBeGreaterThanOrEqual(4)
+  })
+
+  it('flags both descendant and sibling redundant &', () => {
+    const result = lintNesting(nestingFixture)
+    const selectors = result.unnecessaryAmpersand.map((f) => f.selector)
+    expect(selectors).toContain('& .title')
+    expect(selectors).toContain('& > .body')
+    expect(selectors).toContain('& + .card')
+    expect(selectors).toContain('& ~ .divider')
+    expect(selectors).toContain('& .component__child-element')
+  })
+})
+
+describe('nestingDepthHeatmap with nesting-pitfalls fixture', () => {
+  it('counts all rules and distributes by depth', () => {
+    const result = nestingDepthHeatmap(nestingFixture)
+    expect(result.totalRules).toBeGreaterThan(0)
+    expect(result.maxDepth).toBeGreaterThanOrEqual(4)
+    // Depth 0 (top-level) should have multiple rules
+    const topLevel = result.counts.find((c) => c.depth === 0)
+    expect(topLevel).toBeDefined()
+    expect(topLevel.count).toBeGreaterThanOrEqual(4)
+  })
+
+  it('flags rules beyond default threshold (3) as excessive', () => {
+    const result = nestingDepthHeatmap(nestingFixture)
+    const excessive = result.excessive
+    // The .card-text rule at depth 4+ should be flagged
+    const deepNested = excessive.filter((e) => e.depth >= 4)
+    expect(deepNested.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('respects a custom threshold of 2', () => {
+    const result = nestingDepthHeatmap(nestingFixture, { maxDepth: 2 })
+    const excessive = result.excessive
+    // Depth 3+ rules should be flagged
+    const deepNested = excessive.filter((e) => e.depth >= 3)
+    expect(deepNested.length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/lib/__tests__/css-lint-rules.test.mjs
+++ b/lib/__tests__/css-lint-rules.test.mjs
@@ -6,6 +6,8 @@ import {
   lintGapDecorationsCompat,
   lintGapDecorationAdoption,
   lintCss,
+  parseNestedRules,
+  lintNesting,
 } from '../css-lint-rules.mjs'
 
 describe('parseCssRules', () => {
@@ -358,5 +360,121 @@ describe('lintGapDecorationAdoption', () => {
     const { adoption } = lintGapDecorationAdoption(css, { stylesheetCount: 5 })
     expect(adoption.stylesheetsScanned).toBe(5)
     expect(adoption.stylesheetsWithHacks).toBe(1)
+  })
+})
+
+describe('parseNestedRules', () => {
+  it('parses a flat stylesheet with depth 0 and null parents', () => {
+    const rules = parseNestedRules('.a { color: red; }\n.b { color: blue; }')
+    expect(rules).toHaveLength(2)
+    expect(rules[0].selector).toBe('.a')
+    expect(rules[0].depth).toBe(0)
+    expect(rules[0].parentSelector).toBeNull()
+    expect(rules[1].selector).toBe('.b')
+  })
+
+  it('detects a single level of nesting', () => {
+    const rules = parseNestedRules('.card { & .title { font-weight: bold; } }')
+    expect(rules).toHaveLength(2)
+    expect(rules[0].selector).toBe('.card')
+    expect(rules[0].depth).toBe(0)
+    expect(rules[1].selector).toBe('& .title')
+    expect(rules[1].depth).toBe(1)
+    expect(rules[1].parentSelector).toBe('.card')
+  })
+
+  it('measures deeper nesting levels', () => {
+    const rules = parseNestedRules('.a { & .b { & .c { color: red; } } }')
+    expect(rules.map((r) => r.depth)).toEqual([0, 1, 2])
+    expect(rules[2].selector).toBe('& .c')
+  })
+
+  it('strips leading declarations before a nested rule', () => {
+    const rules = parseNestedRules(
+      '.card { color: red; & .title { font-weight: bold; } }'
+    )
+    expect(rules[1].selector).toBe('& .title')
+  })
+
+  it('recurses through at-rules without changing depth', () => {
+    const rules = parseNestedRules(
+      '@media (min-width: 600px) { .foo { color: red; } }'
+    )
+    expect(rules).toHaveLength(1)
+    expect(rules[0].selector).toBe('.foo')
+    expect(rules[0].depth).toBe(0)
+    expect(rules[0].parentSelector).toBeNull()
+  })
+
+  it('handles nested at-rules inside a rule', () => {
+    const rules = parseNestedRules(
+      '.card { @media (min-width: 600px) { & .title { color: red; } } }'
+    )
+    expect(rules[1].selector).toBe('& .title')
+    expect(rules[1].depth).toBe(1)
+    expect(rules[1].parentSelector).toBe('.card')
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parseNestedRules('')).toEqual([])
+  })
+})
+
+describe('lintNesting', () => {
+  it('reports maxDepth 0 and no findings for flat CSS', () => {
+    const result = lintNesting('.text { color: red; }')
+    expect(result.maxDepth).toBe(0)
+    expect(result.unnecessaryAmpersand).toEqual([])
+    expect(result.specificityGrowth).toEqual([])
+  })
+
+  it('reports maxDepth 1 for one level of nesting', () => {
+    const result = lintNesting('.card { & .title { color: red; } }')
+    expect(result.maxDepth).toBe(1)
+  })
+
+  it('reports maxDepth 2 for two levels of nesting', () => {
+    const result = lintNesting('.a { & .b { & .c { color: red; } } }')
+    expect(result.maxDepth).toBe(2)
+  })
+
+  it('flags a redundant "&" before a descendant selector', () => {
+    const result = lintNesting('.card { & .title { color: red; } }')
+    expect(result.unnecessaryAmpersand).toHaveLength(1)
+    expect(result.unnecessaryAmpersand[0].selector).toBe('& .title')
+    expect(result.unnecessaryAmpersand[0].depth).toBe(1)
+    expect(result.unnecessaryAmpersand[0].severity).toBe('suggestion')
+  })
+
+  it('flags redundant "&" before child and sibling combinators', () => {
+    const css =
+      '.a { & > .b { color: red; } & + .c { color: blue; } & ~ .d { color: green; } }'
+    const result = lintNesting(css)
+    expect(result.unnecessaryAmpersand).toHaveLength(3)
+    expect(result.unnecessaryAmpersand.map((f) => f.selector)).toEqual([
+      '& > .b',
+      '& + .c',
+      '& ~ .d',
+    ])
+  })
+
+  it('does not flag compound "&" forms that are necessary', () => {
+    const css =
+      '.card { &:hover { color: red; } &.active { color: blue; } &[disabled] { opacity: 0.5; } &::before { content: ""; } }'
+    const result = lintNesting(css)
+    expect(result.unnecessaryAmpersand).toEqual([])
+  })
+
+  it('does not flag "&" in the middle of a selector', () => {
+    const css = '.a { .theme-dark & .button { color: red; } }'
+    const result = lintNesting(css)
+    expect(result.unnecessaryAmpersand).toEqual([])
+  })
+
+  it('handles empty CSS gracefully', () => {
+    const result = lintNesting('')
+    expect(result.maxDepth).toBe(0)
+    expect(result.unnecessaryAmpersand).toEqual([])
+    expect(result.specificityGrowth).toEqual([])
   })
 })

--- a/lib/__tests__/css-lint-rules.test.mjs
+++ b/lib/__tests__/css-lint-rules.test.mjs
@@ -8,6 +8,7 @@ import {
   lintCss,
   parseNestedRules,
   lintNesting,
+  nestingDepthHeatmap,
 } from '../css-lint-rules.mjs'
 
 describe('parseCssRules', () => {
@@ -476,5 +477,51 @@ describe('lintNesting', () => {
     expect(result.maxDepth).toBe(0)
     expect(result.unnecessaryAmpersand).toEqual([])
     expect(result.specificityGrowth).toEqual([])
+  })
+})
+
+describe('nestingDepthHeatmap', () => {
+  it('reports a single depth-0 bucket for flat CSS', () => {
+    const result = nestingDepthHeatmap('.a { color: red; } .b { color: blue; }')
+    expect(result.maxDepth).toBe(0)
+    expect(result.totalRules).toBe(2)
+    expect(result.counts).toEqual([{ depth: 0, count: 2 }])
+    expect(result.excessive).toEqual([])
+  })
+
+  it('distributes rules across nesting depth levels', () => {
+    const css =
+      '.a { color: red; & .b { color: blue; & .c { color: green; } } }'
+    const result = nestingDepthHeatmap(css)
+    expect(result.maxDepth).toBe(2)
+    expect(result.totalRules).toBe(3)
+    expect(result.counts).toEqual([
+      { depth: 0, count: 1 },
+      { depth: 1, count: 1 },
+      { depth: 2, count: 1 },
+    ])
+    expect(result.excessive).toEqual([])
+  })
+
+  it('flags rules deeper than the default threshold (3)', () => {
+    const css = '.a { & .b { & .c { & .d { & .e { color: red; } } } } }'
+    const result = nestingDepthHeatmap(css)
+    expect(result.maxDepth).toBe(4)
+    expect(result.excessive).toEqual([{ selector: '& .e', depth: 4 }])
+  })
+
+  it('accepts a custom threshold', () => {
+    const css = '.a { & .b { & .c { color: red; } } }'
+    const result = nestingDepthHeatmap(css, { maxDepth: 1 })
+    expect(result.maxDepth).toBe(2)
+    expect(result.excessive).toEqual([{ selector: '& .c', depth: 2 }])
+  })
+
+  it('reports zero rules for empty CSS', () => {
+    const result = nestingDepthHeatmap('')
+    expect(result.totalRules).toBe(0)
+    expect(result.maxDepth).toBe(0)
+    expect(result.counts).toEqual([])
+    expect(result.excessive).toEqual([])
   })
 })

--- a/lib/css-lint-rules.mjs
+++ b/lib/css-lint-rules.mjs
@@ -625,3 +625,51 @@ export function lintNesting(css) {
     unnecessaryAmpersand,
   }
 }
+
+/**
+ * Build a nesting-complexity heatmap from raw CSS.
+ *
+ * Aggregates parseNestedRules() output into a per-depth rule-count
+ * distribution and flags every rule nested deeper than the given threshold.
+ * Depth levels run from 0 (top-level, unnested) up to maxDepth.
+ *
+ * @param {string} css - Raw CSS source
+ * @param {{ maxDepth?: number }} [opts] - Config. `maxDepth` is the maximum
+ *   allowed nesting depth; rules deeper than this are reported in
+ *   `excessive`. Defaults to 3.
+ * @returns {{
+ *   maxDepth: number,
+ *   totalRules: number,
+ *   counts: Array<{depth: number, count: number}>,
+ *   excessive: Array<{selector: string, depth: number}>
+ * }}
+ */
+export function nestingDepthHeatmap(css, opts = {}) {
+  const threshold = opts.maxDepth ?? 3
+  const rules = parseNestedRules(css)
+
+  const countsByDepth = new Map()
+  let maxDepth = 0
+  for (const rule of rules) {
+    countsByDepth.set(rule.depth, (countsByDepth.get(rule.depth) || 0) + 1)
+    if (rule.depth > maxDepth) maxDepth = rule.depth
+  }
+
+  const counts = []
+  if (rules.length > 0) {
+    for (let depth = 0; depth <= maxDepth; depth++) {
+      counts.push({ depth, count: countsByDepth.get(depth) || 0 })
+    }
+  }
+
+  const excessive = rules
+    .filter((rule) => rule.depth > threshold)
+    .map((rule) => ({ selector: rule.selector, depth: rule.depth }))
+
+  return {
+    maxDepth,
+    totalRules: rules.length,
+    counts,
+    excessive,
+  }
+}

--- a/lib/css-lint-rules.mjs
+++ b/lib/css-lint-rules.mjs
@@ -382,3 +382,246 @@ export function lintCss(css, projectDir) {
     findings: [...gapResult.findings, ...compatResult.findings],
   }
 }
+
+/**
+ * Parse CSS into nested style rules, tracking nesting depth.
+ *
+ * Walks raw CSS source and returns one entry per style rule (including
+ * nested rules), each with its selector, its nesting depth, and the
+ * selector of its parent. At-rules (@media, @supports, @layer, etc.) are
+ * recursed into transparently: they do not add nesting depth and do not
+ * change the parent selector, because wrapping a rule in a media query
+ * does not compound specificity.
+ *
+ * Depth convention: a top-level (unnested) rule has depth 0. A rule nested
+ * directly inside another selector has depth 1, and so on.
+ *
+ * @param {string} css - Raw CSS source
+ * @returns {Array<{selector: string, depth: number, parentSelector: string|null}>}
+ */
+export function parseNestedRules(css) {
+  const stripped = String(css)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/[^\n]*/g, ' ')
+
+  const rules = []
+  walkNestedRules(stripped, 0, null, rules)
+  return rules
+}
+
+/**
+ * Recursively walk a CSS fragment, collecting nested style rules.
+ *
+ * @param {string} text - CSS fragment (a stylesheet body or a rule body)
+ * @param {number} depth - Nesting depth of rules found in this fragment
+ * @param {string|null} parentSelector - Selector of the enclosing style rule
+ * @param {Array} out - Accumulator for parsed rules
+ */
+function walkNestedRules(text, depth, parentSelector, out) {
+  let pos = 0
+  const n = text.length
+
+  while (pos < n) {
+    const openBrace = text.indexOf('{', pos)
+    if (openBrace === -1) break
+
+    const closeBrace = findMatchingBrace(text, openBrace)
+    if (closeBrace === -1) break
+
+    // The header is the text between the previous rule boundary and the
+    // opening brace. For nested rules it may contain leading declarations,
+    // so the selector is everything after the last top-level semicolon.
+    const header = text.slice(pos, openBrace)
+    const body = text.slice(openBrace + 1, closeBrace)
+    const selectorOrAtRule = extractSelector(header)
+
+    if (selectorOrAtRule.startsWith('@')) {
+      // At-rule: recurse into its body without changing depth or parent.
+      walkNestedRules(body, depth, parentSelector, out)
+    } else if (selectorOrAtRule) {
+      out.push({
+        selector: selectorOrAtRule,
+        depth,
+        parentSelector,
+      })
+      walkNestedRules(body, depth + 1, selectorOrAtRule, out)
+    }
+
+    pos = closeBrace + 1
+  }
+}
+
+/**
+ * Find the matching closing brace for the brace at `openPos`, respecting
+ * nested braces and string literals.
+ *
+ * @param {string} text
+ * @param {number} openPos
+ * @returns {number} Position of the matching closing brace, or -1
+ */
+function findMatchingBrace(text, openPos) {
+  let depth = 1
+  let inString = false
+  let stringChar = ''
+  for (let i = openPos + 1; i < text.length; i++) {
+    const ch = text[i]
+    if (inString) {
+      if (ch === '\\') {
+        i++
+        continue
+      }
+      if (ch === stringChar) inString = false
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      inString = true
+      stringChar = ch
+      continue
+    }
+    if (ch === '{') depth++
+    else if (ch === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+/**
+ * Extract the selector (or at-rule prelude) from a rule header, dropping
+ * any leading declarations that precede a nested rule. Returns the text
+ * after the last top-level semicolon, trimmed; if there is no semicolon,
+ * the whole header is returned trimmed.
+ *
+ * @param {string} header
+ * @returns {string}
+ */
+function extractSelector(header) {
+  const lastSemi = lastTopLevelSemicolon(header)
+  return lastSemi === -1 ? header.trim() : header.slice(lastSemi + 1).trim()
+}
+
+/**
+ * Find the index of the last semicolon that is not inside a string or
+ * parentheses/brackets.
+ *
+ * @param {string} text
+ * @returns {number} Index of the last top-level semicolon, or -1
+ */
+function lastTopLevelSemicolon(text) {
+  let depth = 0
+  let inString = false
+  let stringChar = ''
+  let last = -1
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    if (inString) {
+      if (ch === '\\') {
+        i++
+        continue
+      }
+      if (ch === stringChar) inString = false
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      inString = true
+      stringChar = ch
+      continue
+    }
+    if (ch === '(' || ch === '[') depth++
+    else if (ch === ')' || ch === ']') depth--
+    else if (ch === ';' && depth === 0) last = i
+  }
+  return last
+}
+
+/**
+ * Split a comma-separated selector list, respecting nested parentheses and
+ * brackets (so commas inside :not(...) or :is(...) do not split the list).
+ *
+ * @param {string} text
+ * @returns {string[]}
+ */
+function splitSelectorList(text) {
+  const parts = []
+  let depth = 0
+  let current = ''
+  for (const ch of text) {
+    if (ch === '(' || ch === '[') {
+      depth++
+      current += ch
+    } else if (ch === ')' || ch === ']') {
+      depth--
+      current += ch
+    } else if (ch === ',' && depth === 0) {
+      const trimmed = current.trim()
+      if (trimmed) parts.push(trimmed)
+      current = ''
+    } else {
+      current += ch
+    }
+  }
+  const trimmed = current.trim()
+  if (trimmed) parts.push(trimmed)
+  return parts
+}
+
+/**
+ * A leading "&" is redundant when it is immediately followed by a
+ * combinator (whitespace for descendant, or > + ~ for child/sibling). In
+ * those positions the relative-selector form already implies the parent, so
+ * "& .title" can be written ".title" and "& > .item" can be written
+ * "> .item". Compound forms ("&:hover", "&.active", "&[disabled]",
+ * "&__element") do need the "&" and are not flagged.
+ *
+ * @param {string} selectorPart - A single selector (already trimmed)
+ * @returns {boolean}
+ */
+function isUnnecessaryAmpersand(selectorPart) {
+  const t = selectorPart.trim()
+  if (!t.startsWith('&')) return false
+  const rest = t.slice(1)
+  return /^[\s>+~]/.test(rest) && rest.trim() !== ''
+}
+
+/**
+ * Audit CSS nesting: measure maximum nesting depth and flag redundant "&"
+ * nesting selectors.
+ *
+ * Returns a NestingAudit-shaped object:
+ *   - maxDepth: deepest nesting level (0 when the stylesheet has no nesting)
+ *   - specificityGrowth: empty for now (compound "&" specificity-growth
+ *     detection is not part of this milestone)
+ *   - unnecessaryAmpersand: NestingIssue[] for selectors whose leading "&"
+ *     is redundant (e.g. "& .title" -> ".title", "& > .item" -> "> .item")
+ *
+ * @param {string} css - Raw CSS source
+ * @returns {{maxDepth: number, specificityGrowth: Array<object>, unnecessaryAmpersand: Array<object>}}
+ */
+export function lintNesting(css) {
+  const rules = parseNestedRules(css)
+  const unnecessaryAmpersand = []
+
+  let maxDepth = 0
+  for (const rule of rules) {
+    if (rule.depth > maxDepth) maxDepth = rule.depth
+    for (const part of splitSelectorList(rule.selector)) {
+      if (isUnnecessaryAmpersand(part)) {
+        unnecessaryAmpersand.push({
+          selector: part,
+          depth: rule.depth,
+          reason:
+            'Redundant "&" before a combinator; relative selectors do not need it. ' +
+            'Drop "&" and write the selector directly (e.g. ".title" instead of "& .title").',
+          severity: 'suggestion',
+        })
+      }
+    }
+  }
+
+  return {
+    maxDepth,
+    specificityGrowth: [],
+    unnecessaryAmpersand,
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -169,6 +169,19 @@ export interface PropertyTypeIssue {
   declaredSyntax: string // the @property syntax descriptor, e.g. '<color>'
 }
 
+export interface NestingIssue {
+  selector: string
+  depth: number
+  reason: string
+  severity: 'warning' | 'suggestion'
+}
+
+export interface NestingAudit {
+  maxDepth: number
+  specificityGrowth: NestingIssue[]
+  unnecessaryAmpersand: NestingIssue[]
+}
+
 export interface AuditReport {
   brand: string
   chaosScore: number
@@ -183,6 +196,7 @@ export interface AuditReport {
   adoptionSuggestions?: AdoptionSuggestion[]
   overflowSafetyIssues?: OverflowSafetyIssue[]
   propertyTypeIssues?: PropertyTypeIssue[]
+  nesting?: NestingAudit
 }
 
 export interface ColorDecision {


### PR DESCRIPTION
**Card:** https://github.com/nujovich/mint-radar/issues/23

**What:** Adds a CSS nesting audit that flags nesting depth and specificity
anti-patterns. Milestone 1 added the `NestingAudit` type to `lib/types.ts`
with `maxDepth`, `specificityGrowth`, and `unnecessaryAmpersand` fields, plus
a `nesting` field on `AuditReport`. Milestone 2 adds `parseNestedRules` and
`lintNesting` to `lib/css-lint-rules.mjs`, which walk nested selectors,
measure maximum nesting depth, and flag redundant `&` prefixes. Milestone 3
adds a nesting-complexity heatmap to the `lint` output with a configurable
`--max-nesting-depth` threshold.

**Why:** CSS nesting is widely available since 2024, but recent write-ups
(Piccalilli, Kilian Valkhof) warn about the same pitfalls teams hit with Sass
nesting: excessive depth, uncontrolled specificity growth, and redundant `&`
selectors. Stylelint has basic nesting rules but no dedicated auditor that
measures maximum depth or detects unnecessary specificity growth. This closes
that gap.

**Decision:** PLAN defined 4 concrete code milestones.

## Milestones

- [x] Milestone 1 -- Add `NestingAudit` type to `lib/types.ts` with `maxDepth`,
  `specificityGrowth`, and `unnecessaryAmpersand` fields, plus a `nesting`
  field on `AuditReport`
- [x] Milestone 2 -- Implement a parser that walks nested selectors with `&`,
  measuring maximum depth and flagging unnecessary `&` (when the nested
  selector is already specific)
- [x] Milestone 3 -- Add a nesting complexity heatmap to the audit output with
  a configurable `--max-nesting-depth` threshold
- [x] Milestone 4 -- Add test fixtures and tests based on Piccalilli and Kilian
  Valkhof nesting pitfalls

## Milestone 3 detail

Added a nesting-complexity heatmap to the `mint-ds lint` output:

- `lib/css-lint-rules.mjs` — new `nestingDepthHeatmap(css, opts)` function that
  aggregates `parseNestedRules()` into a per-depth rule-count distribution
  (depth 0 through maxDepth) and flags every rule nested deeper than the
  threshold (default 3) in `excessive`.
- `bin/mint-ds.mjs` — `cmdLint` now renders the heatmap as an ASCII bar chart
  (green below the threshold, yellow at it, red above it) and lists a WARN line
  for each rule exceeding the threshold. New `--max-nesting-depth <n>` flag
  (documented under LINT OPTIONS in `--help`); invalid or missing values fall
  back to the default of 3.
- `lib/__tests__/css-lint-rules.test.mjs` — 5 new tests covering flat CSS,
  multi-level distribution, default/custom thresholds, and empty input.

**How to test:**

```bash
npm run typecheck
npm test
npx mint-ds lint <dir> --max-nesting-depth 2
```
